### PR TITLE
feat(tests): add integration tests for HarvestService and core mock implementations

### DIFF
--- a/crates/ceres-core/Cargo.toml
+++ b/crates/ceres-core/Cargo.toml
@@ -41,3 +41,4 @@ futures.workspace = true
 
 [dev-dependencies]
 tempfile = "3"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/ceres-core/tests/integration.rs
+++ b/crates/ceres-core/tests/integration.rs
@@ -1,0 +1,20 @@
+//! Integration tests for ceres-core crate.
+//!
+//! This module contains integration tests that verify the core services
+//! (`HarvestService`, `SearchService`) using mock implementations of
+//! the underlying traits (`DatasetStore`, `EmbeddingProvider`, `PortalClientFactory`).
+//!
+//! Unlike ceres-db which tests against a real PostgreSQL database,
+//! these tests use in-memory mocks to verify business logic in isolation.
+//!
+//! # Running Tests
+//!
+//! ```bash
+//! # Run all integration tests
+//! cargo test --test integration -p ceres-core
+//! ```
+
+mod integration {
+    pub mod common;
+    pub mod harvest_tests;
+}

--- a/crates/ceres-core/tests/integration/common.rs
+++ b/crates/ceres-core/tests/integration/common.rs
@@ -1,0 +1,277 @@
+//! Test utilities and mock implementations for integration tests.
+//!
+//! Provides mock implementations of the core traits for testing
+//! `HarvestService` and `SearchService` in isolation.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use ceres_core::models::NewDataset;
+use ceres_core::traits::{DatasetStore, EmbeddingProvider, PortalClient, PortalClientFactory};
+use ceres_core::{AppError, SearchResult};
+use pgvector::Vector;
+use sqlx::types::Json;
+use uuid::Uuid;
+
+// =============================================================================
+// MockEmbeddingProvider
+// =============================================================================
+
+/// Mock embedding provider that returns deterministic vectors.
+///
+/// Returns a 768-dimensional vector based on the input text length,
+/// making embeddings reproducible for testing.
+#[derive(Clone)]
+pub struct MockEmbeddingProvider;
+
+impl EmbeddingProvider for MockEmbeddingProvider {
+    async fn generate(&self, text: &str) -> Result<Vec<f32>, AppError> {
+        // Generate a deterministic embedding based on text length
+        let seed = text.len() as f32;
+        let embedding: Vec<f32> = (0..768).map(|i| (seed + i as f32) / 1000.0).collect();
+        Ok(embedding)
+    }
+}
+
+// =============================================================================
+// MockPortalClient
+// =============================================================================
+
+/// Mock portal data for testing.
+#[derive(Clone)]
+pub struct MockPortalData {
+    pub id: String,
+    pub title: String,
+    pub description: Option<String>,
+}
+
+/// Mock portal client with configurable datasets.
+#[derive(Clone)]
+pub struct MockPortalClient {
+    #[allow(dead_code)]
+    portal_url: String,
+    datasets: Vec<MockPortalData>,
+}
+
+impl MockPortalClient {
+    pub fn new(portal_url: &str, datasets: Vec<MockPortalData>) -> Self {
+        Self {
+            portal_url: portal_url.to_string(),
+            datasets,
+        }
+    }
+}
+
+impl PortalClient for MockPortalClient {
+    type PortalData = MockPortalData;
+
+    async fn list_dataset_ids(&self) -> Result<Vec<String>, AppError> {
+        Ok(self.datasets.iter().map(|d| d.id.clone()).collect())
+    }
+
+    async fn get_dataset(&self, id: &str) -> Result<Self::PortalData, AppError> {
+        self.datasets
+            .iter()
+            .find(|d| d.id == id)
+            .cloned()
+            .ok_or_else(|| AppError::Generic(format!("Dataset not found: {}", id)))
+    }
+
+    fn into_new_dataset(data: Self::PortalData, portal_url: &str) -> NewDataset {
+        let content_hash =
+            NewDataset::compute_content_hash(&data.title, data.description.as_deref());
+
+        NewDataset {
+            original_id: data.id.clone(),
+            source_portal: portal_url.to_string(),
+            url: format!("{}/dataset/{}", portal_url, data.id),
+            title: data.title,
+            description: data.description,
+            embedding: None,
+            metadata: serde_json::json!({}),
+            content_hash,
+        }
+    }
+}
+
+// =============================================================================
+// MockPortalClientFactory
+// =============================================================================
+
+/// Factory for creating mock portal clients.
+#[derive(Clone)]
+pub struct MockPortalClientFactory {
+    datasets: Vec<MockPortalData>,
+}
+
+impl MockPortalClientFactory {
+    pub fn new(datasets: Vec<MockPortalData>) -> Self {
+        Self { datasets }
+    }
+}
+
+impl PortalClientFactory for MockPortalClientFactory {
+    type Client = MockPortalClient;
+
+    fn create(&self, portal_url: &str) -> Result<Self::Client, AppError> {
+        Ok(MockPortalClient::new(portal_url, self.datasets.clone()))
+    }
+}
+
+// =============================================================================
+// MockDatasetStore
+// =============================================================================
+
+/// In-memory dataset store for testing.
+///
+/// Stores datasets in a `HashMap` and provides full implementation of
+/// `DatasetStore` trait for verifying harvest/search logic.
+#[derive(Clone)]
+pub struct MockDatasetStore {
+    /// Stored datasets keyed by (source_portal, original_id)
+    datasets: Arc<Mutex<HashMap<(String, String), StoredDataset>>>,
+}
+
+/// Internal representation of a stored dataset.
+#[derive(Clone)]
+struct StoredDataset {
+    id: Uuid,
+    dataset: NewDataset,
+}
+
+impl MockDatasetStore {
+    pub fn new() -> Self {
+        Self {
+            datasets: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Returns the number of stored datasets.
+    #[allow(dead_code)]
+    pub fn len(&self) -> usize {
+        self.datasets.lock().unwrap().len()
+    }
+
+    /// Returns true if no datasets are stored.
+    #[allow(dead_code)]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Checks if a dataset exists for the given portal and original_id.
+    #[allow(dead_code)]
+    pub fn contains(&self, portal_url: &str, original_id: &str) -> bool {
+        let key = (portal_url.to_string(), original_id.to_string());
+        self.datasets.lock().unwrap().contains_key(&key)
+    }
+
+    /// Gets a dataset by portal URL and original ID.
+    #[allow(dead_code)]
+    pub fn get(&self, portal_url: &str, original_id: &str) -> Option<NewDataset> {
+        let key = (portal_url.to_string(), original_id.to_string());
+        self.datasets
+            .lock()
+            .unwrap()
+            .get(&key)
+            .map(|s| s.dataset.clone())
+    }
+}
+
+impl Default for MockDatasetStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DatasetStore for MockDatasetStore {
+    async fn get_hashes_for_portal(
+        &self,
+        portal_url: &str,
+    ) -> Result<HashMap<String, Option<String>>, AppError> {
+        let datasets = self.datasets.lock().unwrap();
+        let hashes: HashMap<String, Option<String>> = datasets
+            .iter()
+            .filter(|((portal, _), _)| portal == portal_url)
+            .map(|((_, original_id), stored)| {
+                (
+                    original_id.clone(),
+                    Some(stored.dataset.content_hash.clone()),
+                )
+            })
+            .collect();
+        Ok(hashes)
+    }
+
+    async fn update_timestamp_only(
+        &self,
+        _portal_url: &str,
+        _original_id: &str,
+    ) -> Result<(), AppError> {
+        // No-op for mock - we don't track timestamps
+        Ok(())
+    }
+
+    async fn batch_update_timestamps(
+        &self,
+        _portal_url: &str,
+        original_ids: &[String],
+    ) -> Result<u64, AppError> {
+        // Return count as if all were updated
+        Ok(original_ids.len() as u64)
+    }
+
+    async fn upsert(&self, dataset: &NewDataset) -> Result<Uuid, AppError> {
+        let mut datasets = self.datasets.lock().unwrap();
+        let key = (dataset.source_portal.clone(), dataset.original_id.clone());
+
+        let id = if let Some(existing) = datasets.get(&key) {
+            existing.id
+        } else {
+            Uuid::new_v4()
+        };
+
+        datasets.insert(
+            key,
+            StoredDataset {
+                id,
+                dataset: dataset.clone(),
+            },
+        );
+
+        Ok(id)
+    }
+
+    async fn search(
+        &self,
+        _query_vector: Vector,
+        limit: usize,
+    ) -> Result<Vec<SearchResult>, AppError> {
+        // Simple mock: return first `limit` datasets with fake similarity scores
+        let datasets = self.datasets.lock().unwrap();
+        let results: Vec<SearchResult> = datasets
+            .values()
+            .take(limit)
+            .enumerate()
+            .map(|(i, stored)| {
+                // Create a minimal Dataset for SearchResult
+                SearchResult {
+                    dataset: ceres_core::Dataset {
+                        id: stored.id,
+                        original_id: stored.dataset.original_id.clone(),
+                        source_portal: stored.dataset.source_portal.clone(),
+                        url: stored.dataset.url.clone(),
+                        title: stored.dataset.title.clone(),
+                        description: stored.dataset.description.clone(),
+                        embedding: stored.dataset.embedding.clone(),
+                        metadata: Json(stored.dataset.metadata.clone()),
+                        first_seen_at: chrono::Utc::now(),
+                        last_updated_at: chrono::Utc::now(),
+                        content_hash: Some(stored.dataset.content_hash.clone()),
+                    },
+                    similarity_score: 1.0 - (i as f32 * 0.1),
+                }
+            })
+            .collect();
+        Ok(results)
+    }
+}

--- a/crates/ceres-core/tests/integration/harvest_tests.rs
+++ b/crates/ceres-core/tests/integration/harvest_tests.rs
@@ -1,0 +1,153 @@
+//! Integration tests for HarvestService.
+//!
+//! These tests verify the core harvesting logic using mock implementations.
+
+use crate::integration::common::{
+    MockDatasetStore, MockEmbeddingProvider, MockPortalClientFactory, MockPortalData,
+};
+use ceres_core::SyncConfig;
+use ceres_core::harvest::HarvestService;
+
+const TEST_PORTAL_URL: &str = "https://test-portal.example.com";
+
+/// Test 1: Verify that harvesting creates a new dataset with embedding.
+///
+/// When a portal has a dataset that doesn't exist in the store,
+/// the harvest should:
+/// - Fetch the dataset from the portal
+/// - Generate an embedding
+/// - Store the dataset with the embedding
+#[tokio::test]
+async fn test_harvest_creates_new_dataset() {
+    // Arrange
+    let datasets = vec![MockPortalData {
+        id: "dataset-001".to_string(),
+        title: "Climate Data 2024".to_string(),
+        description: Some("Annual climate measurements for 2024".to_string()),
+    }];
+
+    let store = MockDatasetStore::new();
+    let embedding = MockEmbeddingProvider;
+    let factory = MockPortalClientFactory::new(datasets);
+
+    let config = SyncConfig { concurrency: 1 };
+    let service = HarvestService::with_config(store.clone(), embedding, factory, config);
+
+    // Act
+    let stats = service.sync_portal(TEST_PORTAL_URL).await.unwrap();
+
+    // Assert
+    assert_eq!(stats.created, 1, "Should have created 1 dataset");
+    assert_eq!(stats.updated, 0, "Should have updated 0 datasets");
+    assert_eq!(stats.unchanged, 0, "Should have 0 unchanged datasets");
+    assert_eq!(stats.failed, 0, "Should have 0 failed datasets");
+    assert_eq!(stats.total(), 1, "Total should be 1");
+
+    // Verify the dataset was stored
+    assert!(
+        store.contains(TEST_PORTAL_URL, "dataset-001"),
+        "Dataset should be stored"
+    );
+
+    // Verify embedding was generated
+    let stored = store.get(TEST_PORTAL_URL, "dataset-001").unwrap();
+    assert!(
+        stored.embedding.is_some(),
+        "Dataset should have an embedding"
+    );
+}
+
+/// Test 2: Verify that unchanged datasets are skipped.
+///
+/// When a dataset already exists in the store with the same content hash,
+/// the harvest should:
+/// - Skip embedding generation
+/// - Mark the dataset as unchanged
+/// - Not re-upsert the dataset
+#[tokio::test]
+async fn test_harvest_skips_unchanged_dataset() {
+    // Arrange
+    let datasets = vec![MockPortalData {
+        id: "dataset-002".to_string(),
+        title: "Population Statistics".to_string(),
+        description: Some("City population data".to_string()),
+    }];
+
+    let store = MockDatasetStore::new();
+    let embedding = MockEmbeddingProvider;
+    let factory = MockPortalClientFactory::new(datasets);
+
+    let config = SyncConfig { concurrency: 1 };
+    let service = HarvestService::with_config(store.clone(), embedding, factory, config);
+
+    // First harvest - should create
+    let stats1 = service.sync_portal(TEST_PORTAL_URL).await.unwrap();
+    assert_eq!(stats1.created, 1, "First harvest should create 1 dataset");
+
+    // Second harvest with same data - should be unchanged
+    let stats2 = service.sync_portal(TEST_PORTAL_URL).await.unwrap();
+
+    // Assert
+    assert_eq!(stats2.created, 0, "Second harvest should create 0 datasets");
+    assert_eq!(stats2.updated, 0, "Second harvest should update 0 datasets");
+    assert_eq!(
+        stats2.unchanged, 1,
+        "Second harvest should have 1 unchanged"
+    );
+    assert_eq!(stats2.failed, 0, "Should have 0 failed datasets");
+
+    // Store should still have exactly 1 dataset
+    assert_eq!(store.len(), 1, "Store should have exactly 1 dataset");
+}
+
+// =============================================================================
+// TODO: Future integration tests for ceres-core
+// =============================================================================
+//
+// The following tests should be implemented as the project matures:
+//
+// ## HarvestService tests
+//
+// TODO(#29): test_harvest_updates_changed_dataset
+// - When content hash differs, dataset should be re-processed with new embedding
+//
+// TODO(#29): test_harvest_handles_embedding_error
+// - When embedding generation fails, dataset should be marked as failed
+// - Other datasets should continue processing
+//
+// TODO(#29): test_harvest_handles_portal_error
+// - When portal API fails for a dataset, it should be marked as failed
+// - Other datasets should continue processing
+//
+// TODO(#29): test_batch_harvest_multiple_portals
+// - Verify batch_harvest processes multiple portals
+// - Verify error in one portal doesn't stop others
+// - Verify aggregated statistics are correct
+//
+// TODO(#29): test_harvest_progress_reporting
+// - Verify HarvestEvent events are emitted correctly
+// - Verify progress intervals work as expected
+//
+// TODO(#29): test_harvest_concurrency
+// - Verify concurrent processing works correctly
+// - Test with different concurrency levels
+//
+// ## SearchService tests
+//
+// TODO(#29): test_search_returns_results
+// - Verify search generates query embedding
+// - Verify results are returned from store
+//
+// TODO(#29): test_search_handles_embedding_error
+// - When query embedding fails, search should return error
+//
+// ## Edge cases
+//
+// TODO(#29): test_harvest_empty_portal
+// - Portal with no datasets should return empty stats
+//
+// TODO(#29): test_harvest_dataset_without_description
+// - Datasets with None description should still work
+//
+// TODO(#29): test_harvest_empty_title_and_description
+// - Datasets with empty text should not generate embedding


### PR DESCRIPTION
Works towards #29  

Adds integration test infrastructure for ceres-core using in-memory mock implementations. 

Changes:
Mock implementations for DatasetStore, EmbeddingProvider, PortalClientFactory
2 initial tests for HarvestService: create new dataset, skip unchanged

TODO comments for future test coverage