### PR TITLE
test: improve coverage for sync and config modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sqlx",
+ "tempfile",
  "thiserror",
  "toml",
  "tracing",

--- a/crates/ceres-core/Cargo.toml
+++ b/crates/ceres-core/Cargo.toml
@@ -32,3 +32,6 @@ dirs.workspace = true
 
 # Logging
 tracing.workspace = true
+
+[dev-dependencies]
+tempfile = "3"


### PR DESCRIPTION
14 new unit tests
- Add unit tests for `PortalHarvestResult` and `BatchHarvestSummary` in sync.rs
- Add unit tests for `load_portals_config()` with real temp files in config.rs
- Add `tempfile` as dev-dependency

Closes #12 (v0.1.0 scope)