### PR TITLE
feat: implement incremental harvesting with full sync option and database tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,6 +397,7 @@ name = "ceres-client"
 version = "0.1.1"
 dependencies = [
  "ceres-core",
+ "chrono",
  "pgvector",
  "reqwest",
  "serde",

--- a/crates/ceres-cli/src/config.rs
+++ b/crates/ceres-cli/src/config.rs
@@ -55,7 +55,8 @@ pub enum Command {
   ceres harvest                               # Harvest all enabled portals from config
   ceres harvest https://dati.comune.milano.it # Harvest single URL (backward compatible)
   ceres harvest --portal milano               # Harvest portal by name from config
-  ceres harvest --config ~/custom.toml        # Use custom config file")]
+  ceres harvest --config ~/custom.toml        # Use custom config file
+  ceres harvest --full-sync                   # Force full sync even if incremental is available")]
     Harvest {
         /// URL of a single CKAN portal to harvest (backward compatible)
         #[arg(value_name = "URL")]
@@ -68,6 +69,10 @@ pub enum Command {
         /// Custom path to portals.toml configuration file
         #[arg(short, long, value_name = "PATH")]
         config: Option<PathBuf>,
+
+        /// Force full sync even if incremental sync is available
+        #[arg(long)]
+        full_sync: bool,
     },
     /// Search indexed datasets using semantic similarity
     #[command(after_help = "Example: ceres search \"trasporto pubblico\" --limit 10")]

--- a/crates/ceres-client/Cargo.toml
+++ b/crates/ceres-client/Cargo.toml
@@ -26,3 +26,6 @@ pgvector.workspace = true
 
 # Async
 tokio.workspace = true
+
+# Date/time
+chrono.workspace = true

--- a/crates/ceres-core/src/config.rs
+++ b/crates/ceres-core/src/config.rs
@@ -57,13 +57,27 @@ impl Default for HttpConfig {
 /// Consider auto-tuning based on API response times.
 #[derive(Clone)]
 pub struct SyncConfig {
+    /// Number of concurrent dataset processing tasks.
     pub concurrency: usize,
+    /// Force full sync even if incremental sync is available.
+    pub force_full_sync: bool,
 }
 
 impl Default for SyncConfig {
     fn default() -> Self {
         // TODO(config): Read from SYNC_CONCURRENCY env var
-        Self { concurrency: 10 }
+        Self {
+            concurrency: 10,
+            force_full_sync: false,
+        }
+    }
+}
+
+impl SyncConfig {
+    /// Creates a new SyncConfig with force_full_sync enabled.
+    pub fn with_full_sync(mut self) -> Self {
+        self.force_full_sync = true;
+        self
     }
 }
 

--- a/crates/ceres-core/tests/integration/common.rs
+++ b/crates/ceres-core/tests/integration/common.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, Mutex};
 use ceres_core::models::NewDataset;
 use ceres_core::traits::{DatasetStore, EmbeddingProvider, PortalClient, PortalClientFactory};
 use ceres_core::{AppError, SearchResult};
+use chrono::{DateTime, Utc};
 use pgvector::Vector;
 use sqlx::types::Json;
 use uuid::Uuid;
@@ -91,6 +92,14 @@ impl PortalClient for MockPortalClient {
             metadata: serde_json::json!({}),
             content_hash,
         }
+    }
+
+    async fn search_modified_since(
+        &self,
+        _since: DateTime<Utc>,
+    ) -> Result<Vec<Self::PortalData>, AppError> {
+        // For testing, return all datasets as "modified"
+        Ok(self.datasets.clone())
     }
 }
 
@@ -273,5 +282,24 @@ impl DatasetStore for MockDatasetStore {
             })
             .collect();
         Ok(results)
+    }
+
+    async fn get_last_sync_time(
+        &self,
+        _portal_url: &str,
+    ) -> Result<Option<DateTime<Utc>>, AppError> {
+        // Always return None to simulate first sync (full sync)
+        Ok(None)
+    }
+
+    async fn record_sync_status(
+        &self,
+        _portal_url: &str,
+        _sync_time: DateTime<Utc>,
+        _sync_mode: &str,
+        _datasets_synced: i32,
+    ) -> Result<(), AppError> {
+        // No-op for mock
+        Ok(())
     }
 }

--- a/crates/ceres-core/tests/integration/harvest_tests.rs
+++ b/crates/ceres-core/tests/integration/harvest_tests.rs
@@ -30,7 +30,10 @@ async fn test_harvest_creates_new_dataset() {
     let embedding = MockEmbeddingProvider;
     let factory = MockPortalClientFactory::new(datasets);
 
-    let config = SyncConfig { concurrency: 1 };
+    let config = SyncConfig {
+        concurrency: 1,
+        force_full_sync: true, // Force full sync for tests
+    };
     let service = HarvestService::with_config(store.clone(), embedding, factory, config);
 
     // Act
@@ -77,7 +80,10 @@ async fn test_harvest_skips_unchanged_dataset() {
     let embedding = MockEmbeddingProvider;
     let factory = MockPortalClientFactory::new(datasets);
 
-    let config = SyncConfig { concurrency: 1 };
+    let config = SyncConfig {
+        concurrency: 1,
+        force_full_sync: true, // Force full sync for tests
+    };
     let service = HarvestService::with_config(store.clone(), embedding, factory, config);
 
     // First harvest - should create

--- a/crates/ceres-db/src/lib.rs
+++ b/crates/ceres-db/src/lib.rs
@@ -13,4 +13,4 @@
 
 mod repository;
 
-pub use repository::DatasetRepository;
+pub use repository::{DatasetRepository, PortalSyncStatus};

--- a/migrations/202601060001_portal_sync_status.sql
+++ b/migrations/202601060001_portal_sync_status.sql
@@ -1,0 +1,12 @@
+-- Migration: Add portal_sync_status table for incremental harvesting
+-- This table tracks the last successful sync timestamp per portal,
+-- enabling time-based incremental harvesting via CKAN's package_search API.
+
+CREATE TABLE IF NOT EXISTS portal_sync_status (
+    portal_url VARCHAR PRIMARY KEY,
+    last_successful_sync TIMESTAMPTZ,
+    last_sync_mode VARCHAR(20),  -- 'full' or 'incremental'
+    datasets_synced INTEGER DEFAULT 0,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);


### PR DESCRIPTION
This PR adds incremental harvesting, cutting harvest times from 30 mins to 9/10 on sequential harvestings for around 20k datasets and 5/6 portals.
 
Closes #10
