### PR TITLE
fix(cli): avoid UTF-8 panic in text truncation

### DIFF
--- a/crates/ceres-cli/src/main.rs
+++ b/crates/ceres-cli/src/main.rs
@@ -477,10 +477,6 @@ fn create_similarity_bar(score: f32) -> String {
     format!("[{}{}]", "█".repeat(filled), "░".repeat(empty))
 }
 
-// FIXME(unicode): Byte slicing can panic on multi-byte UTF-8 characters
-// `&cleaned[..max_len]` assumes ASCII. For text with emojis or non-Latin
-// characters, this will panic. Use `.chars().take(max_len)` instead.
-// See: https://doc.rust-lang.org/book/ch08-02-strings.html#bytes-and-scalar-values-and-grapheme-clusters
 fn truncate_text(text: &str, max_len: usize) -> String {
     let cleaned: String = text
         .chars()
@@ -491,8 +487,9 @@ fn truncate_text(text: &str, max_len: usize) -> String {
     if cleaned.len() <= max_len {
         cleaned
     } else {
-        // FIXME: Use cleaned.chars().take(max_len).collect::<String>()
-        format!("{}...", &cleaned[..max_len])
+        // Safely truncate text by characters to handle multi-byte UTF-8
+        let truncated: String = cleaned.chars().take(max_len).collect();
+        format!("{}...", truncated)
     }
 }
 


### PR DESCRIPTION
## Description

### fix(cli): avoid UTF-8 panic in text truncation

-  replace byte slicing with char-based 
-  prevent panics on multi-byte Unicode characters

The truncation logic now operates on Unicode characters using `.chars().take(max_len)`, ensuring descriptions containing emojis or non-Latin characters are handled safely.


## Related Issue

Fixes #21

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the code style of this project (`cargo fmt`)
- [x] I have run `cargo clippy` and addressed any warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally (`cargo test`)
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings