### PR TITLE
feat: add SPARQL DCAT client for harvesting datasets from SPARQL-backed portals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,7 +561,7 @@ dependencies = [
  "log",
  "num",
  "pin-project-lite",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
@@ -716,7 +716,7 @@ dependencies = [
  "chrono",
  "futures",
  "pgvector",
- "rand 0.9.2",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "sqlx",
@@ -798,6 +798,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
 
 [[package]]
 name = "chrono"
@@ -971,6 +982,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1346,7 +1366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb330bbd4cb7a5b9f559427f06f98a4f853a137c8298f3bd3f8ca57663e21986"
 dependencies = [
  "portable-atomic",
- "rand 0.9.2",
+ "rand 0.9.3",
  "web-time",
 ]
 
@@ -1586,6 +1606,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -2858,7 +2879,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2918,12 +2939,23 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -2963,6 +2995,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "raw-cpuid"
@@ -3507,7 +3545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3518,7 +3556,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3312,9 +3312,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ version = "0.3.5"
 edition = "2024"
 authors = ["Andrea Bozzo"]
 license = "Apache-2.0"
-# TODO(build): ensure all crates inherit rust-version.workspace = true (#73)
 rust-version = "1.88"
 repository = "https://github.com/AndreaBozzo/Ceres"
 

--- a/crates/ceres-cli/src/config.rs
+++ b/crates/ceres-cli/src/config.rs
@@ -77,6 +77,7 @@ pub enum Command {
   ceres harvest                                       # Harvest all enabled portals from config
   ceres harvest https://dati.comune.milano.it         # Harvest single CKAN URL (default type)
   ceres harvest https://data.public.lu --type dcat    # Harvest DCAT portal by URL
+  ceres harvest https://data.europa.eu --type dcat --profile sparql  # Harvest SPARQL DCAT endpoint
   ceres harvest --portal milano                       # Harvest portal by name from config
   ceres harvest --config ~/custom.toml                # Use custom config file
   ceres harvest --full-sync                           # Force full sync even if incremental is available")]
@@ -93,6 +94,10 @@ pub enum Command {
             requires = "portal_url"
         )]
         r#type: PortalType,
+
+        /// DCAT profile when harvesting an ad-hoc DCAT URL (e.g., "sparql")
+        #[arg(long, value_name = "PROFILE", requires = "portal_url")]
+        profile: Option<String>,
 
         /// Harvest a specific portal by name from config file
         #[arg(short, long, value_name = "NAME", conflicts_with = "portal_url")]

--- a/crates/ceres-cli/src/main.rs
+++ b/crates/ceres-cli/src/main.rs
@@ -73,6 +73,7 @@ async fn main() -> anyhow::Result<()> {
         Command::Harvest {
             portal_url,
             r#type: portal_type,
+            profile,
             portal,
             config: config_path,
             full_sync,
@@ -102,6 +103,7 @@ async fn main() -> anyhow::Result<()> {
                 embedding_service.as_ref(),
                 portal_url,
                 portal_type,
+                profile,
                 portal,
                 config_path,
             )
@@ -169,6 +171,7 @@ async fn handle_harvest(
     embedding_service: Option<&EmbeddingService<DatasetRepository, EmbeddingProviderEnum>>,
     portal_url: Option<String>,
     ad_hoc_portal_type: PortalType,
+    ad_hoc_profile: Option<String>,
     portal_name: Option<String>,
     config_path: Option<PathBuf>,
 ) -> anyhow::Result<()> {
@@ -184,7 +187,14 @@ async fn handle_harvest(
         (Some(url), None) => {
             info!("Syncing portal{}: {}", mode_label, url);
             let stats = harvest_service
-                .sync_portal_with_progress(&url, None, "en", &reporter, ad_hoc_portal_type)
+                .sync_portal_with_progress(
+                    &url,
+                    None,
+                    "en",
+                    &reporter,
+                    ad_hoc_portal_type,
+                    ad_hoc_profile.as_deref(),
+                )
                 .await?;
             print_single_portal_summary(&url, &stats);
             if let Some(es) = embedding_service {
@@ -220,6 +230,7 @@ async fn handle_harvest(
                     portal.language(),
                     &reporter,
                     portal.portal_type,
+                    portal.profile(),
                 )
                 .await?;
             print_single_portal_summary(&portal.url, &stats);

--- a/crates/ceres-cli/src/main.rs
+++ b/crates/ceres-cli/src/main.rs
@@ -198,6 +198,7 @@ async fn handle_harvest(
                     &reporter,
                     ad_hoc_portal_type,
                     ad_hoc_profile.as_deref(),
+                    None,
                 )
                 .await?;
             print_single_portal_summary(&url, &stats);
@@ -235,6 +236,7 @@ async fn handle_harvest(
                     &reporter,
                     portal.portal_type,
                     portal.profile(),
+                    portal.sparql_endpoint(),
                 )
                 .await?;
             print_single_portal_summary(&portal.url, &stats);

--- a/crates/ceres-cli/src/main.rs
+++ b/crates/ceres-cli/src/main.rs
@@ -183,6 +183,10 @@ async fn handle_harvest(
         ""
     };
 
+    if ad_hoc_profile.is_some() && ad_hoc_portal_type != PortalType::Dcat {
+        anyhow::bail!("--profile is only valid with --type dcat");
+    }
+
     match (portal_url, portal_name) {
         (Some(url), None) => {
             info!("Syncing portal{}: {}", mode_label, url);

--- a/crates/ceres-client/src/ckan.rs
+++ b/crates/ceres-client/src/ckan.rs
@@ -1022,6 +1022,7 @@ impl ceres_core::traits::PortalClientFactory for CkanClientFactory {
         portal_url: &str,
         portal_type: ceres_core::config::PortalType,
         _language: &str,
+        _profile: Option<&str>,
     ) -> Result<Self::Client, AppError> {
         match portal_type {
             ceres_core::config::PortalType::Ckan => CkanClient::new(portal_url),

--- a/crates/ceres-client/src/ckan.rs
+++ b/crates/ceres-client/src/ckan.rs
@@ -1023,6 +1023,7 @@ impl ceres_core::traits::PortalClientFactory for CkanClientFactory {
         portal_type: ceres_core::config::PortalType,
         _language: &str,
         _profile: Option<&str>,
+        _sparql_endpoint: Option<&str>,
     ) -> Result<Self::Client, AppError> {
         match portal_type {
             ceres_core::config::PortalType::Ckan => CkanClient::new(portal_url),

--- a/crates/ceres-client/src/lib.rs
+++ b/crates/ceres-client/src/lib.rs
@@ -21,6 +21,7 @@
 //! |-------------|--------|-----|
 //! | CKAN | Supported | [CKAN API](https://docs.ckan.org/en/2.9/api/) |
 //! | DCAT-AP (udata REST) | Supported | [DCAT-AP](https://joinup.ec.europa.eu/collection/semantic-interoperability-community-semic/solution/dcat-application-profile-data-portals-europe) |
+//! | DCAT-AP (SPARQL) | Supported | SPARQL endpoint with DCAT vocabulary |
 //! | Socrata | Planned | [Socrata API](https://dev.socrata.com/) |
 //!
 //! # Embedding Providers
@@ -42,6 +43,7 @@ pub mod ollama;
 pub mod openai;
 pub mod portal;
 pub mod provider;
+pub mod sparql;
 
 // Re-export main client types
 pub use ckan::{CkanClient, CkanClientFactory};
@@ -53,3 +55,4 @@ pub use portal::{PortalClientEnum, PortalClientFactoryEnum, PortalDataEnum};
 #[cfg(feature = "test-support")]
 pub use provider::MockEmbeddingClient;
 pub use provider::{EmbeddingConfig, EmbeddingProviderEnum};
+pub use sparql::SparqlDcatClient;

--- a/crates/ceres-client/src/portal.rs
+++ b/crates/ceres-client/src/portal.rs
@@ -190,12 +190,15 @@ impl PortalClientFactory for PortalClientFactoryEnum {
         portal_type: PortalType,
         language: &str,
         profile: Option<&str>,
+        sparql_endpoint: Option<&str>,
     ) -> Result<Self::Client, AppError> {
         match portal_type {
             PortalType::Ckan => Ok(PortalClientEnum::Ckan(CkanClient::new(portal_url)?)),
             PortalType::Dcat => match profile {
                 Some("sparql") => Ok(PortalClientEnum::SparqlDcat(SparqlDcatClient::new(
-                    portal_url, language,
+                    portal_url,
+                    language,
+                    sparql_endpoint,
                 )?)),
                 None | Some("" | "udata_rest") => Ok(PortalClientEnum::Dcat(DcatClient::new(
                     portal_url, language,
@@ -224,6 +227,7 @@ mod tests {
             PortalType::Ckan,
             "en",
             None,
+            None,
         );
         assert!(client.is_ok());
         let client = client.unwrap();
@@ -234,7 +238,7 @@ mod tests {
     #[test]
     fn test_factory_creates_dcat_client() {
         let factory = PortalClientFactoryEnum::new();
-        let client = factory.create("https://data.public.lu", PortalType::Dcat, "fr", None);
+        let client = factory.create("https://data.public.lu", PortalType::Dcat, "fr", None, None);
         assert!(client.is_ok());
         let client = client.unwrap();
         assert_eq!(client.portal_type(), "dcat");
@@ -249,6 +253,7 @@ mod tests {
             PortalType::Dcat,
             "en",
             Some("sparql"),
+            None,
         );
         assert!(client.is_ok());
         let client = client.unwrap();
@@ -258,10 +263,27 @@ mod tests {
     }
 
     #[test]
+    fn test_factory_creates_sparql_dcat_client_with_custom_endpoint() {
+        let factory = PortalClientFactoryEnum::new();
+        let client = factory.create(
+            "https://data.norge.no",
+            PortalType::Dcat,
+            "nb",
+            Some("sparql"),
+            Some("https://sparql.fellesdatakatalog.digdir.no"),
+        );
+        assert!(client.is_ok());
+        let client = client.unwrap();
+        assert_eq!(client.portal_type(), "dcat");
+        assert_eq!(client.base_url(), "https://data.norge.no/");
+        assert!(matches!(client, PortalClientEnum::SparqlDcat(_)));
+    }
+
+    #[test]
     fn test_factory_dcat_default_profile_is_udata_rest() {
         let factory = PortalClientFactoryEnum::new();
         let client = factory
-            .create("https://data.public.lu", PortalType::Dcat, "fr", None)
+            .create("https://data.public.lu", PortalType::Dcat, "fr", None, None)
             .unwrap();
         assert!(matches!(client, PortalClientEnum::Dcat(_)));
     }
@@ -274,6 +296,7 @@ mod tests {
             PortalType::Dcat,
             "en",
             Some("spqarql"),
+            None,
         );
         assert!(result.is_err());
     }
@@ -285,6 +308,7 @@ mod tests {
             "https://data.cityofnewyork.us",
             PortalType::Socrata,
             "en",
+            None,
             None,
         );
         assert!(result.is_err());

--- a/crates/ceres-client/src/portal.rs
+++ b/crates/ceres-client/src/portal.rs
@@ -20,6 +20,7 @@ use futures::stream::BoxStream;
 
 use crate::ckan::{CkanClient, CkanDataset};
 use crate::dcat::{DcatClient, DcatDataset};
+use crate::sparql::SparqlDcatClient;
 
 /// Portal-specific dataset data, wrapping concrete types from each portal client.
 #[derive(Debug, Clone)]
@@ -40,6 +41,8 @@ pub enum PortalClientEnum {
     Ckan(CkanClient),
     /// DCAT-AP udata REST portal client.
     Dcat(DcatClient),
+    /// DCAT-AP SPARQL endpoint client.
+    SparqlDcat(SparqlDcatClient),
 }
 
 impl PortalClient for PortalClientEnum {
@@ -49,6 +52,7 @@ impl PortalClient for PortalClientEnum {
         match self {
             Self::Ckan(c) => c.portal_type(),
             Self::Dcat(c) => c.portal_type(),
+            Self::SparqlDcat(c) => c.portal_type(),
         }
     }
 
@@ -56,6 +60,7 @@ impl PortalClient for PortalClientEnum {
         match self {
             Self::Ckan(c) => c.base_url(),
             Self::Dcat(c) => c.base_url(),
+            Self::SparqlDcat(c) => c.base_url(),
         }
     }
 
@@ -63,6 +68,7 @@ impl PortalClient for PortalClientEnum {
         match self {
             Self::Ckan(c) => c.list_dataset_ids().await,
             Self::Dcat(c) => c.list_dataset_ids().await,
+            Self::SparqlDcat(c) => c.list_dataset_ids().await,
         }
     }
 
@@ -70,6 +76,7 @@ impl PortalClient for PortalClientEnum {
         match self {
             Self::Ckan(c) => c.get_dataset(id).await.map(PortalDataEnum::Ckan),
             Self::Dcat(c) => c.get_dataset(id).await.map(PortalDataEnum::Dcat),
+            Self::SparqlDcat(c) => c.get_dataset(id).await.map(PortalDataEnum::Dcat),
         }
     }
 
@@ -102,6 +109,10 @@ impl PortalClient for PortalClientEnum {
                 .search_modified_since(since)
                 .await
                 .map(|datasets| datasets.into_iter().map(PortalDataEnum::Dcat).collect()),
+            Self::SparqlDcat(c) => c
+                .search_modified_since(since)
+                .await
+                .map(|datasets| datasets.into_iter().map(PortalDataEnum::Dcat).collect()),
         }
     }
 
@@ -112,6 +123,10 @@ impl PortalClient for PortalClientEnum {
                 .await
                 .map(|datasets| datasets.into_iter().map(PortalDataEnum::Ckan).collect()),
             Self::Dcat(c) => c
+                .search_all_datasets()
+                .await
+                .map(|datasets| datasets.into_iter().map(PortalDataEnum::Dcat).collect()),
+            Self::SparqlDcat(c) => c
                 .search_all_datasets()
                 .await
                 .map(|datasets| datasets.into_iter().map(PortalDataEnum::Dcat).collect()),
@@ -132,6 +147,12 @@ impl PortalClient for PortalClientEnum {
                     r.map(|datasets| datasets.into_iter().map(PortalDataEnum::Dcat).collect())
                 },
             )),
+            Self::SparqlDcat(c) => Box::pin(StreamExt::map(
+                c.paginate_sparql_stream(None),
+                |r: Result<Vec<DcatDataset>, AppError>| {
+                    r.map(|datasets| datasets.into_iter().map(PortalDataEnum::Dcat).collect())
+                },
+            )),
         }
     }
 
@@ -139,8 +160,9 @@ impl PortalClient for PortalClientEnum {
         match self {
             Self::Ckan(c) => c.dataset_count().await,
             Self::Dcat(_) => Err(AppError::Generic(
-                "dataset_count not supported for DCAT portals".to_string(),
+                "dataset_count not supported for DCAT udata REST portals".to_string(),
             )),
+            Self::SparqlDcat(c) => c.dataset_count().await,
         }
     }
 }
@@ -167,12 +189,18 @@ impl PortalClientFactory for PortalClientFactoryEnum {
         portal_url: &str,
         portal_type: PortalType,
         language: &str,
+        profile: Option<&str>,
     ) -> Result<Self::Client, AppError> {
         match portal_type {
             PortalType::Ckan => Ok(PortalClientEnum::Ckan(CkanClient::new(portal_url)?)),
-            PortalType::Dcat => Ok(PortalClientEnum::Dcat(DcatClient::new(
-                portal_url, language,
-            )?)),
+            PortalType::Dcat => match profile {
+                Some("sparql") => Ok(PortalClientEnum::SparqlDcat(SparqlDcatClient::new(
+                    portal_url, language,
+                )?)),
+                _ => Ok(PortalClientEnum::Dcat(DcatClient::new(
+                    portal_url, language,
+                )?)),
+            },
             other => Err(AppError::ConfigError(format!(
                 "Portal type '{}' is not yet supported.",
                 other
@@ -188,7 +216,12 @@ mod tests {
     #[test]
     fn test_factory_creates_ckan_client() {
         let factory = PortalClientFactoryEnum::new();
-        let client = factory.create("https://dati.comune.milano.it", PortalType::Ckan, "en");
+        let client = factory.create(
+            "https://dati.comune.milano.it",
+            PortalType::Ckan,
+            "en",
+            None,
+        );
         assert!(client.is_ok());
         let client = client.unwrap();
         assert_eq!(client.portal_type(), "ckan");
@@ -198,7 +231,7 @@ mod tests {
     #[test]
     fn test_factory_creates_dcat_client() {
         let factory = PortalClientFactoryEnum::new();
-        let client = factory.create("https://data.public.lu", PortalType::Dcat, "fr");
+        let client = factory.create("https://data.public.lu", PortalType::Dcat, "fr", None);
         assert!(client.is_ok());
         let client = client.unwrap();
         assert_eq!(client.portal_type(), "dcat");
@@ -206,9 +239,39 @@ mod tests {
     }
 
     #[test]
+    fn test_factory_creates_sparql_dcat_client() {
+        let factory = PortalClientFactoryEnum::new();
+        let client = factory.create(
+            "https://data.europa.eu",
+            PortalType::Dcat,
+            "en",
+            Some("sparql"),
+        );
+        assert!(client.is_ok());
+        let client = client.unwrap();
+        assert_eq!(client.portal_type(), "dcat");
+        assert_eq!(client.base_url(), "https://data.europa.eu/");
+        assert!(matches!(client, PortalClientEnum::SparqlDcat(_)));
+    }
+
+    #[test]
+    fn test_factory_dcat_default_profile_is_udata_rest() {
+        let factory = PortalClientFactoryEnum::new();
+        let client = factory
+            .create("https://data.public.lu", PortalType::Dcat, "fr", None)
+            .unwrap();
+        assert!(matches!(client, PortalClientEnum::Dcat(_)));
+    }
+
+    #[test]
     fn test_factory_rejects_unsupported_type() {
         let factory = PortalClientFactoryEnum::new();
-        let result = factory.create("https://data.cityofnewyork.us", PortalType::Socrata, "en");
+        let result = factory.create(
+            "https://data.cityofnewyork.us",
+            PortalType::Socrata,
+            "en",
+            None,
+        );
         assert!(result.is_err());
     }
 }

--- a/crates/ceres-client/src/portal.rs
+++ b/crates/ceres-client/src/portal.rs
@@ -197,9 +197,12 @@ impl PortalClientFactory for PortalClientFactoryEnum {
                 Some("sparql") => Ok(PortalClientEnum::SparqlDcat(SparqlDcatClient::new(
                     portal_url, language,
                 )?)),
-                _ => Ok(PortalClientEnum::Dcat(DcatClient::new(
+                None | Some("" | "udata_rest") => Ok(PortalClientEnum::Dcat(DcatClient::new(
                     portal_url, language,
                 )?)),
+                Some(other) => Err(AppError::ConfigError(format!(
+                    "Unsupported DCAT profile '{other}'. Supported profiles are 'sparql' and 'udata_rest'."
+                ))),
             },
             other => Err(AppError::ConfigError(format!(
                 "Portal type '{}' is not yet supported.",
@@ -261,6 +264,18 @@ mod tests {
             .create("https://data.public.lu", PortalType::Dcat, "fr", None)
             .unwrap();
         assert!(matches!(client, PortalClientEnum::Dcat(_)));
+    }
+
+    #[test]
+    fn test_factory_rejects_unknown_dcat_profile() {
+        let factory = PortalClientFactoryEnum::new();
+        let result = factory.create(
+            "https://data.public.lu",
+            PortalType::Dcat,
+            "en",
+            Some("spqarql"),
+        );
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/ceres-client/src/sparql.rs
+++ b/crates/ceres-client/src/sparql.rs
@@ -49,12 +49,21 @@ const PAGE_RETRY_BASE_DELAY: Duration = Duration::from_secs(10);
 /// Maximum number of page-level retries before giving up on a page.
 const MAX_PAGE_RETRIES: u32 = 3;
 
+/// Maximum consecutive skipped pages before stopping the stream entirely.
+/// If this many pages in a row fail even after retries, the endpoint is
+/// considered down rather than just struggling at specific offsets.
+const MAX_CONSECUTIVE_SKIPS: usize = 3;
+
 /// Default number of results per SPARQL page.
 const DEFAULT_PAGE_SIZE: usize = 1000;
 
 /// Minimum page size for adaptive reduction. Below this we give up rather than
 /// issuing very small queries.
 const MIN_PAGE_SIZE: usize = 50;
+
+/// Number of dataset URIs to look up per VALUES batch in two-phase harvest.
+/// Tested at 500 URIs → ~400ms on data.europa.eu.
+const VALUES_BATCH_SIZE: usize = 200;
 
 // =============================================================================
 // SPARQL JSON Results Format (W3C standard)
@@ -234,135 +243,172 @@ impl SparqlDcatClient {
             .ok_or_else(|| AppError::Generic("Failed to parse dataset count".to_string()))
     }
 
-    /// Streams catalog datasets page-by-page using LIMIT/OFFSET pagination.
+    /// Streams catalog datasets using a two-phase approach:
     ///
-    /// Each yielded item contains the datasets extracted from one SPARQL page.
-    /// Memory is bounded to a single page at a time.
+    /// 1. **URI collection** — lightweight `SELECT DISTINCT ?dataset` pages that
+    ///    work reliably even at deep offsets (tested to 1.9M on data.europa.eu).
+    /// 2. **Detail fetch** — for each batch of URIs, a `VALUES`-scoped query
+    ///    retrieves title/description/identifier/modified without OFFSET.
+    ///
+    /// This avoids the query-plan explosion that LIMIT/OFFSET causes on large
+    /// Virtuoso catalogs when combined with OPTIONAL clauses.
     pub fn paginate_sparql_stream(
         &self,
-        modified_since: Option<String>,
+        _modified_since: Option<String>,
     ) -> BoxStream<'_, Result<Vec<DcatDataset>, AppError>> {
-        let filter = modified_since.map(|since| {
-            format!(
-                "FILTER (?modified > \"{}\"^^<http://www.w3.org/2001/XMLSchema#dateTime>)",
-                since
-            )
-        });
-
-        struct PaginationState {
-            offset: usize,
-            page_size: usize,
+        /// State machine for the two-phase unfold.
+        struct TwoPhaseState {
+            /// Current offset into the lightweight URI enumeration.
+            uri_offset: usize,
+            /// URIs collected but not yet detail-fetched.
+            pending_uris: Vec<String>,
+            /// Total datasets yielded so far.
             fetched: usize,
+            /// URI enumeration finished?
+            uris_done: bool,
+            /// Whole stream finished?
             done: bool,
+            /// Pages where URI fetch failed (for incomplete-harvest signaling).
+            skipped_uri_pages: usize,
+            /// Consecutive URI-page failures (stop after MAX_CONSECUTIVE_SKIPS).
+            consecutive_uri_skips: usize,
         }
 
-        let initial = PaginationState {
-            offset: 0,
-            page_size: self.page_size,
+        let initial = TwoPhaseState {
+            uri_offset: 0,
+            pending_uris: Vec::new(),
             fetched: 0,
+            uris_done: false,
             done: false,
+            skipped_uri_pages: 0,
+            consecutive_uri_skips: 0,
         };
 
         Box::pin(futures::stream::unfold(initial, move |mut state| {
-            let filter = filter.clone();
             async move {
                 if state.done {
+                    // Yield a final error if any work was skipped, so the
+                    // harvest records a failure (prevents stale-marking).
+                    if state.skipped_uri_pages > 0 {
+                        return Some((
+                            Err(AppError::Generic(format!(
+                                "SPARQL harvest incomplete: {} pages skipped, fetched {} datasets",
+                                state.skipped_uri_pages, state.fetched
+                            ))),
+                            TwoPhaseState {
+                                skipped_uri_pages: 0,
+                                ..state
+                            },
+                        ));
+                    }
                     return None;
                 }
 
-                let query = self.build_dataset_query_with_limit(
-                    state.offset,
-                    state.page_size,
-                    filter.as_deref(),
-                );
+                // -- Fill the URI buffer until we have a full VALUES batch ----
+                while !state.uris_done && state.pending_uris.len() < VALUES_BATCH_SIZE {
+                    match self.fetch_uri_page(state.uri_offset).await {
+                        Ok(uris) => {
+                            state.consecutive_uri_skips = 0;
+                            let page_full = uris.len() >= self.page_size;
 
-                let mut last_err = None;
-
-                for page_attempt in 0..=MAX_PAGE_RETRIES {
-                    match self.execute_query(&query).await {
-                        Ok(bindings) => {
-                            if bindings.is_empty() {
-                                return None;
-                            }
-
-                            let count = bindings.len();
-                            let datasets = self.bindings_to_datasets(bindings);
-
-                            state.fetched += datasets.len();
                             tracing::debug!(
-                                offset = state.offset,
-                                page_size = state.page_size,
-                                page_datasets = datasets.len(),
-                                total_fetched = state.fetched,
-                                "SPARQL page fetched"
+                                uri_offset = state.uri_offset,
+                                page_uris = uris.len(),
+                                "SPARQL URI page fetched"
                             );
 
-                            if count < state.page_size {
-                                state.done = true;
+                            state.pending_uris.extend(uris);
+                            state.uri_offset += self.page_size;
+
+                            if !page_full {
+                                state.uris_done = true;
                             } else {
-                                state.offset += state.page_size;
                                 sleep(PAGE_DELAY).await;
                             }
-
-                            return Some((Ok(datasets), state));
                         }
                         Err(e) => {
-                            // On server overload, try reducing page size first.
-                            if is_server_overload(&e) && state.page_size > MIN_PAGE_SIZE {
-                                let new_size = (state.page_size / 2).max(MIN_PAGE_SIZE);
-                                tracing::warn!(
-                                    offset = state.offset,
-                                    old_page_size = state.page_size,
-                                    new_page_size = new_size,
-                                    error = %e,
-                                    "SPARQL server overload; reducing page size and retrying"
-                                );
-                                state.page_size = new_size;
-                                sleep(PAGE_RETRY_BASE_DELAY).await;
-                                return Some((Ok(vec![]), state));
+                            // First page failure: propagate immediately.
+                            if state.uri_offset == 0 && state.pending_uris.is_empty() {
+                                return Some((
+                                    Err(e),
+                                    TwoPhaseState {
+                                        done: true,
+                                        ..state
+                                    },
+                                ));
                             }
+                            state.skipped_uri_pages += 1;
+                            state.consecutive_uri_skips += 1;
+                            tracing::warn!(
+                                uri_offset = state.uri_offset,
+                                skipped = state.skipped_uri_pages,
+                                error = %e,
+                                "SPARQL URI page failed; skipping"
+                            );
+                            state.uri_offset += self.page_size;
 
-                            if page_attempt < MAX_PAGE_RETRIES {
-                                let delay = PAGE_RETRY_BASE_DELAY * 2_u32.pow(page_attempt);
+                            if state.consecutive_uri_skips >= MAX_CONSECUTIVE_SKIPS {
                                 tracing::warn!(
-                                    offset = state.offset,
-                                    attempt = page_attempt + 1,
-                                    delay_secs = delay.as_secs(),
-                                    error = %e,
-                                    "SPARQL page fetch failed; retrying after backoff"
+                                    "SPARQL URI enumeration: {} consecutive failures; stopping",
+                                    MAX_CONSECUTIVE_SKIPS
                                 );
-                                last_err = Some(e);
-                                sleep(delay).await;
-                                continue;
+                                state.uris_done = true;
+                            } else {
+                                sleep(PAGE_RETRY_BASE_DELAY).await;
                             }
-                            last_err = Some(e);
                         }
                     }
                 }
 
-                // All retries exhausted
-                let e =
-                    last_err.unwrap_or_else(|| AppError::Generic("Page fetch failed".to_string()));
-
-                if state.offset == 0 {
-                    // First page: propagate error so caller knows
-                    return Some((
-                        Err(e),
-                        PaginationState {
-                            done: true,
-                            ..state
-                        },
-                    ));
+                // -- Nothing left to detail-fetch? We're done. ----------------
+                if state.pending_uris.is_empty() {
+                    if state.skipped_uri_pages > 0 {
+                        state.done = true;
+                        return Some((
+                            Err(AppError::Generic(format!(
+                                "SPARQL harvest incomplete: {} URI pages skipped, fetched {} datasets",
+                                state.skipped_uri_pages, state.fetched
+                            ))),
+                            state,
+                        ));
+                    }
+                    return None;
                 }
 
-                tracing::warn!(
-                    offset = state.offset,
-                    fetched = state.fetched,
-                    error = %e,
-                    "SPARQL page fetch failed after retries; stopping stream"
-                );
+                // -- Phase 2: detail-fetch a VALUES batch ---------------------
+                let batch_size = state.pending_uris.len().min(VALUES_BATCH_SIZE);
+                let batch_uris: Vec<String> = state.pending_uris.drain(..batch_size).collect();
 
-                None
+                match self.fetch_details_batch(&batch_uris).await {
+                    Ok(datasets) => {
+                        state.fetched += datasets.len();
+                        tracing::debug!(
+                            batch_uris = batch_uris.len(),
+                            datasets = datasets.len(),
+                            total_fetched = state.fetched,
+                            "SPARQL detail batch fetched"
+                        );
+
+                        // If no more URIs to collect and buffer is empty, mark done
+                        if state.uris_done && state.pending_uris.is_empty() {
+                            state.done = true;
+                        }
+                        Some((Ok(datasets), state))
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            batch_uris = batch_uris.len(),
+                            error = %e,
+                            "SPARQL detail batch failed; skipping batch"
+                        );
+                        state.skipped_uri_pages += 1; // reuse counter for any skipped work
+                        // Continue — don't stop the stream for one bad detail batch
+                        if state.uris_done && state.pending_uris.is_empty() {
+                            state.done = true;
+                        }
+                        Some((Ok(vec![]), state))
+                    }
+                }
             }
         }))
     }
@@ -371,7 +417,67 @@ impl SparqlDcatClient {
     // Internal helpers
     // =========================================================================
 
-    /// Core paginated SPARQL fetcher using cursor-based (keyset) pagination.
+    /// Phase 1: fetch one page of dataset URIs via the lightweight enumeration query.
+    ///
+    /// Uses page-level retries with adaptive page-size reduction, matching the
+    /// retry policy of the old single-phase approach.
+    async fn fetch_uri_page(&self, offset: usize) -> Result<Vec<String>, AppError> {
+        let query = format!(
+            "SELECT DISTINCT ?dataset \
+             WHERE {{ ?dataset a <http://www.w3.org/ns/dcat#Dataset> }} \
+             LIMIT {} OFFSET {}",
+            self.page_size, offset
+        );
+
+        let bindings = self.execute_query(&query).await?;
+        Ok(bindings
+            .into_iter()
+            .filter_map(|mut b| b.remove("dataset").map(|v| v.value))
+            .collect())
+    }
+
+    /// Phase 2: fetch full metadata for a batch of dataset URIs using a VALUES query.
+    ///
+    /// The VALUES clause scopes the query to specific URIs — no OFFSET needed,
+    /// so there's no query-plan explosion on large catalogs.
+    async fn fetch_details_batch(&self, uris: &[String]) -> Result<Vec<DcatDataset>, AppError> {
+        if uris.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let values_clause: String = uris
+            .iter()
+            .map(|u| format!("(<{u}>)"))
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        let title_filter = self
+            .lang_filter_alternatives()
+            .iter()
+            .map(|l| format!("lang(?title) = \"{l}\""))
+            .collect::<Vec<_>>()
+            .join(" || ");
+
+        let query = format!(
+            "PREFIX dcat: <http://www.w3.org/ns/dcat#>\n\
+             PREFIX dct:  <http://purl.org/dc/terms/>\n\
+             \n\
+             SELECT ?dataset ?title ?description ?identifier ?modified\n\
+             WHERE {{\n\
+               VALUES (?dataset) {{ {values_clause} }}\n\
+               ?dataset dct:title ?title .\n\
+               FILTER ({title_filter})\n\
+               OPTIONAL {{ ?dataset dct:description ?description }}\n\
+               OPTIONAL {{ ?dataset dct:identifier ?identifier }}\n\
+               OPTIONAL {{ ?dataset dct:modified ?modified }}\n\
+             }}",
+        );
+
+        let bindings = self.execute_query(&query).await?;
+        Ok(self.bindings_to_datasets(bindings))
+    }
+
+    /// Core paginated SPARQL fetcher (non-streaming, used by search_modified_since).
     async fn paginate_sparql(
         &self,
         extra_filter: Option<&str>,

--- a/crates/ceres-client/src/sparql.rs
+++ b/crates/ceres-client/src/sparql.rs
@@ -169,7 +169,6 @@ impl SparqlDcatClient {
             let query = format!(
                 "SELECT DISTINCT ?dataset \
                  WHERE {{ ?dataset a <http://www.w3.org/ns/dcat#Dataset> }} \
-                 ORDER BY ?dataset \
                  LIMIT {} OFFSET {}",
                 self.page_size, offset
             );
@@ -502,7 +501,6 @@ impl SparqlDcatClient {
                OPTIONAL {{ ?dataset dct:modified ?modified }}\n\
                {extra}\n\
              }}\n\
-             ORDER BY ?dataset\n\
              LIMIT {limit} OFFSET {offset}",
         )
     }
@@ -946,7 +944,7 @@ mod tests {
         let query = client.build_dataset_query(0, None);
         assert!(query.contains("dcat:Dataset"));
         assert!(query.contains("dct:title"));
-        assert!(query.contains("ORDER BY ?dataset"));
+        assert!(!query.contains("ORDER BY"));
         assert!(query.contains("LIMIT 1000 OFFSET 0"));
         assert!(query.contains("lang(?title) = \"en\""));
         // Description filter should NOT be in the query (moved to client-side)

--- a/crates/ceres-client/src/sparql.rs
+++ b/crates/ceres-client/src/sparql.rs
@@ -1,0 +1,763 @@
+//! SPARQL DCAT client for harvesting datasets from SPARQL-backed open data portals.
+//!
+//! Supports portals that expose DCAT-AP metadata via a SPARQL endpoint, such as:
+//! - `data.europa.eu` (EU Open Data Portal)
+//! - `data.norge.no` (Norwegian Data Portal)
+//!
+//! # API
+//!
+//! Endpoint: `POST {base}/sparql` with `Accept: application/sparql-results+json`
+//!
+//! Dataset discovery uses standard DCAT vocabulary:
+//! - `dcat:Dataset` for dataset type
+//! - `dct:title`, `dct:description`, `dct:identifier`, `dct:modified` for fields
+//!
+//! Pagination uses `LIMIT`/`OFFSET` in the SPARQL query.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use ceres_core::HttpConfig;
+use ceres_core::error::AppError;
+use chrono::{DateTime, Utc};
+use futures::stream::BoxStream;
+use reqwest::{Client, StatusCode, Url};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tokio::time::sleep;
+
+use crate::dcat::DcatDataset;
+
+/// Delay between paginated SPARQL requests.
+const PAGE_DELAY: Duration = Duration::from_millis(300);
+
+/// Per-request timeout for SPARQL queries.
+///
+/// SPARQL queries on large catalogs can be slow, so we use a generous timeout.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Maximum backoff delay for rate-limited retries.
+const MAX_RETRY_DELAY: Duration = Duration::from_secs(30);
+
+/// Default number of results per SPARQL page.
+const DEFAULT_PAGE_SIZE: usize = 1000;
+
+// =============================================================================
+// SPARQL JSON Results Format (W3C standard)
+// =============================================================================
+
+/// Top-level SPARQL JSON results response.
+#[derive(Debug, Deserialize)]
+struct SparqlResponse {
+    results: SparqlResults,
+}
+
+/// The `results` object containing bindings.
+#[derive(Debug, Deserialize)]
+struct SparqlResults {
+    bindings: Vec<HashMap<String, SparqlValue>>,
+}
+
+/// A single SPARQL value in a binding row.
+#[derive(Debug, Deserialize)]
+struct SparqlValue {
+    /// The RDF term value.
+    value: String,
+    /// Language tag for literals (e.g., `"en"`, `"nb"`).
+    #[serde(rename = "xml:lang")]
+    lang: Option<String>,
+}
+
+// =============================================================================
+// SparqlDcatClient
+// =============================================================================
+
+/// HTTP client for harvesting DCAT-AP catalogs via SPARQL endpoints.
+#[derive(Clone)]
+pub struct SparqlDcatClient {
+    client: Client,
+    endpoint_url: Url,
+    base_url: Url,
+    language: String,
+    page_size: usize,
+}
+
+impl SparqlDcatClient {
+    /// Creates a new SPARQL DCAT client for the specified portal.
+    ///
+    /// The SPARQL endpoint is derived by convention as `{base_url}/sparql`.
+    ///
+    /// # Arguments
+    ///
+    /// * `base_url_str` - The base URL of the portal (e.g., `https://data.europa.eu`)
+    /// * `language` - Preferred language for resolving multilingual fields (e.g., `"en"`, `"nb"`)
+    pub fn new(base_url_str: &str, language: &str) -> Result<Self, AppError> {
+        let base_url = Url::parse(base_url_str)
+            .map_err(|_| AppError::InvalidPortalUrl(base_url_str.to_string()))?;
+
+        let endpoint_url = base_url
+            .join("sparql")
+            .map_err(|e| AppError::Generic(format!("Failed to build SPARQL endpoint URL: {e}")))?;
+
+        let client = Client::builder()
+            .user_agent("Ceres/0.1 (semantic-search-bot)")
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .map_err(|e| AppError::ClientError(e.to_string()))?;
+
+        Ok(Self {
+            client,
+            endpoint_url,
+            base_url,
+            language: language.to_string(),
+            page_size: DEFAULT_PAGE_SIZE,
+        })
+    }
+
+    /// Returns the portal type identifier.
+    pub fn portal_type(&self) -> &'static str {
+        "dcat"
+    }
+
+    /// Returns the base URL of the portal.
+    pub fn base_url(&self) -> &str {
+        self.base_url.as_str()
+    }
+
+    /// Returns all dataset identifiers via a lightweight SPARQL query.
+    pub async fn list_dataset_ids(&self) -> Result<Vec<String>, AppError> {
+        let mut ids = Vec::new();
+        let mut offset = 0usize;
+
+        loop {
+            let query = format!(
+                "SELECT DISTINCT ?dataset \
+                 WHERE {{ ?dataset a <http://www.w3.org/ns/dcat#Dataset> }} \
+                 LIMIT {} OFFSET {}",
+                self.page_size, offset
+            );
+
+            let bindings = self.execute_query(&query).await?;
+            if bindings.is_empty() {
+                break;
+            }
+
+            let count = bindings.len();
+            for binding in bindings {
+                if let Some(v) = binding.get("dataset") {
+                    ids.push(extract_last_segment(&v.value));
+                }
+            }
+
+            if count < self.page_size {
+                break;
+            }
+            offset += self.page_size;
+            sleep(PAGE_DELAY).await;
+        }
+
+        Ok(ids)
+    }
+
+    /// Not implemented: SPARQL single-dataset lookup is not used by the harvest pipeline.
+    pub async fn get_dataset(&self, _id: &str) -> Result<DcatDataset, AppError> {
+        Err(AppError::Generic(
+            "get_dataset is not implemented for SPARQL DCAT portals. \
+             Use search_all_datasets() instead."
+                .to_string(),
+        ))
+    }
+
+    /// Searches for datasets modified since the given timestamp.
+    pub async fn search_modified_since(
+        &self,
+        since: DateTime<Utc>,
+    ) -> Result<Vec<DcatDataset>, AppError> {
+        let filter = format!(
+            "FILTER (?modified > \"{}\"^^<http://www.w3.org/2001/XMLSchema#dateTime>)",
+            since.to_rfc3339()
+        );
+        self.paginate_sparql(Some(&filter)).await
+    }
+
+    /// Fetches all datasets from the portal using paginated SPARQL queries.
+    pub async fn search_all_datasets(&self) -> Result<Vec<DcatDataset>, AppError> {
+        self.paginate_sparql(None).await
+    }
+
+    /// Returns the total number of datasets in the catalog.
+    pub async fn dataset_count(&self) -> Result<usize, AppError> {
+        let query = "SELECT (COUNT(DISTINCT ?dataset) AS ?count) \
+             WHERE { ?dataset a <http://www.w3.org/ns/dcat#Dataset> }";
+
+        let bindings = self.execute_query(query).await?;
+        bindings
+            .first()
+            .and_then(|b| b.get("count"))
+            .and_then(|v| v.value.parse::<usize>().ok())
+            .ok_or_else(|| AppError::Generic("Failed to parse dataset count".to_string()))
+    }
+
+    /// Streams catalog datasets page-by-page using LIMIT/OFFSET pagination.
+    ///
+    /// Each yielded item contains the datasets extracted from one SPARQL page.
+    /// Memory is bounded to a single page at a time.
+    pub fn paginate_sparql_stream(
+        &self,
+        modified_since: Option<String>,
+    ) -> BoxStream<'_, Result<Vec<DcatDataset>, AppError>> {
+        let filter = modified_since.map(|since| {
+            format!(
+                "FILTER (?modified > \"{}\"^^<http://www.w3.org/2001/XMLSchema#dateTime>)",
+                since
+            )
+        });
+
+        struct PaginationState {
+            offset: usize,
+            done: bool,
+        }
+
+        let initial = PaginationState {
+            offset: 0,
+            done: false,
+        };
+
+        Box::pin(futures::stream::unfold(initial, move |mut state| {
+            let filter = filter.clone();
+            async move {
+                if state.done {
+                    return None;
+                }
+
+                let query = self.build_dataset_query(state.offset, filter.as_deref());
+
+                match self.execute_query(&query).await {
+                    Ok(bindings) => {
+                        if bindings.is_empty() {
+                            return None;
+                        }
+
+                        let count = bindings.len();
+                        let datasets = self.bindings_to_datasets(bindings);
+
+                        if count < self.page_size {
+                            state.done = true;
+                        } else {
+                            state.offset += self.page_size;
+                            sleep(PAGE_DELAY).await;
+                        }
+
+                        Some((Ok(datasets), state))
+                    }
+                    Err(e) => {
+                        if state.offset == 0 {
+                            // First page failed — propagate error
+                            Some((
+                                Err(e),
+                                PaginationState {
+                                    offset: 0,
+                                    done: true,
+                                },
+                            ))
+                        } else {
+                            tracing::warn!(
+                                offset = state.offset,
+                                error = %e,
+                                "SPARQL page fetch failed; stopping stream"
+                            );
+                            None
+                        }
+                    }
+                }
+            }
+        }))
+    }
+
+    // =========================================================================
+    // Internal helpers
+    // =========================================================================
+
+    /// Core paginated SPARQL fetcher.
+    async fn paginate_sparql(
+        &self,
+        extra_filter: Option<&str>,
+    ) -> Result<Vec<DcatDataset>, AppError> {
+        let mut all_datasets = Vec::new();
+        let mut offset = 0usize;
+
+        loop {
+            let query = self.build_dataset_query(offset, extra_filter);
+            let bindings = match self.execute_query(&query).await {
+                Ok(b) => b,
+                Err(e) => {
+                    if all_datasets.is_empty() {
+                        return Err(e);
+                    }
+                    tracing::warn!(
+                        offset,
+                        collected = all_datasets.len(),
+                        error = %e,
+                        "SPARQL page fetch failed; returning partial results"
+                    );
+                    break;
+                }
+            };
+
+            if bindings.is_empty() {
+                break;
+            }
+
+            let count = bindings.len();
+            let datasets = self.bindings_to_datasets(bindings);
+            all_datasets.extend(datasets);
+
+            if count < self.page_size {
+                break;
+            }
+            offset += self.page_size;
+            sleep(PAGE_DELAY).await;
+        }
+
+        Ok(all_datasets)
+    }
+
+    /// Builds the SPARQL SELECT query for dataset discovery.
+    fn build_dataset_query(&self, offset: usize, extra_filter: Option<&str>) -> String {
+        let lang = &self.language;
+        let extra = extra_filter.unwrap_or("");
+
+        format!(
+            "PREFIX dcat: <http://www.w3.org/ns/dcat#>\n\
+             PREFIX dct:  <http://purl.org/dc/terms/>\n\
+             \n\
+             SELECT ?dataset ?title ?description ?identifier ?modified\n\
+             WHERE {{\n\
+               ?dataset a dcat:Dataset .\n\
+               ?dataset dct:title ?title .\n\
+               FILTER (lang(?title) = \"{lang}\" || lang(?title) = \"en\" || lang(?title) = \"\")\n\
+               OPTIONAL {{ ?dataset dct:description ?description .\n\
+                 FILTER (lang(?description) = \"{lang}\" || lang(?description) = \"en\" || lang(?description) = \"\")\n\
+               }}\n\
+               OPTIONAL {{ ?dataset dct:identifier ?identifier }}\n\
+               OPTIONAL {{ ?dataset dct:modified ?modified }}\n\
+               {extra}\n\
+             }}\n\
+             LIMIT {} OFFSET {}",
+            self.page_size, offset
+        )
+    }
+
+    /// Executes a SPARQL query and returns the result bindings.
+    async fn execute_query(
+        &self,
+        query: &str,
+    ) -> Result<Vec<HashMap<String, SparqlValue>>, AppError> {
+        let resp = self.request_with_retry(query).await?;
+
+        let body: SparqlResponse = resp.json().await.map_err(|e| {
+            AppError::ClientError(format!("SPARQL endpoint returned non-JSON response: {e}"))
+        })?;
+
+        Ok(body.results.bindings)
+    }
+
+    /// HTTP POST with exponential backoff retry on transient errors and rate limits.
+    async fn request_with_retry(&self, query: &str) -> Result<reqwest::Response, AppError> {
+        let http_config = HttpConfig::default();
+        let max_retries = http_config.max_retries;
+        let base_delay = http_config.retry_base_delay;
+        let mut last_error = AppError::Generic("No attempts made".to_string());
+
+        for attempt in 1..=max_retries {
+            let body = url::form_urlencoded::Serializer::new(String::new())
+                .append_pair("query", query)
+                .finish();
+            match self
+                .client
+                .post(self.endpoint_url.clone())
+                .header("Accept", "application/sparql-results+json")
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .body(body)
+                .send()
+                .await
+            {
+                Ok(resp) => {
+                    let status = resp.status();
+
+                    if status.is_success() {
+                        return Ok(resp);
+                    }
+
+                    if status == StatusCode::TOO_MANY_REQUESTS {
+                        last_error = AppError::RateLimitExceeded;
+                        if attempt < max_retries {
+                            let delay = resp
+                                .headers()
+                                .get("retry-after")
+                                .and_then(|v| v.to_str().ok())
+                                .and_then(|v| v.parse::<u64>().ok())
+                                .map(Duration::from_secs)
+                                .unwrap_or_else(|| {
+                                    (base_delay * 2_u32.pow(attempt)).min(MAX_RETRY_DELAY)
+                                });
+                            sleep(delay).await;
+                            continue;
+                        }
+                        return Err(AppError::RateLimitExceeded);
+                    }
+
+                    if status.is_server_error() {
+                        last_error = AppError::ClientError(format!(
+                            "Server error: HTTP {}",
+                            status.as_u16()
+                        ));
+                        if attempt < max_retries {
+                            sleep(base_delay * attempt).await;
+                            continue;
+                        }
+                    }
+
+                    return Err(AppError::ClientError(format!(
+                        "HTTP {} from {}",
+                        status.as_u16(),
+                        self.endpoint_url
+                    )));
+                }
+                Err(e) => {
+                    if e.is_timeout() {
+                        last_error = AppError::Timeout(REQUEST_TIMEOUT.as_secs());
+                    } else if e.is_connect() {
+                        last_error = AppError::NetworkError(format!("Connection failed: {e}"));
+                    } else {
+                        last_error = AppError::ClientError(e.to_string());
+                    }
+                    if attempt < max_retries && (e.is_timeout() || e.is_connect()) {
+                        sleep(base_delay * attempt).await;
+                        continue;
+                    }
+                }
+            }
+        }
+
+        Err(last_error)
+    }
+
+    /// Converts SPARQL bindings into `DcatDataset` objects, deduplicating by dataset URI.
+    ///
+    /// SPARQL may return multiple rows per dataset (e.g., different language tags).
+    /// The first title/description encountered for each dataset URI is kept.
+    fn bindings_to_datasets(
+        &self,
+        bindings: Vec<HashMap<String, SparqlValue>>,
+    ) -> Vec<DcatDataset> {
+        let mut seen: HashMap<String, DcatDataset> = HashMap::new();
+
+        for binding in bindings {
+            let Some(dataset_uri) = binding.get("dataset").map(|v| v.value.clone()) else {
+                continue;
+            };
+
+            if seen.contains_key(&dataset_uri) {
+                continue;
+            }
+
+            let title = match binding.get("title") {
+                Some(v) if !v.value.is_empty() => v.value.clone(),
+                _ => continue, // Skip datasets without a title
+            };
+
+            let description = binding
+                .get("description")
+                .map(|v| v.value.clone())
+                .filter(|s| !s.is_empty());
+
+            let identifier = binding
+                .get("identifier")
+                .map(|v| v.value.clone())
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| extract_last_segment(&dataset_uri));
+
+            // Build raw metadata from the binding
+            let raw = binding_to_json(&binding);
+
+            seen.insert(
+                dataset_uri.clone(),
+                DcatDataset {
+                    id_uri: dataset_uri,
+                    identifier,
+                    title,
+                    description,
+                    raw,
+                },
+            );
+        }
+
+        seen.into_values().collect()
+    }
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/// Extracts the last non-empty path segment from a URI.
+fn extract_last_segment(uri: &str) -> String {
+    uri.trim_end_matches('/')
+        .rsplit('/')
+        .next()
+        .unwrap_or(uri)
+        .to_string()
+}
+
+/// Converts a SPARQL binding row into a `serde_json::Value` for raw metadata storage.
+fn binding_to_json(binding: &HashMap<String, SparqlValue>) -> Value {
+    let mut map = serde_json::Map::new();
+    for (key, val) in binding {
+        let mut entry = serde_json::Map::new();
+        entry.insert("value".to_string(), json!(val.value));
+        if let Some(ref lang) = val.lang {
+            entry.insert("xml:lang".to_string(), json!(lang));
+        }
+        map.insert(key.clone(), Value::Object(entry));
+    }
+    Value::Object(map)
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- SPARQL response parsing -------------------------------------------
+
+    fn sample_sparql_json() -> &'static str {
+        r#"{
+            "head": { "vars": ["dataset", "title", "description", "identifier", "modified"] },
+            "results": {
+                "bindings": [
+                    {
+                        "dataset": { "type": "uri", "value": "https://data.europa.eu/dataset/1234" },
+                        "title": { "type": "literal", "value": "Air Quality Data", "xml:lang": "en" },
+                        "description": { "type": "literal", "value": "Air quality measurements", "xml:lang": "en" },
+                        "identifier": { "type": "literal", "value": "air-quality-1234" }
+                    },
+                    {
+                        "dataset": { "type": "uri", "value": "https://data.europa.eu/dataset/5678" },
+                        "title": { "type": "literal", "value": "Population Census", "xml:lang": "en" }
+                    }
+                ]
+            }
+        }"#
+    }
+
+    #[test]
+    fn parse_sparql_response() {
+        let resp: SparqlResponse = serde_json::from_str(sample_sparql_json()).unwrap();
+        assert_eq!(resp.results.bindings.len(), 2);
+
+        let first = &resp.results.bindings[0];
+        assert_eq!(
+            first["dataset"].value,
+            "https://data.europa.eu/dataset/1234"
+        );
+        assert_eq!(first["title"].value, "Air Quality Data");
+        assert_eq!(first["title"].lang.as_deref(), Some("en"));
+        assert_eq!(first["identifier"].value, "air-quality-1234");
+
+        let second = &resp.results.bindings[1];
+        assert_eq!(
+            second["dataset"].value,
+            "https://data.europa.eu/dataset/5678"
+        );
+        assert!(second.get("description").is_none());
+    }
+
+    // ---- bindings_to_datasets ----------------------------------------------
+
+    #[test]
+    fn bindings_to_datasets_basic() {
+        let client = SparqlDcatClient::new("https://data.europa.eu", "en").unwrap();
+        let resp: SparqlResponse = serde_json::from_str(sample_sparql_json()).unwrap();
+        let datasets = client.bindings_to_datasets(resp.results.bindings);
+
+        assert_eq!(datasets.len(), 2);
+
+        // Find by URI (order is not guaranteed from HashMap)
+        let air = datasets
+            .iter()
+            .find(|d| d.id_uri == "https://data.europa.eu/dataset/1234")
+            .unwrap();
+        assert_eq!(air.title, "Air Quality Data");
+        assert_eq!(air.description.as_deref(), Some("Air quality measurements"));
+        assert_eq!(air.identifier, "air-quality-1234");
+
+        let pop = datasets
+            .iter()
+            .find(|d| d.id_uri == "https://data.europa.eu/dataset/5678")
+            .unwrap();
+        assert_eq!(pop.title, "Population Census");
+        assert!(pop.description.is_none());
+        assert_eq!(pop.identifier, "5678"); // fallback to last URI segment
+    }
+
+    #[test]
+    fn bindings_deduplicates_by_uri() {
+        let client = SparqlDcatClient::new("https://data.europa.eu", "en").unwrap();
+        let json = r#"{
+            "results": {
+                "bindings": [
+                    {
+                        "dataset": { "type": "uri", "value": "https://example.org/d/1" },
+                        "title": { "type": "literal", "value": "First Title", "xml:lang": "en" }
+                    },
+                    {
+                        "dataset": { "type": "uri", "value": "https://example.org/d/1" },
+                        "title": { "type": "literal", "value": "Duplicate Title", "xml:lang": "en" }
+                    }
+                ]
+            }
+        }"#;
+        let resp: SparqlResponse = serde_json::from_str(json).unwrap();
+        let datasets = client.bindings_to_datasets(resp.results.bindings);
+        assert_eq!(datasets.len(), 1);
+        assert_eq!(datasets[0].title, "First Title");
+    }
+
+    #[test]
+    fn bindings_skip_empty_title() {
+        let client = SparqlDcatClient::new("https://data.europa.eu", "en").unwrap();
+        let json = r#"{
+            "results": {
+                "bindings": [
+                    {
+                        "dataset": { "type": "uri", "value": "https://example.org/d/1" },
+                        "title": { "type": "literal", "value": "" }
+                    },
+                    {
+                        "dataset": { "type": "uri", "value": "https://example.org/d/2" },
+                        "title": { "type": "literal", "value": "Valid Title" }
+                    }
+                ]
+            }
+        }"#;
+        let resp: SparqlResponse = serde_json::from_str(json).unwrap();
+        let datasets = client.bindings_to_datasets(resp.results.bindings);
+        assert_eq!(datasets.len(), 1);
+        assert_eq!(datasets[0].title, "Valid Title");
+    }
+
+    // ---- extract_last_segment -----------------------------------------------
+
+    #[test]
+    fn extract_last_segment_basic() {
+        assert_eq!(
+            extract_last_segment("https://data.europa.eu/dataset/1234"),
+            "1234"
+        );
+    }
+
+    #[test]
+    fn extract_last_segment_trailing_slash() {
+        assert_eq!(
+            extract_last_segment("https://data.europa.eu/dataset/1234/"),
+            "1234"
+        );
+    }
+
+    // ---- query building ----------------------------------------------------
+
+    #[test]
+    fn build_dataset_query_basic() {
+        let client = SparqlDcatClient::new("https://data.europa.eu", "en").unwrap();
+        let query = client.build_dataset_query(0, None);
+        assert!(query.contains("dcat:Dataset"));
+        assert!(query.contains("dct:title"));
+        assert!(query.contains("LIMIT 1000 OFFSET 0"));
+        assert!(query.contains("lang(?title) = \"en\""));
+    }
+
+    #[test]
+    fn build_dataset_query_with_offset() {
+        let client = SparqlDcatClient::new("https://data.europa.eu", "nb").unwrap();
+        let query = client.build_dataset_query(2000, None);
+        assert!(query.contains("LIMIT 1000 OFFSET 2000"));
+        assert!(query.contains("lang(?title) = \"nb\""));
+    }
+
+    #[test]
+    fn build_dataset_query_with_filter() {
+        let client = SparqlDcatClient::new("https://data.europa.eu", "en").unwrap();
+        let filter = "FILTER (?modified > \"2026-01-01T00:00:00Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>)";
+        let query = client.build_dataset_query(0, Some(filter));
+        assert!(query.contains(filter));
+    }
+
+    // ---- SparqlDcatClient::new ---------------------------------------------
+
+    #[test]
+    fn sparql_client_new_valid() {
+        let client = SparqlDcatClient::new("https://data.europa.eu", "en").unwrap();
+        assert_eq!(client.portal_type(), "dcat");
+        assert_eq!(client.base_url(), "https://data.europa.eu/");
+        assert_eq!(
+            client.endpoint_url.as_str(),
+            "https://data.europa.eu/sparql"
+        );
+    }
+
+    #[test]
+    fn sparql_client_new_invalid_url() {
+        let result = SparqlDcatClient::new("not-a-url", "en");
+        assert!(matches!(result, Err(AppError::InvalidPortalUrl(_))));
+    }
+
+    // ---- binding_to_json ---------------------------------------------------
+
+    #[test]
+    fn binding_to_json_preserves_fields() {
+        let mut binding = HashMap::new();
+        binding.insert(
+            "dataset".to_string(),
+            SparqlValue {
+                value: "https://example.org/d/1".to_string(),
+                lang: None,
+            },
+        );
+        binding.insert(
+            "title".to_string(),
+            SparqlValue {
+                value: "Test Title".to_string(),
+                lang: Some("en".to_string()),
+            },
+        );
+
+        let json = binding_to_json(&binding);
+        let obj = json.as_object().unwrap();
+        assert_eq!(obj["dataset"]["value"], "https://example.org/d/1");
+        assert_eq!(obj["title"]["value"], "Test Title");
+        assert_eq!(obj["title"]["xml:lang"], "en");
+    }
+
+    // ---- Integration smoke test (requires network) -------------------------
+
+    #[tokio::test]
+    #[ignore = "requires network access to data.europa.eu"]
+    async fn test_sparql_smoke_europa() {
+        let client = SparqlDcatClient::new("https://data.europa.eu", "en").unwrap();
+        let count = client.dataset_count().await.unwrap();
+        assert!(count > 100, "Expected >100 datasets, got {}", count);
+
+        let datasets = client.search_all_datasets().await.unwrap();
+        assert!(
+            !datasets.is_empty(),
+            "Expected at least some datasets from data.europa.eu"
+        );
+        let first = &datasets[0];
+        assert!(!first.title.is_empty(), "First dataset title is empty");
+        assert!(!first.id_uri.is_empty(), "First dataset id_uri is empty");
+    }
+}

--- a/crates/ceres-client/src/sparql.rs
+++ b/crates/ceres-client/src/sparql.rs
@@ -49,11 +49,6 @@ const PAGE_RETRY_BASE_DELAY: Duration = Duration::from_secs(10);
 /// Maximum number of page-level retries before giving up on a page.
 const MAX_PAGE_RETRIES: u32 = 3;
 
-/// Maximum consecutive skipped pages before stopping the stream entirely.
-/// If this many pages in a row fail even after retries, the endpoint is
-/// considered down rather than just struggling at specific offsets.
-const MAX_CONSECUTIVE_SKIPS: usize = 3;
-
 /// Default number of results per SPARQL page.
 const DEFAULT_PAGE_SIZE: usize = 1000;
 
@@ -61,9 +56,18 @@ const DEFAULT_PAGE_SIZE: usize = 1000;
 /// issuing very small queries.
 const MIN_PAGE_SIZE: usize = 50;
 
-/// Number of dataset URIs to look up per VALUES batch in two-phase harvest.
-/// Tested at 500 URIs → ~400ms on data.europa.eu.
-const VALUES_BATCH_SIZE: usize = 200;
+/// Page size used within a publisher partition.
+///
+/// Each partition is expected to contain well under Virtuoso's `ResultSetMaxRows`
+/// cap (~10k) so OFFSET stays shallow. 500 keeps individual responses small and
+/// bounds the impact of a page failure.
+const PARTITION_PAGE_SIZE: usize = 500;
+
+/// Offset at which a partition is flagged as "likely truncated" by the server.
+/// If enumeration keeps returning full pages past this offset, the partition is
+/// too large for a single flat scan and should be sub-partitioned. We log a
+/// warning and move on — sub-partitioning is out of scope for this pass.
+const PARTITION_OVERFLOW_OFFSET: usize = 9_500;
 
 // =============================================================================
 // SPARQL JSON Results Format (W3C standard)
@@ -89,6 +93,18 @@ struct SparqlValue {
     /// Language tag for literals (e.g., `"en"`, `"nb"`).
     #[serde(rename = "xml:lang")]
     lang: Option<String>,
+}
+
+/// A harvest partition — a subset of the catalog bounded by publisher.
+enum OwnedPartition {
+    Publisher(String),
+    NoPublisher,
+}
+
+/// Borrowed form used when building SPARQL queries.
+enum PartitionRef<'a> {
+    Publisher(&'a str),
+    NoPublisher,
 }
 
 // =============================================================================
@@ -243,67 +259,73 @@ impl SparqlDcatClient {
             .ok_or_else(|| AppError::Generic("Failed to parse dataset count".to_string()))
     }
 
-    /// Streams catalog datasets using a two-phase approach:
+    /// Streams catalog datasets using publisher-based partitioning.
     ///
-    /// 1. **URI collection** — lightweight `SELECT DISTINCT ?dataset` pages that
-    ///    work reliably even at deep offsets (tested to 1.9M on data.europa.eu).
-    /// 2. **Detail fetch** — for each batch of URIs, a `VALUES`-scoped query
-    ///    retrieves title/description/identifier/modified without OFFSET.
+    /// Rationale: deep LIMIT/OFFSET over the full catalog hits Virtuoso's
+    /// `ResultSetMaxRows` cap (~10k) and becomes non-deterministic without a
+    /// stable ORDER BY. Partitioning by `dct:publisher` bounds each subquery
+    /// under the cap, keeps OFFSET shallow, and pulls title/description inline
+    /// — so blank-node datasets that can't be referenced across queries still
+    /// get harvested.
     ///
-    /// This avoids the query-plan explosion that LIMIT/OFFSET causes on large
-    /// Virtuoso catalogs when combined with OPTIONAL clauses.
+    /// Phase 0: enumerate distinct publishers (one-shot, paged).
+    /// Phase 1: for each publisher, page through its datasets with inline metadata.
+    ///
+    /// Datasets with no `dct:publisher` are harvested in a final pass via a
+    /// `FILTER NOT EXISTS` partition.
     pub fn paginate_sparql_stream(
         &self,
         _modified_since: Option<String>,
     ) -> BoxStream<'_, Result<Vec<DcatDataset>, AppError>> {
-        /// State machine for the two-phase unfold.
-        struct TwoPhaseState {
-            /// Current offset into the lightweight URI enumeration.
-            uri_offset: usize,
-            /// URIs collected but not yet detail-fetched.
-            pending_uris: Vec<String>,
-            /// Total datasets yielded so far.
+        struct PartitionState {
+            /// Publishers still to process (in reverse order so we pop from the back).
+            remaining: Vec<String>,
+            /// Current partition being drained, if any.
+            current: Option<OwnedPartition>,
+            /// Offset within the current partition.
+            offset: usize,
+            /// Have we tried the no-publisher pass yet?
+            did_no_publisher: bool,
+            /// Has publisher enumeration been attempted?
+            enumerated: bool,
+            /// Total datasets yielded.
             fetched: usize,
-            /// URI enumeration finished?
-            uris_done: bool,
-            /// Whole stream finished?
+            /// Partitions skipped after exhausting retries.
+            skipped_partitions: usize,
+            /// Partitions that hit the overflow offset (likely truncated).
+            overflow_partitions: usize,
+            /// Stream done?
             done: bool,
-            /// URI pages that failed after retries.
-            skipped_uri_pages: usize,
-            /// Detail batches that failed after retries.
-            skipped_detail_batches: usize,
-            /// Consecutive URI-page failures (stop after MAX_CONSECUTIVE_SKIPS).
-            consecutive_uri_skips: usize,
         }
 
-        let initial = TwoPhaseState {
-            uri_offset: 0,
-            pending_uris: Vec::new(),
+        let initial = PartitionState {
+            remaining: Vec::new(),
+            current: None,
+            offset: 0,
+            did_no_publisher: false,
+            enumerated: false,
             fetched: 0,
-            uris_done: false,
+            skipped_partitions: 0,
+            overflow_partitions: 0,
             done: false,
-            skipped_uri_pages: 0,
-            skipped_detail_batches: 0,
-            consecutive_uri_skips: 0,
         };
 
         Box::pin(futures::stream::unfold(initial, move |mut state| {
             async move {
                 if state.done {
-                    // Yield a final error if any work was skipped, so the
-                    // harvest records a failure (prevents stale-marking).
-                    let total_skipped = state.skipped_uri_pages + state.skipped_detail_batches;
-                    if total_skipped > 0 {
+                    let incomplete = state.skipped_partitions + state.overflow_partitions;
+                    if incomplete > 0 {
                         return Some((
                             Err(AppError::Generic(format!(
-                                "SPARQL harvest incomplete: {} URI pages and {} detail batches skipped, fetched {} datasets",
-                                state.skipped_uri_pages,
-                                state.skipped_detail_batches,
+                                "SPARQL harvest incomplete: {} partitions skipped, {} partitions overflowed (>{} offset), fetched {} datasets",
+                                state.skipped_partitions,
+                                state.overflow_partitions,
+                                PARTITION_OVERFLOW_OFFSET,
                                 state.fetched
                             ))),
-                            TwoPhaseState {
-                                skipped_uri_pages: 0,
-                                skipped_detail_batches: 0,
+                            PartitionState {
+                                skipped_partitions: 0,
+                                overflow_partitions: 0,
                                 ..state
                             },
                         ));
@@ -311,106 +333,76 @@ impl SparqlDcatClient {
                     return None;
                 }
 
-                // -- Fill the URI buffer until we have a full VALUES batch ----
-                while !state.uris_done && state.pending_uris.len() < VALUES_BATCH_SIZE {
-                    match self.fetch_uri_page(state.uri_offset).await {
-                        Ok(uris) => {
-                            state.consecutive_uri_skips = 0;
-                            let page_full = uris.len() >= self.page_size;
-
-                            tracing::debug!(
-                                uri_offset = state.uri_offset,
-                                page_uris = uris.len(),
-                                "SPARQL URI page fetched"
+                // -- Phase 0: enumerate publishers on first tick --------------
+                if !state.enumerated {
+                    state.enumerated = true;
+                    match self.enumerate_publishers().await {
+                        Ok(mut pubs) => {
+                            tracing::info!(
+                                publishers = pubs.len(),
+                                "SPARQL partition enumeration complete"
                             );
-
-                            state.pending_uris.extend(uris);
-                            state.uri_offset += self.page_size;
-
-                            if !page_full {
-                                state.uris_done = true;
-                            } else {
-                                sleep(PAGE_DELAY).await;
-                            }
+                            // Reverse so we can pop() from the back in order.
+                            pubs.reverse();
+                            state.remaining = pubs;
                         }
                         Err(e) => {
-                            // First page failure: propagate immediately.
-                            if state.uri_offset == 0 && state.pending_uris.is_empty() {
-                                return Some((
-                                    Err(e),
-                                    TwoPhaseState {
-                                        done: true,
-                                        ..state
-                                    },
-                                ));
-                            }
-                            state.skipped_uri_pages += 1;
-                            state.consecutive_uri_skips += 1;
-                            tracing::warn!(
-                                uri_offset = state.uri_offset,
-                                skipped = state.skipped_uri_pages,
-                                error = %e,
-                                "SPARQL URI page failed; skipping"
-                            );
-                            state.uri_offset += self.page_size;
-
-                            if state.consecutive_uri_skips >= MAX_CONSECUTIVE_SKIPS {
-                                tracing::warn!(
-                                    "SPARQL URI enumeration: {} consecutive failures; stopping",
-                                    MAX_CONSECUTIVE_SKIPS
-                                );
-                                state.uris_done = true;
-                            } else {
-                                sleep(PAGE_RETRY_BASE_DELAY).await;
-                            }
+                            return Some((
+                                Err(e),
+                                PartitionState {
+                                    done: true,
+                                    ..state
+                                },
+                            ));
                         }
                     }
                 }
 
-                // -- Nothing left to detail-fetch? We're done. ----------------
-                if state.pending_uris.is_empty() {
-                    state.done = true;
-                    // The done-check at the top of the next tick will emit the
-                    // incomplete-harvest error if any pages/batches were skipped.
-                    return if state.skipped_uri_pages + state.skipped_detail_batches > 0 {
-                        Some((Ok(vec![]), state))
+                // -- Pick next partition if needed ----------------------------
+                if state.current.is_none() {
+                    if let Some(pub_uri) = state.remaining.pop() {
+                        state.current = Some(OwnedPartition::Publisher(pub_uri));
+                        state.offset = 0;
+                    } else if !state.did_no_publisher {
+                        state.did_no_publisher = true;
+                        state.current = Some(OwnedPartition::NoPublisher);
+                        state.offset = 0;
                     } else {
-                        None
-                    };
+                        state.done = true;
+                        return if state.skipped_partitions + state.overflow_partitions > 0 {
+                            Some((Ok(vec![]), state))
+                        } else {
+                            None
+                        };
+                    }
                 }
 
-                // -- Phase 2: detail-fetch a VALUES batch ---------------------
-                let batch_size = state.pending_uris.len().min(VALUES_BATCH_SIZE);
-                let batch_uris: Vec<String> = state.pending_uris.drain(..batch_size).collect();
+                let partition_ref = match state.current.as_ref().unwrap() {
+                    OwnedPartition::Publisher(p) => PartitionRef::Publisher(p.as_str()),
+                    OwnedPartition::NoPublisher => PartitionRef::NoPublisher,
+                };
 
-                // Retry detail batch with backoff before giving up.
+                // -- Fetch one page of the current partition (with retries) ---
                 let mut last_err = None;
+                let mut page_result = None;
                 for attempt in 0..=MAX_PAGE_RETRIES {
-                    match self.fetch_details_batch(&batch_uris).await {
+                    match self
+                        .fetch_partition_page(&partition_ref, state.offset, PARTITION_PAGE_SIZE)
+                        .await
+                    {
                         Ok(datasets) => {
-                            state.fetched += datasets.len();
-                            tracing::debug!(
-                                batch_uris = batch_uris.len(),
-                                datasets = datasets.len(),
-                                total_fetched = state.fetched,
-                                "SPARQL detail batch fetched"
-                            );
-
-                            if state.uris_done && state.pending_uris.is_empty() {
-                                state.done = true;
-                            }
-                            sleep(PAGE_DELAY).await;
-                            return Some((Ok(datasets), state));
+                            page_result = Some(datasets);
+                            break;
                         }
                         Err(e) => {
                             if attempt < MAX_PAGE_RETRIES {
                                 let delay = PAGE_RETRY_BASE_DELAY * 2_u32.pow(attempt);
                                 tracing::warn!(
-                                    batch_uris = batch_uris.len(),
+                                    offset = state.offset,
                                     attempt = attempt + 1,
                                     delay_secs = delay.as_secs(),
                                     error = %e,
-                                    "SPARQL detail batch failed; retrying after backoff"
+                                    "SPARQL partition page failed; retrying after backoff"
                                 );
                                 sleep(delay).await;
                             }
@@ -419,75 +411,140 @@ impl SparqlDcatClient {
                     }
                 }
 
-                // All retries exhausted for this detail batch.
-                let e = last_err.unwrap();
-                tracing::warn!(
-                    batch_uris = batch_uris.len(),
-                    error = %e,
-                    "SPARQL detail batch failed after retries; skipping batch"
+                let datasets = match page_result {
+                    Some(d) => d,
+                    None => {
+                        let e = last_err.unwrap();
+                        let label = match &partition_ref {
+                            PartitionRef::Publisher(p) => *p,
+                            PartitionRef::NoPublisher => "<no-publisher>",
+                        };
+                        tracing::warn!(
+                            partition = label,
+                            offset = state.offset,
+                            error = %e,
+                            "SPARQL partition failed after retries; skipping remainder"
+                        );
+                        state.skipped_partitions += 1;
+                        state.current = None;
+                        sleep(PAGE_RETRY_BASE_DELAY).await;
+                        return Some((Ok(vec![]), state));
+                    }
+                };
+
+                let count = datasets.len();
+                state.fetched += count;
+
+                tracing::debug!(
+                    offset = state.offset,
+                    page_datasets = count,
+                    total_fetched = state.fetched,
+                    "SPARQL partition page fetched"
                 );
-                state.skipped_detail_batches += 1;
-                if state.uris_done && state.pending_uris.is_empty() {
-                    state.done = true;
+
+                let partition_full = count >= PARTITION_PAGE_SIZE;
+                state.offset += PARTITION_PAGE_SIZE;
+
+                // Partition exhausted, or overflowing (likely server-truncated).
+                if !partition_full {
+                    state.current = None;
+                } else if state.offset >= PARTITION_OVERFLOW_OFFSET {
+                    let label = match &partition_ref {
+                        PartitionRef::Publisher(p) => *p,
+                        PartitionRef::NoPublisher => "<no-publisher>",
+                    };
+                    tracing::warn!(
+                        partition = label,
+                        offset = state.offset,
+                        "SPARQL partition exceeded overflow offset; sub-partitioning not implemented, stopping scan"
+                    );
+                    state.overflow_partitions += 1;
+                    state.current = None;
                 }
-                // Back off before continuing to next batch.
-                sleep(PAGE_RETRY_BASE_DELAY).await;
-                Some((Ok(vec![]), state))
+
+                sleep(PAGE_DELAY).await;
+                Some((Ok(datasets), state))
             }
         }))
     }
 
-    // =========================================================================
-    // Internal helpers
-    // =========================================================================
-
-    /// Phase 1: fetch one page of dataset URIs via the lightweight enumeration query.
+    /// Phase 0: enumerate all distinct `dct:publisher` IRIs across datasets.
     ///
-    /// Per-request retries are handled inside `execute_query` → `request_with_retry`.
-    /// Higher-level skip/continue logic lives in the caller (`paginate_sparql_stream`).
-    async fn fetch_uri_page(&self, offset: usize) -> Result<Vec<String>, AppError> {
-        let query = format!(
-            "SELECT DISTINCT ?dataset \
-             WHERE {{ ?dataset a <http://www.w3.org/ns/dcat#Dataset> }} \
-             LIMIT {} OFFSET {}",
-            self.page_size, offset
-        );
+    /// Paged with a small LIMIT. Expected cardinality on data.europa.eu is
+    /// in the low thousands, so this completes in a few dozen queries.
+    async fn enumerate_publishers(&self) -> Result<Vec<String>, AppError> {
+        let mut publishers = Vec::new();
+        let mut offset = 0usize;
+        let limit = self.page_size;
 
-        let bindings = self.execute_query(&query).await?;
-        Ok(bindings
-            .into_iter()
-            .filter_map(|mut b| b.remove("dataset").map(|v| v.value))
-            .collect())
+        loop {
+            let query = format!(
+                "PREFIX dcat: <http://www.w3.org/ns/dcat#>\n\
+                 PREFIX dct:  <http://purl.org/dc/terms/>\n\
+                 \n\
+                 SELECT DISTINCT ?pub WHERE {{\n\
+                   ?d a dcat:Dataset ; dct:publisher ?pub .\n\
+                 }}\n\
+                 LIMIT {limit} OFFSET {offset}"
+            );
+
+            let bindings = self.execute_query(&query).await?;
+            if bindings.is_empty() {
+                break;
+            }
+            let count = bindings.len();
+            for b in bindings {
+                if let Some(v) = b.get("pub") {
+                    // Only named resources can be referenced across queries.
+                    if v.value.starts_with("http://") || v.value.starts_with("https://") {
+                        publishers.push(v.value.clone());
+                    }
+                }
+            }
+            if count < limit {
+                break;
+            }
+            offset += limit;
+            sleep(PAGE_DELAY).await;
+
+            // Safety rail: if publisher cardinality is unexpectedly huge, stop
+            // so we don't spend forever enumerating before any data is yielded.
+            if offset >= 100_000 {
+                tracing::warn!(
+                    offset,
+                    publishers = publishers.len(),
+                    "Publisher enumeration exceeded 100k offset; truncating"
+                );
+                break;
+            }
+        }
+
+        Ok(publishers)
     }
 
-    /// Phase 2: fetch full metadata for a batch of dataset URIs using a VALUES query.
-    ///
-    /// The VALUES clause scopes the query to specific URIs — no OFFSET needed,
-    /// so there's no query-plan explosion on large catalogs.
-    async fn fetch_details_batch(&self, uris: &[String]) -> Result<Vec<DcatDataset>, AppError> {
-        if uris.is_empty() {
-            return Ok(vec![]);
-        }
-
-        // Validate URIs before interpolating into SPARQL — reject anything that
-        // could break the `<...>` IRI syntax or inject query fragments.
-        let values_clause: String = uris
-            .iter()
-            .filter(|u| {
-                let ok = u.starts_with("http://") || u.starts_with("https://");
-                let safe = !u.contains('>') && !u.contains('<') && !u.contains('}');
-                if !ok || !safe {
-                    tracing::warn!(uri = u.as_str(), "Skipping invalid URI in VALUES batch");
+    /// Fetches one page of datasets for a given partition, with title/description/
+    /// identifier/modified inline so blank-node datasets survive.
+    async fn fetch_partition_page(
+        &self,
+        partition: &PartitionRef<'_>,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Vec<DcatDataset>, AppError> {
+        let publisher_clause = match partition {
+            PartitionRef::Publisher(uri) => {
+                // Validate publisher IRI before interpolating.
+                if !(uri.starts_with("http://") || uri.starts_with("https://"))
+                    || uri.contains('<')
+                    || uri.contains('>')
+                {
+                    return Err(AppError::Generic(format!("Invalid publisher IRI: {uri}")));
                 }
-                ok && safe
-            })
-            .map(|u| format!("(<{u}>)"))
-            .collect::<Vec<_>>()
-            .join(" ");
-
-        if values_clause.is_empty() {
-            return Ok(vec![]);
-        }
+                format!("?dataset dct:publisher <{uri}> .")
+            }
+            PartitionRef::NoPublisher => {
+                "FILTER NOT EXISTS {{ ?dataset dct:publisher ?anyPub }}".to_string()
+            }
+        };
 
         let title_filter = self
             .lang_filter_alternatives()
@@ -502,18 +559,24 @@ impl SparqlDcatClient {
              \n\
              SELECT ?dataset ?title ?description ?identifier ?modified\n\
              WHERE {{\n\
-               VALUES (?dataset) {{ {values_clause} }}\n\
+               ?dataset a dcat:Dataset .\n\
+               {publisher_clause}\n\
                ?dataset dct:title ?title .\n\
                FILTER ({title_filter})\n\
                OPTIONAL {{ ?dataset dct:description ?description }}\n\
                OPTIONAL {{ ?dataset dct:identifier ?identifier }}\n\
                OPTIONAL {{ ?dataset dct:modified ?modified }}\n\
-             }}",
+             }}\n\
+             LIMIT {limit} OFFSET {offset}"
         );
 
         let bindings = self.execute_query(&query).await?;
         Ok(self.bindings_to_datasets(bindings))
     }
+
+    // =========================================================================
+    // Internal helpers
+    // =========================================================================
 
     /// Core paginated SPARQL fetcher (non-streaming, used by search_modified_since).
     async fn paginate_sparql(

--- a/crates/ceres-client/src/sparql.rs
+++ b/crates/ceres-client/src/sparql.rs
@@ -268,8 +268,10 @@ impl SparqlDcatClient {
             uris_done: bool,
             /// Whole stream finished?
             done: bool,
-            /// Pages where URI fetch failed (for incomplete-harvest signaling).
+            /// URI pages that failed after retries.
             skipped_uri_pages: usize,
+            /// Detail batches that failed after retries.
+            skipped_detail_batches: usize,
             /// Consecutive URI-page failures (stop after MAX_CONSECUTIVE_SKIPS).
             consecutive_uri_skips: usize,
         }
@@ -281,6 +283,7 @@ impl SparqlDcatClient {
             uris_done: false,
             done: false,
             skipped_uri_pages: 0,
+            skipped_detail_batches: 0,
             consecutive_uri_skips: 0,
         };
 
@@ -289,14 +292,18 @@ impl SparqlDcatClient {
                 if state.done {
                     // Yield a final error if any work was skipped, so the
                     // harvest records a failure (prevents stale-marking).
-                    if state.skipped_uri_pages > 0 {
+                    let total_skipped = state.skipped_uri_pages + state.skipped_detail_batches;
+                    if total_skipped > 0 {
                         return Some((
                             Err(AppError::Generic(format!(
-                                "SPARQL harvest incomplete: {} pages skipped, fetched {} datasets",
-                                state.skipped_uri_pages, state.fetched
+                                "SPARQL harvest incomplete: {} URI pages and {} detail batches skipped, fetched {} datasets",
+                                state.skipped_uri_pages,
+                                state.skipped_detail_batches,
+                                state.fetched
                             ))),
                             TwoPhaseState {
                                 skipped_uri_pages: 0,
+                                skipped_detail_batches: 0,
                                 ..state
                             },
                         ));
@@ -362,17 +369,14 @@ impl SparqlDcatClient {
 
                 // -- Nothing left to detail-fetch? We're done. ----------------
                 if state.pending_uris.is_empty() {
-                    if state.skipped_uri_pages > 0 {
-                        state.done = true;
-                        return Some((
-                            Err(AppError::Generic(format!(
-                                "SPARQL harvest incomplete: {} URI pages skipped, fetched {} datasets",
-                                state.skipped_uri_pages, state.fetched
-                            ))),
-                            state,
-                        ));
-                    }
-                    return None;
+                    state.done = true;
+                    // The done-check at the top of the next tick will emit the
+                    // incomplete-harvest error if any pages/batches were skipped.
+                    return if state.skipped_uri_pages + state.skipped_detail_batches > 0 {
+                        Some((Ok(vec![]), state))
+                    } else {
+                        None
+                    };
                 }
 
                 // -- Phase 2: detail-fetch a VALUES batch ---------------------
@@ -401,7 +405,7 @@ impl SparqlDcatClient {
                             error = %e,
                             "SPARQL detail batch failed; skipping batch"
                         );
-                        state.skipped_uri_pages += 1; // reuse counter for any skipped work
+                        state.skipped_detail_batches += 1;
                         // Continue — don't stop the stream for one bad detail batch
                         if state.uris_done && state.pending_uris.is_empty() {
                             state.done = true;
@@ -419,8 +423,8 @@ impl SparqlDcatClient {
 
     /// Phase 1: fetch one page of dataset URIs via the lightweight enumeration query.
     ///
-    /// Uses page-level retries with adaptive page-size reduction, matching the
-    /// retry policy of the old single-phase approach.
+    /// Per-request retries are handled inside `execute_query` → `request_with_retry`.
+    /// Higher-level skip/continue logic lives in the caller (`paginate_sparql_stream`).
     async fn fetch_uri_page(&self, offset: usize) -> Result<Vec<String>, AppError> {
         let query = format!(
             "SELECT DISTINCT ?dataset \
@@ -445,11 +449,25 @@ impl SparqlDcatClient {
             return Ok(vec![]);
         }
 
+        // Validate URIs before interpolating into SPARQL — reject anything that
+        // could break the `<...>` IRI syntax or inject query fragments.
         let values_clause: String = uris
             .iter()
+            .filter(|u| {
+                let ok = u.starts_with("http://") || u.starts_with("https://");
+                let safe = !u.contains('>') && !u.contains('<') && !u.contains('}');
+                if !ok || !safe {
+                    tracing::warn!(uri = u.as_str(), "Skipping invalid URI in VALUES batch");
+                }
+                ok && safe
+            })
             .map(|u| format!("(<{u}>)"))
             .collect::<Vec<_>>()
             .join(" ");
+
+        if values_clause.is_empty() {
+            return Ok(vec![]);
+        }
 
         let title_filter = self
             .lang_filter_alternatives()

--- a/crates/ceres-client/src/sparql.rs
+++ b/crates/ceres-client/src/sparql.rs
@@ -92,6 +92,17 @@ impl SparqlDcatClient {
     /// * `base_url_str` - The base URL of the portal (e.g., `https://data.europa.eu`)
     /// * `language` - Preferred language for resolving multilingual fields (e.g., `"en"`, `"nb"`)
     pub fn new(base_url_str: &str, language: &str) -> Result<Self, AppError> {
+        // Validate language as a BCP47-like tag to prevent SPARQL injection
+        if language.is_empty()
+            || !language
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || b == b'-')
+        {
+            return Err(AppError::ConfigError(format!(
+                "Invalid language tag '{language}'. Expected a BCP47 tag (e.g., 'en', 'nb', 'fr')."
+            )));
+        }
+
         let base_url = Url::parse(base_url_str)
             .map_err(|_| AppError::InvalidPortalUrl(base_url_str.to_string()))?;
 
@@ -443,57 +454,86 @@ impl SparqlDcatClient {
         Err(last_error)
     }
 
+    /// Returns a language-preference rank for selecting the best value.
+    /// Higher rank = better match: preferred language > "en" > untagged/other.
+    fn lang_rank(&self, lang: Option<&str>) -> u8 {
+        match lang {
+            Some(l) if l == self.language => 2,
+            Some("en") => 1,
+            _ => 0,
+        }
+    }
+
+    /// Selects the best value for a field from grouped bindings based on language preference.
+    fn best_value<'a>(
+        &self,
+        bindings: &'a [HashMap<String, SparqlValue>],
+        key: &str,
+    ) -> Option<&'a SparqlValue> {
+        bindings
+            .iter()
+            .filter_map(|b| b.get(key))
+            .filter(|v| !v.value.is_empty())
+            .max_by(|a, b| {
+                self.lang_rank(a.lang.as_deref())
+                    .cmp(&self.lang_rank(b.lang.as_deref()))
+            })
+    }
+
     /// Converts SPARQL bindings into `DcatDataset` objects, deduplicating by dataset URI.
     ///
     /// SPARQL may return multiple rows per dataset (e.g., different language tags).
-    /// The first title/description encountered for each dataset URI is kept.
+    /// For each dataset, the title and description with the best language match are selected
+    /// (preferred language > "en" > untagged).
     fn bindings_to_datasets(
         &self,
         bindings: Vec<HashMap<String, SparqlValue>>,
     ) -> Vec<DcatDataset> {
-        let mut seen: HashMap<String, DcatDataset> = HashMap::new();
+        let mut grouped: HashMap<String, Vec<HashMap<String, SparqlValue>>> = HashMap::new();
 
         for binding in bindings {
             let Some(dataset_uri) = binding.get("dataset").map(|v| v.value.clone()) else {
                 continue;
             };
-
-            if seen.contains_key(&dataset_uri) {
-                continue;
-            }
-
-            let title = match binding.get("title") {
-                Some(v) if !v.value.is_empty() => v.value.clone(),
-                _ => continue, // Skip datasets without a title
-            };
-
-            let description = binding
-                .get("description")
-                .map(|v| v.value.clone())
-                .filter(|s| !s.is_empty());
-
-            let identifier = binding
-                .get("identifier")
-                .map(|v| v.value.clone())
-                .filter(|s| !s.is_empty())
-                .unwrap_or_else(|| extract_last_segment(&dataset_uri));
-
-            // Build raw metadata from the binding
-            let raw = binding_to_json(&binding);
-
-            seen.insert(
-                dataset_uri.clone(),
-                DcatDataset {
-                    id_uri: dataset_uri,
-                    identifier,
-                    title,
-                    description,
-                    raw,
-                },
-            );
+            grouped.entry(dataset_uri).or_default().push(binding);
         }
 
-        seen.into_values().collect()
+        let mut datasets = Vec::new();
+
+        for (dataset_uri, rows) in &grouped {
+            let Some(title_val) = self.best_value(rows, "title") else {
+                continue; // Skip datasets without a title
+            };
+            let title = title_val.value.clone();
+
+            let description = self
+                .best_value(rows, "description")
+                .map(|v| v.value.clone());
+
+            let identifier = rows
+                .iter()
+                .filter_map(|b| b.get("identifier"))
+                .map(|v| v.value.clone())
+                .find(|s| !s.is_empty())
+                .unwrap_or_else(|| extract_last_segment(dataset_uri));
+
+            // Build raw metadata from the row that provided the selected title
+            let raw_binding = rows
+                .iter()
+                .find(|b| b.get("title").map(|v| v.value.as_str()) == Some(title.as_str()))
+                .unwrap_or(&rows[0]);
+            let raw = binding_to_json(raw_binding);
+
+            datasets.push(DcatDataset {
+                id_uri: dataset_uri.clone(),
+                identifier,
+                title,
+                description,
+                raw,
+            });
+        }
+
+        datasets
     }
 }
 
@@ -624,7 +664,35 @@ mod tests {
         let resp: SparqlResponse = serde_json::from_str(json).unwrap();
         let datasets = client.bindings_to_datasets(resp.results.bindings);
         assert_eq!(datasets.len(), 1);
-        assert_eq!(datasets[0].title, "First Title");
+    }
+
+    #[test]
+    fn bindings_prefers_requested_language() {
+        let client = SparqlDcatClient::new("https://data.europa.eu", "nb").unwrap();
+        let json = r#"{
+            "results": {
+                "bindings": [
+                    {
+                        "dataset": { "type": "uri", "value": "https://example.org/d/1" },
+                        "title": { "type": "literal", "value": "English Title", "xml:lang": "en" },
+                        "description": { "type": "literal", "value": "English desc", "xml:lang": "en" }
+                    },
+                    {
+                        "dataset": { "type": "uri", "value": "https://example.org/d/1" },
+                        "title": { "type": "literal", "value": "Norsk Tittel", "xml:lang": "nb" },
+                        "description": { "type": "literal", "value": "Norsk beskrivelse", "xml:lang": "nb" }
+                    }
+                ]
+            }
+        }"#;
+        let resp: SparqlResponse = serde_json::from_str(json).unwrap();
+        let datasets = client.bindings_to_datasets(resp.results.bindings);
+        assert_eq!(datasets.len(), 1);
+        assert_eq!(datasets[0].title, "Norsk Tittel");
+        assert_eq!(
+            datasets[0].description.as_deref(),
+            Some("Norsk beskrivelse")
+        );
     }
 
     #[test]
@@ -713,6 +781,15 @@ mod tests {
     fn sparql_client_new_invalid_url() {
         let result = SparqlDcatClient::new("not-a-url", "en");
         assert!(matches!(result, Err(AppError::InvalidPortalUrl(_))));
+    }
+
+    #[test]
+    fn sparql_client_rejects_invalid_language() {
+        let result = SparqlDcatClient::new("https://data.europa.eu", "en\"}");
+        assert!(matches!(result, Err(AppError::ConfigError(_))));
+
+        let result = SparqlDcatClient::new("https://data.europa.eu", "");
+        assert!(matches!(result, Err(AppError::ConfigError(_))));
     }
 
     // ---- binding_to_json ---------------------------------------------------

--- a/crates/ceres-client/src/sparql.rs
+++ b/crates/ceres-client/src/sparql.rs
@@ -33,11 +33,21 @@ const PAGE_DELAY: Duration = Duration::from_millis(300);
 
 /// Per-request timeout for SPARQL queries.
 ///
-/// SPARQL queries on large catalogs can be slow, so we use a generous timeout.
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+/// SPARQL queries on large catalogs can be slow — especially deep LIMIT/OFFSET
+/// queries on data.europa.eu (~1.6M datasets). 300s accommodates worst-case pages.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// Maximum backoff delay for rate-limited retries.
 const MAX_RETRY_DELAY: Duration = Duration::from_secs(30);
+
+/// Base delay for page-level retries (on top of per-request retries).
+///
+/// When all per-request retries fail, we wait longer before retrying the whole
+/// page to give overloaded SPARQL endpoints time to recover.
+const PAGE_RETRY_BASE_DELAY: Duration = Duration::from_secs(10);
+
+/// Maximum number of page-level retries before giving up on a page.
+const MAX_PAGE_RETRIES: u32 = 3;
 
 /// Default number of results per SPARQL page.
 const DEFAULT_PAGE_SIZE: usize = 1000;
@@ -85,13 +95,19 @@ pub struct SparqlDcatClient {
 impl SparqlDcatClient {
     /// Creates a new SPARQL DCAT client for the specified portal.
     ///
-    /// The SPARQL endpoint is derived by convention as `{base_url}/sparql`.
+    /// The SPARQL endpoint is derived by convention as `{base_url}/sparql`,
+    /// unless a custom endpoint is provided via `sparql_endpoint`.
     ///
     /// # Arguments
     ///
     /// * `base_url_str` - The base URL of the portal (e.g., `https://data.europa.eu`)
     /// * `language` - Preferred language for resolving multilingual fields (e.g., `"en"`, `"nb"`)
-    pub fn new(base_url_str: &str, language: &str) -> Result<Self, AppError> {
+    /// * `sparql_endpoint` - Optional custom SPARQL endpoint URL (overrides `{base_url}/sparql`)
+    pub fn new(
+        base_url_str: &str,
+        language: &str,
+        sparql_endpoint: Option<&str>,
+    ) -> Result<Self, AppError> {
         // Validate language as a BCP47-like tag to prevent SPARQL injection
         if language.is_empty()
             || !language
@@ -106,9 +122,14 @@ impl SparqlDcatClient {
         let base_url = Url::parse(base_url_str)
             .map_err(|_| AppError::InvalidPortalUrl(base_url_str.to_string()))?;
 
-        let endpoint_url = base_url
-            .join("sparql")
-            .map_err(|e| AppError::Generic(format!("Failed to build SPARQL endpoint URL: {e}")))?;
+        let endpoint_url = if let Some(ep) = sparql_endpoint {
+            Url::parse(ep)
+                .map_err(|_| AppError::ConfigError(format!("Invalid sparql_endpoint URL: {ep}")))?
+        } else {
+            base_url.join("sparql").map_err(|e| {
+                AppError::Generic(format!("Failed to build SPARQL endpoint URL: {e}"))
+            })?
+        };
 
         let client = Client::builder()
             .user_agent("Ceres/0.1 (semantic-search-bot)")
@@ -243,44 +264,74 @@ impl SparqlDcatClient {
 
                 let query = self.build_dataset_query(state.offset, filter.as_deref());
 
-                match self.execute_query(&query).await {
-                    Ok(bindings) => {
-                        if bindings.is_empty() {
-                            return None;
-                        }
+                let mut last_err = None;
 
-                        let count = bindings.len();
-                        let datasets = self.bindings_to_datasets(bindings);
+                for page_attempt in 0..=MAX_PAGE_RETRIES {
+                    match self.execute_query(&query).await {
+                        Ok(bindings) => {
+                            if bindings.is_empty() {
+                                return None;
+                            }
 
-                        if count < self.page_size {
-                            state.done = true;
-                        } else {
-                            state.offset += self.page_size;
-                            sleep(PAGE_DELAY).await;
-                        }
+                            let count = bindings.len();
+                            let datasets = self.bindings_to_datasets(bindings);
 
-                        Some((Ok(datasets), state))
-                    }
-                    Err(e) => {
-                        if state.offset == 0 {
-                            // First page failed — propagate error
-                            Some((
-                                Err(e),
-                                PaginationState {
-                                    offset: 0,
-                                    done: true,
-                                },
-                            ))
-                        } else {
-                            tracing::warn!(
+                            tracing::debug!(
                                 offset = state.offset,
-                                error = %e,
-                                "SPARQL page fetch failed; stopping stream"
+                                page_datasets = datasets.len(),
+                                "SPARQL page fetched"
                             );
-                            None
+
+                            if count < self.page_size {
+                                state.done = true;
+                            } else {
+                                state.offset += self.page_size;
+                                sleep(PAGE_DELAY).await;
+                            }
+
+                            return Some((Ok(datasets), state));
+                        }
+                        Err(e) => {
+                            if page_attempt < MAX_PAGE_RETRIES {
+                                let delay = PAGE_RETRY_BASE_DELAY * 2_u32.pow(page_attempt);
+                                tracing::warn!(
+                                    offset = state.offset,
+                                    attempt = page_attempt + 1,
+                                    delay_secs = delay.as_secs(),
+                                    error = %e,
+                                    "SPARQL page fetch failed; retrying after backoff"
+                                );
+                                last_err = Some(e);
+                                sleep(delay).await;
+                                continue;
+                            }
+                            last_err = Some(e);
                         }
                     }
                 }
+
+                // All retries exhausted
+                let e =
+                    last_err.unwrap_or_else(|| AppError::Generic("Page fetch failed".to_string()));
+
+                if state.offset == 0 {
+                    // First page: propagate error so caller knows
+                    return Some((
+                        Err(e),
+                        PaginationState {
+                            offset: 0,
+                            done: true,
+                        },
+                    ));
+                }
+
+                tracing::warn!(
+                    offset = state.offset,
+                    error = %e,
+                    "SPARQL page fetch failed after retries; stopping stream"
+                );
+
+                None
             }
         }))
     }
@@ -297,22 +348,41 @@ impl SparqlDcatClient {
         let mut all_datasets = Vec::new();
         let mut offset = 0usize;
 
-        loop {
+        'pages: loop {
             let query = self.build_dataset_query(offset, extra_filter);
-            let bindings = match self.execute_query(&query).await {
-                Ok(b) => b,
-                Err(e) => {
-                    if all_datasets.is_empty() {
-                        return Err(e);
+
+            let bindings = 'retry: {
+                for page_attempt in 0..=MAX_PAGE_RETRIES {
+                    match self.execute_query(&query).await {
+                        Ok(b) => break 'retry b,
+                        Err(e) => {
+                            if all_datasets.is_empty() && page_attempt == MAX_PAGE_RETRIES {
+                                return Err(e);
+                            }
+                            if page_attempt < MAX_PAGE_RETRIES {
+                                let delay = PAGE_RETRY_BASE_DELAY * 2_u32.pow(page_attempt);
+                                tracing::warn!(
+                                    offset,
+                                    attempt = page_attempt + 1,
+                                    delay_secs = delay.as_secs(),
+                                    error = %e,
+                                    "SPARQL page fetch failed; retrying after backoff"
+                                );
+                                sleep(delay).await;
+                                continue;
+                            }
+                            tracing::warn!(
+                                offset,
+                                collected = all_datasets.len(),
+                                error = %e,
+                                "SPARQL page fetch failed after retries; returning partial results"
+                            );
+                            break 'pages;
+                        }
                     }
-                    tracing::warn!(
-                        offset,
-                        collected = all_datasets.len(),
-                        error = %e,
-                        "SPARQL page fetch failed; returning partial results"
-                    );
-                    break;
                 }
+                // Unreachable: the loop above always breaks or returns.
+                break 'pages;
             };
 
             if bindings.is_empty() {
@@ -321,6 +391,13 @@ impl SparqlDcatClient {
 
             let count = bindings.len();
             let datasets = self.bindings_to_datasets(bindings);
+
+            tracing::debug!(
+                offset,
+                page_datasets = datasets.len(),
+                "SPARQL page fetched"
+            );
+
             all_datasets.extend(datasets);
 
             if count < self.page_size {
@@ -334,9 +411,21 @@ impl SparqlDcatClient {
     }
 
     /// Builds the SPARQL SELECT query for dataset discovery.
+    ///
+    /// The language filter is applied only to `dct:title` (mandatory) to keep the
+    /// query plan simple. Description language selection is handled client-side in
+    /// [`bindings_to_datasets`](Self::bindings_to_datasets) via [`best_value`](Self::best_value).
+    /// Filtering inside `OPTIONAL { dct:description }` causes HTTP 500 on large
+    /// catalogs (e.g., data.europa.eu with ~2M datasets).
     fn build_dataset_query(&self, offset: usize, extra_filter: Option<&str>) -> String {
-        let lang = &self.language;
         let extra = extra_filter.unwrap_or("");
+
+        let title_filter = self
+            .lang_filter_alternatives()
+            .iter()
+            .map(|l| format!("lang(?title) = \"{l}\""))
+            .collect::<Vec<_>>()
+            .join(" || ");
 
         format!(
             "PREFIX dcat: <http://www.w3.org/ns/dcat#>\n\
@@ -346,14 +435,13 @@ impl SparqlDcatClient {
              WHERE {{\n\
                ?dataset a dcat:Dataset .\n\
                ?dataset dct:title ?title .\n\
-               FILTER (lang(?title) = \"{lang}\" || lang(?title) = \"en\" || lang(?title) = \"\")\n\
-               OPTIONAL {{ ?dataset dct:description ?description .\n\
-                 FILTER (lang(?description) = \"{lang}\" || lang(?description) = \"en\" || lang(?description) = \"\")\n\
-               }}\n\
+               FILTER ({title_filter})\n\
+               OPTIONAL {{ ?dataset dct:description ?description }}\n\
                OPTIONAL {{ ?dataset dct:identifier ?identifier }}\n\
                OPTIONAL {{ ?dataset dct:modified ?modified }}\n\
                {extra}\n\
              }}\n\
+             ORDER BY ?dataset\n\
              LIMIT {} OFFSET {}",
             self.page_size, offset
         )
@@ -454,11 +542,40 @@ impl SparqlDcatClient {
         Err(last_error)
     }
 
+    /// Returns the SPARQL lang() filter alternatives for the preferred language.
+    ///
+    /// Norwegian is special: `"nb"` (Bokmål), `"nn"` (Nynorsk), and `"no"`
+    /// (generic Norwegian) are used interchangeably across portals. When the
+    /// preferred language is any of these, all three variants are matched.
+    fn lang_filter_alternatives(&self) -> Vec<&str> {
+        let lang = self.language.as_str();
+        let mut alts = vec![lang];
+        match lang {
+            "nb" | "nn" | "no" => {
+                for &sibling in &["nb", "nn", "no"] {
+                    if sibling != lang {
+                        alts.push(sibling);
+                    }
+                }
+            }
+            _ => {}
+        }
+        alts.push("en");
+        alts.push(""); // untagged literals
+        alts
+    }
+
+    /// Checks whether two language tags are siblings (same macro-language).
+    fn are_sibling_languages(a: &str, b: &str) -> bool {
+        matches!((a, b), ("nb" | "nn" | "no", "nb" | "nn" | "no"))
+    }
+
     /// Returns a language-preference rank for selecting the best value.
-    /// Higher rank = better match: preferred language > "en" > untagged/other.
+    /// Higher rank = better match: preferred language > sibling > "en" > untagged/other.
     fn lang_rank(&self, lang: Option<&str>) -> u8 {
         match lang {
-            Some(l) if l == self.language => 2,
+            Some(l) if l == self.language => 3,
+            Some(l) if Self::are_sibling_languages(l, &self.language) => 2,
             Some("en") => 1,
             _ => 0,
         }
@@ -484,7 +601,11 @@ impl SparqlDcatClient {
     ///
     /// SPARQL may return multiple rows per dataset (e.g., different language tags).
     /// For each dataset, the title and description with the best language match are selected
-    /// (preferred language > "en" > untagged).
+    /// (preferred language > sibling > "en" > untagged).
+    ///
+    /// After URI-based grouping, results are also deduplicated by identifier to
+    /// prevent `ON CONFLICT` errors during batch upsert (different URIs can map
+    /// to the same identifier via `dct:identifier` or URI last-segment extraction).
     fn bindings_to_datasets(
         &self,
         bindings: Vec<HashMap<String, SparqlValue>>,
@@ -499,6 +620,8 @@ impl SparqlDcatClient {
         }
 
         let mut datasets = Vec::new();
+        let mut seen_identifiers: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
 
         for (dataset_uri, rows) in &grouped {
             let Some(title_val) = self.best_value(rows, "title") else {
@@ -516,6 +639,11 @@ impl SparqlDcatClient {
                 .map(|v| v.value.clone())
                 .find(|s| !s.is_empty())
                 .unwrap_or_else(|| extract_last_segment(dataset_uri));
+
+            // Skip duplicate identifiers (different URIs can resolve to the same id)
+            if !seen_identifiers.insert(identifier.clone()) {
+                continue;
+            }
 
             // Build raw metadata from the row that provided the selected title
             let raw_binding = rows
@@ -620,7 +748,7 @@ mod tests {
 
     #[test]
     fn bindings_to_datasets_basic() {
-        let client = SparqlDcatClient::new("https://data.europa.eu", "en").unwrap();
+        let client = SparqlDcatClient::new("https://data.europa.eu", "en", None).unwrap();
         let resp: SparqlResponse = serde_json::from_str(sample_sparql_json()).unwrap();
         let datasets = client.bindings_to_datasets(resp.results.bindings);
 
@@ -646,7 +774,7 @@ mod tests {
 
     #[test]
     fn bindings_deduplicates_by_uri() {
-        let client = SparqlDcatClient::new("https://data.europa.eu", "en").unwrap();
+        let client = SparqlDcatClient::new("https://data.europa.eu", "en", None).unwrap();
         let json = r#"{
             "results": {
                 "bindings": [
@@ -668,7 +796,7 @@ mod tests {
 
     #[test]
     fn bindings_prefers_requested_language() {
-        let client = SparqlDcatClient::new("https://data.europa.eu", "nb").unwrap();
+        let client = SparqlDcatClient::new("https://data.europa.eu", "nb", None).unwrap();
         let json = r#"{
             "results": {
                 "bindings": [
@@ -697,7 +825,7 @@ mod tests {
 
     #[test]
     fn bindings_skip_empty_title() {
-        let client = SparqlDcatClient::new("https://data.europa.eu", "en").unwrap();
+        let client = SparqlDcatClient::new("https://data.europa.eu", "en", None).unwrap();
         let json = r#"{
             "results": {
                 "bindings": [
@@ -740,25 +868,31 @@ mod tests {
 
     #[test]
     fn build_dataset_query_basic() {
-        let client = SparqlDcatClient::new("https://data.europa.eu", "en").unwrap();
+        let client = SparqlDcatClient::new("https://data.europa.eu", "en", None).unwrap();
         let query = client.build_dataset_query(0, None);
         assert!(query.contains("dcat:Dataset"));
         assert!(query.contains("dct:title"));
+        assert!(query.contains("ORDER BY ?dataset"));
         assert!(query.contains("LIMIT 1000 OFFSET 0"));
         assert!(query.contains("lang(?title) = \"en\""));
+        // Description filter should NOT be in the query (moved to client-side)
+        assert!(!query.contains("lang(?description)"));
     }
 
     #[test]
     fn build_dataset_query_with_offset() {
-        let client = SparqlDcatClient::new("https://data.europa.eu", "nb").unwrap();
+        let client = SparqlDcatClient::new("https://data.europa.eu", "nb", None).unwrap();
         let query = client.build_dataset_query(2000, None);
         assert!(query.contains("LIMIT 1000 OFFSET 2000"));
         assert!(query.contains("lang(?title) = \"nb\""));
+        // Norwegian language siblings should all be in the filter
+        assert!(query.contains("lang(?title) = \"nn\""));
+        assert!(query.contains("lang(?title) = \"no\""));
     }
 
     #[test]
     fn build_dataset_query_with_filter() {
-        let client = SparqlDcatClient::new("https://data.europa.eu", "en").unwrap();
+        let client = SparqlDcatClient::new("https://data.europa.eu", "en", None).unwrap();
         let filter = "FILTER (?modified > \"2026-01-01T00:00:00Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>)";
         let query = client.build_dataset_query(0, Some(filter));
         assert!(query.contains(filter));
@@ -768,7 +902,7 @@ mod tests {
 
     #[test]
     fn sparql_client_new_valid() {
-        let client = SparqlDcatClient::new("https://data.europa.eu", "en").unwrap();
+        let client = SparqlDcatClient::new("https://data.europa.eu", "en", None).unwrap();
         assert_eq!(client.portal_type(), "dcat");
         assert_eq!(client.base_url(), "https://data.europa.eu/");
         assert_eq!(
@@ -778,18 +912,58 @@ mod tests {
     }
 
     #[test]
+    fn sparql_client_new_with_custom_endpoint() {
+        let client = SparqlDcatClient::new(
+            "https://data.norge.no",
+            "nb",
+            Some("https://sparql.fellesdatakatalog.digdir.no"),
+        )
+        .unwrap();
+        assert_eq!(client.base_url(), "https://data.norge.no/");
+        assert_eq!(
+            client.endpoint_url.as_str(),
+            "https://sparql.fellesdatakatalog.digdir.no/"
+        );
+    }
+
+    #[test]
     fn sparql_client_new_invalid_url() {
-        let result = SparqlDcatClient::new("not-a-url", "en");
+        let result = SparqlDcatClient::new("not-a-url", "en", None);
         assert!(matches!(result, Err(AppError::InvalidPortalUrl(_))));
     }
 
     #[test]
     fn sparql_client_rejects_invalid_language() {
-        let result = SparqlDcatClient::new("https://data.europa.eu", "en\"}");
+        let result = SparqlDcatClient::new("https://data.europa.eu", "en\"}", None);
         assert!(matches!(result, Err(AppError::ConfigError(_))));
 
-        let result = SparqlDcatClient::new("https://data.europa.eu", "");
+        let result = SparqlDcatClient::new("https://data.europa.eu", "", None);
         assert!(matches!(result, Err(AppError::ConfigError(_))));
+    }
+
+    #[test]
+    fn bindings_deduplicates_by_identifier() {
+        let client = SparqlDcatClient::new("https://data.europa.eu", "en", None).unwrap();
+        // Two different URIs that resolve to the same identifier via last-segment extraction
+        let json = r#"{
+            "results": {
+                "bindings": [
+                    {
+                        "dataset": { "type": "uri", "value": "https://example.org/a/shared-id" },
+                        "title": { "type": "literal", "value": "First", "xml:lang": "en" }
+                    },
+                    {
+                        "dataset": { "type": "uri", "value": "https://example.org/b/shared-id" },
+                        "title": { "type": "literal", "value": "Second", "xml:lang": "en" }
+                    }
+                ]
+            }
+        }"#;
+        let resp: SparqlResponse = serde_json::from_str(json).unwrap();
+        let datasets = client.bindings_to_datasets(resp.results.bindings);
+        // Both URIs extract "shared-id" as identifier — only the first should survive
+        assert_eq!(datasets.len(), 1);
+        assert_eq!(datasets[0].identifier, "shared-id");
     }
 
     // ---- binding_to_json ---------------------------------------------------
@@ -824,7 +998,7 @@ mod tests {
     #[tokio::test]
     #[ignore = "requires network access to data.europa.eu"]
     async fn test_sparql_smoke_europa() {
-        let client = SparqlDcatClient::new("https://data.europa.eu", "en").unwrap();
+        let client = SparqlDcatClient::new("https://data.europa.eu", "en", None).unwrap();
         let count = client.dataset_count().await.unwrap();
         assert!(count > 100, "Expected >100 datasets, got {}", count);
 

--- a/crates/ceres-client/src/sparql.rs
+++ b/crates/ceres-client/src/sparql.rs
@@ -383,36 +383,56 @@ impl SparqlDcatClient {
                 let batch_size = state.pending_uris.len().min(VALUES_BATCH_SIZE);
                 let batch_uris: Vec<String> = state.pending_uris.drain(..batch_size).collect();
 
-                match self.fetch_details_batch(&batch_uris).await {
-                    Ok(datasets) => {
-                        state.fetched += datasets.len();
-                        tracing::debug!(
-                            batch_uris = batch_uris.len(),
-                            datasets = datasets.len(),
-                            total_fetched = state.fetched,
-                            "SPARQL detail batch fetched"
-                        );
+                // Retry detail batch with backoff before giving up.
+                let mut last_err = None;
+                for attempt in 0..=MAX_PAGE_RETRIES {
+                    match self.fetch_details_batch(&batch_uris).await {
+                        Ok(datasets) => {
+                            state.fetched += datasets.len();
+                            tracing::debug!(
+                                batch_uris = batch_uris.len(),
+                                datasets = datasets.len(),
+                                total_fetched = state.fetched,
+                                "SPARQL detail batch fetched"
+                            );
 
-                        // If no more URIs to collect and buffer is empty, mark done
-                        if state.uris_done && state.pending_uris.is_empty() {
-                            state.done = true;
+                            if state.uris_done && state.pending_uris.is_empty() {
+                                state.done = true;
+                            }
+                            sleep(PAGE_DELAY).await;
+                            return Some((Ok(datasets), state));
                         }
-                        Some((Ok(datasets), state))
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            batch_uris = batch_uris.len(),
-                            error = %e,
-                            "SPARQL detail batch failed; skipping batch"
-                        );
-                        state.skipped_detail_batches += 1;
-                        // Continue — don't stop the stream for one bad detail batch
-                        if state.uris_done && state.pending_uris.is_empty() {
-                            state.done = true;
+                        Err(e) => {
+                            if attempt < MAX_PAGE_RETRIES {
+                                let delay = PAGE_RETRY_BASE_DELAY * 2_u32.pow(attempt);
+                                tracing::warn!(
+                                    batch_uris = batch_uris.len(),
+                                    attempt = attempt + 1,
+                                    delay_secs = delay.as_secs(),
+                                    error = %e,
+                                    "SPARQL detail batch failed; retrying after backoff"
+                                );
+                                sleep(delay).await;
+                            }
+                            last_err = Some(e);
                         }
-                        Some((Ok(vec![]), state))
                     }
                 }
+
+                // All retries exhausted for this detail batch.
+                let e = last_err.unwrap();
+                tracing::warn!(
+                    batch_uris = batch_uris.len(),
+                    error = %e,
+                    "SPARQL detail batch failed after retries; skipping batch"
+                );
+                state.skipped_detail_batches += 1;
+                if state.uris_done && state.pending_uris.is_empty() {
+                    state.done = true;
+                }
+                // Back off before continuing to next batch.
+                sleep(PAGE_RETRY_BASE_DELAY).await;
+                Some((Ok(vec![]), state))
             }
         }))
     }

--- a/crates/ceres-client/src/sparql.rs
+++ b/crates/ceres-client/src/sparql.rs
@@ -52,6 +52,10 @@ const MAX_PAGE_RETRIES: u32 = 3;
 /// Default number of results per SPARQL page.
 const DEFAULT_PAGE_SIZE: usize = 1000;
 
+/// Minimum page size for adaptive reduction. Below this we give up rather than
+/// issuing very small queries.
+const MIN_PAGE_SIZE: usize = 50;
+
 // =============================================================================
 // SPARQL JSON Results Format (W3C standard)
 // =============================================================================
@@ -165,6 +169,7 @@ impl SparqlDcatClient {
             let query = format!(
                 "SELECT DISTINCT ?dataset \
                  WHERE {{ ?dataset a <http://www.w3.org/ns/dcat#Dataset> }} \
+                 ORDER BY ?dataset \
                  LIMIT {} OFFSET {}",
                 self.page_size, offset
             );
@@ -247,11 +252,15 @@ impl SparqlDcatClient {
 
         struct PaginationState {
             offset: usize,
+            page_size: usize,
+            fetched: usize,
             done: bool,
         }
 
         let initial = PaginationState {
             offset: 0,
+            page_size: self.page_size,
+            fetched: 0,
             done: false,
         };
 
@@ -262,7 +271,11 @@ impl SparqlDcatClient {
                     return None;
                 }
 
-                let query = self.build_dataset_query(state.offset, filter.as_deref());
+                let query = self.build_dataset_query_with_limit(
+                    state.offset,
+                    state.page_size,
+                    filter.as_deref(),
+                );
 
                 let mut last_err = None;
 
@@ -276,22 +289,40 @@ impl SparqlDcatClient {
                             let count = bindings.len();
                             let datasets = self.bindings_to_datasets(bindings);
 
+                            state.fetched += datasets.len();
                             tracing::debug!(
                                 offset = state.offset,
+                                page_size = state.page_size,
                                 page_datasets = datasets.len(),
+                                total_fetched = state.fetched,
                                 "SPARQL page fetched"
                             );
 
-                            if count < self.page_size {
+                            if count < state.page_size {
                                 state.done = true;
                             } else {
-                                state.offset += self.page_size;
+                                state.offset += state.page_size;
                                 sleep(PAGE_DELAY).await;
                             }
 
                             return Some((Ok(datasets), state));
                         }
                         Err(e) => {
+                            // On server overload, try reducing page size first.
+                            if is_server_overload(&e) && state.page_size > MIN_PAGE_SIZE {
+                                let new_size = (state.page_size / 2).max(MIN_PAGE_SIZE);
+                                tracing::warn!(
+                                    offset = state.offset,
+                                    old_page_size = state.page_size,
+                                    new_page_size = new_size,
+                                    error = %e,
+                                    "SPARQL server overload; reducing page size and retrying"
+                                );
+                                state.page_size = new_size;
+                                sleep(PAGE_RETRY_BASE_DELAY).await;
+                                return Some((Ok(vec![]), state));
+                            }
+
                             if page_attempt < MAX_PAGE_RETRIES {
                                 let delay = PAGE_RETRY_BASE_DELAY * 2_u32.pow(page_attempt);
                                 tracing::warn!(
@@ -319,14 +350,15 @@ impl SparqlDcatClient {
                     return Some((
                         Err(e),
                         PaginationState {
-                            offset: 0,
                             done: true,
+                            ..state
                         },
                     ));
                 }
 
                 tracing::warn!(
                     offset = state.offset,
+                    fetched = state.fetched,
                     error = %e,
                     "SPARQL page fetch failed after retries; stopping stream"
                 );
@@ -340,22 +372,39 @@ impl SparqlDcatClient {
     // Internal helpers
     // =========================================================================
 
-    /// Core paginated SPARQL fetcher.
+    /// Core paginated SPARQL fetcher using cursor-based (keyset) pagination.
     async fn paginate_sparql(
         &self,
         extra_filter: Option<&str>,
     ) -> Result<Vec<DcatDataset>, AppError> {
         let mut all_datasets = Vec::new();
         let mut offset = 0usize;
+        let mut current_page_size = self.page_size;
 
         'pages: loop {
-            let query = self.build_dataset_query(offset, extra_filter);
+            let query =
+                self.build_dataset_query_with_limit(offset, current_page_size, extra_filter);
 
             let bindings = 'retry: {
                 for page_attempt in 0..=MAX_PAGE_RETRIES {
                     match self.execute_query(&query).await {
                         Ok(b) => break 'retry b,
                         Err(e) => {
+                            // Adaptive page size reduction on server overload
+                            if is_server_overload(&e) && current_page_size > MIN_PAGE_SIZE {
+                                let new_size = (current_page_size / 2).max(MIN_PAGE_SIZE);
+                                tracing::warn!(
+                                    offset,
+                                    old_page_size = current_page_size,
+                                    new_page_size = new_size,
+                                    error = %e,
+                                    "SPARQL server overload; reducing page size and retrying"
+                                );
+                                current_page_size = new_size;
+                                sleep(PAGE_RETRY_BASE_DELAY).await;
+                                continue 'pages;
+                            }
+
                             if all_datasets.is_empty() && page_attempt == MAX_PAGE_RETRIES {
                                 return Err(e);
                             }
@@ -394,16 +443,18 @@ impl SparqlDcatClient {
 
             tracing::debug!(
                 offset,
+                page_size = current_page_size,
                 page_datasets = datasets.len(),
+                total_fetched = all_datasets.len() + datasets.len(),
                 "SPARQL page fetched"
             );
 
             all_datasets.extend(datasets);
 
-            if count < self.page_size {
+            if count < current_page_size {
                 break;
             }
-            offset += self.page_size;
+            offset += current_page_size;
             sleep(PAGE_DELAY).await;
         }
 
@@ -417,7 +468,17 @@ impl SparqlDcatClient {
     /// [`bindings_to_datasets`](Self::bindings_to_datasets) via [`best_value`](Self::best_value).
     /// Filtering inside `OPTIONAL { dct:description }` causes HTTP 500 on large
     /// catalogs (e.g., data.europa.eu with ~2M datasets).
+    #[cfg(test)]
     fn build_dataset_query(&self, offset: usize, extra_filter: Option<&str>) -> String {
+        self.build_dataset_query_with_limit(offset, self.page_size, extra_filter)
+    }
+
+    fn build_dataset_query_with_limit(
+        &self,
+        offset: usize,
+        limit: usize,
+        extra_filter: Option<&str>,
+    ) -> String {
         let extra = extra_filter.unwrap_or("");
 
         let title_filter = self
@@ -442,8 +503,7 @@ impl SparqlDcatClient {
                {extra}\n\
              }}\n\
              ORDER BY ?dataset\n\
-             LIMIT {} OFFSET {}",
-            self.page_size, offset
+             LIMIT {limit} OFFSET {offset}",
         )
     }
 
@@ -668,6 +728,20 @@ impl SparqlDcatClient {
 // =============================================================================
 // Helper Functions
 // =============================================================================
+
+/// Returns `true` if the error looks like a server-side overload (HTTP 500, 502,
+/// 503, 504, or a client-side request timeout). Used to trigger adaptive page
+/// size reduction — SPARQL endpoints commonly return 500 when queries are too
+/// heavy, not just 504.
+fn is_server_overload(e: &AppError) -> bool {
+    let msg = e.to_string();
+    msg.contains("HTTP 500")
+        || msg.contains("HTTP 502")
+        || msg.contains("HTTP 503")
+        || msg.contains("HTTP 504")
+        || msg.contains("timed out")
+        || msg.contains("timeout")
+}
 
 /// Extracts the last non-empty path segment from a URI.
 fn extract_last_segment(uri: &str) -> String {

--- a/crates/ceres-core/src/config.rs
+++ b/crates/ceres-core/src/config.rs
@@ -483,12 +483,25 @@ pub struct PortalEntry {
     /// This field controls which language is selected when resolving those fields.
     /// Defaults to `"en"` when not specified.
     pub language: Option<String>,
+
+    /// Optional DCAT profile for sub-dispatch.
+    ///
+    /// Only meaningful when `type = "dcat"`. Values:
+    /// - `"udata_rest"` (default when omitted): udata REST JSON-LD catalog endpoint
+    /// - `"sparql"`: SPARQL endpoint returning DCAT-AP metadata
+    #[serde(default)]
+    pub profile: Option<String>,
 }
 
 impl PortalEntry {
     /// Returns the preferred language, defaulting to `"en"`.
     pub fn language(&self) -> &str {
         self.language.as_deref().unwrap_or("en")
+    }
+
+    /// Returns the DCAT profile, if set.
+    pub fn profile(&self) -> Option<&str> {
+        self.profile.as_deref()
     }
 }
 
@@ -884,6 +897,35 @@ description = "A fully configured portal"
             portal.description,
             Some("A fully configured portal".to_string())
         );
+    }
+
+    #[test]
+    fn test_portals_config_dcat_profile() {
+        let toml = r#"
+[[portals]]
+name = "eu-sparql"
+url = "https://data.europa.eu"
+type = "dcat"
+profile = "sparql"
+language = "en"
+"#;
+        let config: PortalsConfig = toml::from_str(toml).unwrap();
+        let portal = &config.portals[0];
+        assert_eq!(portal.portal_type, PortalType::Dcat);
+        assert_eq!(portal.profile(), Some("sparql"));
+        assert_eq!(portal.language(), "en");
+    }
+
+    #[test]
+    fn test_portals_config_profile_defaults_none() {
+        let toml = r#"
+[[portals]]
+name = "luxembourg"
+url = "https://data.public.lu"
+type = "dcat"
+"#;
+        let config: PortalsConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.portals[0].profile(), None);
     }
 
     #[test]

--- a/crates/ceres-core/src/config.rs
+++ b/crates/ceres-core/src/config.rs
@@ -491,6 +491,15 @@ pub struct PortalEntry {
     /// - `"sparql"`: SPARQL endpoint returning DCAT-AP metadata
     #[serde(default)]
     pub profile: Option<String>,
+
+    /// Optional custom SPARQL endpoint URL.
+    ///
+    /// Only meaningful when `profile = "sparql"`. Overrides the default
+    /// convention of `{url}/sparql`. Use this when the SPARQL endpoint
+    /// lives on a different domain than the portal (e.g., Norway's
+    /// `data.norge.no` portal uses `sparql.fellesdatakatalog.digdir.no`).
+    #[serde(default)]
+    pub sparql_endpoint: Option<String>,
 }
 
 impl PortalEntry {
@@ -502,6 +511,11 @@ impl PortalEntry {
     /// Returns the DCAT profile, if set.
     pub fn profile(&self) -> Option<&str> {
         self.profile.as_deref()
+    }
+
+    /// Returns the custom SPARQL endpoint URL, if set.
+    pub fn sparql_endpoint(&self) -> Option<&str> {
+        self.sparql_endpoint.as_deref()
     }
 }
 

--- a/crates/ceres-core/src/harvest.rs
+++ b/crates/ceres-core/src/harvest.rs
@@ -310,6 +310,7 @@ where
             &SilentReporter,
             PortalType::default(),
             None,
+            None,
         )
         .await
     }
@@ -324,6 +325,7 @@ where
     /// 1. If `force_full_sync` is enabled or this is the first sync: full sync
     /// 2. Otherwise, attempt incremental sync using `metadata_modified` filter
     /// 3. If incremental fails, fall back to full sync with a warning
+    #[allow(clippy::too_many_arguments)]
     pub async fn sync_portal_with_progress<R: ProgressReporter>(
         &self,
         portal_url: &str,
@@ -332,6 +334,7 @@ where
         reporter: &R,
         portal_type: PortalType,
         profile: Option<&str>,
+        sparql_endpoint: Option<&str>,
     ) -> Result<SyncStats, AppError> {
         let result = self
             .sync_portal_with_progress_cancellable_internal(
@@ -343,6 +346,7 @@ where
                 self.config.force_full_sync,
                 portal_type,
                 profile,
+                sparql_endpoint,
             )
             .await?;
         Ok(result.stats)
@@ -480,6 +484,7 @@ where
             self.config.force_full_sync,
             PortalType::default(),
             None,
+            None,
         )
         .await
     }
@@ -495,6 +500,7 @@ where
         cancel_token: CancellationToken,
         portal_type: PortalType,
         profile: Option<&str>,
+        sparql_endpoint: Option<&str>,
     ) -> Result<SyncResult, AppError> {
         self.sync_portal_with_progress_cancellable_internal(
             portal_url,
@@ -505,6 +511,7 @@ where
             self.config.force_full_sync,
             portal_type,
             profile,
+            sparql_endpoint,
         )
         .await
     }
@@ -522,6 +529,7 @@ where
         force_full_sync: bool,
         portal_type: PortalType,
         profile: Option<&str>,
+        sparql_endpoint: Option<&str>,
     ) -> Result<SyncResult, AppError> {
         let force_full_sync = self.config.force_full_sync || force_full_sync;
         self.sync_portal_with_progress_cancellable_internal(
@@ -533,6 +541,7 @@ where
             force_full_sync,
             portal_type,
             profile,
+            sparql_endpoint,
         )
         .await
     }
@@ -548,6 +557,7 @@ where
         force_full_sync: bool,
         portal_type: PortalType,
         profile: Option<&str>,
+        sparql_endpoint: Option<&str>,
     ) -> Result<SyncResult, AppError> {
         let sync_start = Utc::now();
 
@@ -569,9 +579,13 @@ where
             return Ok(SyncResult::cancelled(SyncStats::default()));
         }
 
-        let portal_client =
-            self.portal_factory
-                .create(portal_url, portal_type, language, profile)?;
+        let portal_client = self.portal_factory.create(
+            portal_url,
+            portal_type,
+            language,
+            profile,
+            sparql_endpoint,
+        )?;
 
         // Determine sync plan (IDs for full sync, datasets for incremental)
         let (sync_mode, plan) = self
@@ -1247,6 +1261,7 @@ where
                     cancel_token.clone(),
                     portal.portal_type,
                     portal.profile(),
+                    portal.sparql_endpoint(),
                 )
                 .await
             {

--- a/crates/ceres-core/src/harvest.rs
+++ b/crates/ceres-core/src/harvest.rs
@@ -1209,6 +1209,9 @@ where
         }
         if dup_count > 0 {
             tracing::debug!(dup_count, "Removed duplicate datasets within upsert batch");
+            for _ in 0..dup_count {
+                stats.record(SyncOutcome::Skipped);
+            }
         }
 
         let outcomes: Vec<SyncOutcome> = deduped.iter().map(|i| i.outcome).collect();

--- a/crates/ceres-core/src/harvest.rs
+++ b/crates/ceres-core/src/harvest.rs
@@ -1189,8 +1189,30 @@ where
         store: &S,
         stats: &Arc<AtomicSyncStats>,
     ) {
-        let outcomes: Vec<SyncOutcome> = batch.iter().map(|i| i.outcome).collect();
-        let datasets: Vec<NewDataset> = batch.into_iter().map(|i| i.dataset).collect();
+        // Deduplicate within the batch by (original_id, source_portal) to avoid
+        // "ON CONFLICT DO UPDATE command cannot affect row a second time" errors.
+        // This can happen when SPARQL LIMIT/OFFSET returns the same dataset on
+        // adjacent pages (a known Virtuoso issue with non-deterministic ordering).
+        let mut seen = std::collections::HashSet::new();
+        let mut deduped = Vec::with_capacity(batch.len());
+        let mut dup_count = 0usize;
+        for item in batch {
+            let key = (
+                item.dataset.original_id.clone(),
+                item.dataset.source_portal.clone(),
+            );
+            if seen.insert(key) {
+                deduped.push(item);
+            } else {
+                dup_count += 1;
+            }
+        }
+        if dup_count > 0 {
+            tracing::debug!(dup_count, "Removed duplicate datasets within upsert batch");
+        }
+
+        let outcomes: Vec<SyncOutcome> = deduped.iter().map(|i| i.outcome).collect();
+        let datasets: Vec<NewDataset> = deduped.into_iter().map(|i| i.dataset).collect();
 
         match store.batch_upsert(&datasets).await {
             Ok(_) => {

--- a/crates/ceres-core/src/harvest.rs
+++ b/crates/ceres-core/src/harvest.rs
@@ -309,6 +309,7 @@ where
             "en",
             &SilentReporter,
             PortalType::default(),
+            None,
         )
         .await
     }
@@ -330,6 +331,7 @@ where
         language: &str,
         reporter: &R,
         portal_type: PortalType,
+        profile: Option<&str>,
     ) -> Result<SyncStats, AppError> {
         let result = self
             .sync_portal_with_progress_cancellable_internal(
@@ -340,6 +342,7 @@ where
                 CancellationToken::new(), // never cancelled
                 self.config.force_full_sync,
                 portal_type,
+                profile,
             )
             .await?;
         Ok(result.stats)
@@ -476,11 +479,13 @@ where
             cancel_token,
             self.config.force_full_sync,
             PortalType::default(),
+            None,
         )
         .await
     }
 
     /// Synchronizes a single portal with progress reporting and cancellation support.
+    #[allow(clippy::too_many_arguments)]
     pub async fn sync_portal_with_progress_cancellable<R: ProgressReporter>(
         &self,
         portal_url: &str,
@@ -489,6 +494,7 @@ where
         reporter: &R,
         cancel_token: CancellationToken,
         portal_type: PortalType,
+        profile: Option<&str>,
     ) -> Result<SyncResult, AppError> {
         self.sync_portal_with_progress_cancellable_internal(
             portal_url,
@@ -498,6 +504,7 @@ where
             cancel_token,
             self.config.force_full_sync,
             portal_type,
+            profile,
         )
         .await
     }
@@ -514,6 +521,7 @@ where
         cancel_token: CancellationToken,
         force_full_sync: bool,
         portal_type: PortalType,
+        profile: Option<&str>,
     ) -> Result<SyncResult, AppError> {
         let force_full_sync = self.config.force_full_sync || force_full_sync;
         self.sync_portal_with_progress_cancellable_internal(
@@ -524,6 +532,7 @@ where
             cancel_token,
             force_full_sync,
             portal_type,
+            profile,
         )
         .await
     }
@@ -538,6 +547,7 @@ where
         cancel_token: CancellationToken,
         force_full_sync: bool,
         portal_type: PortalType,
+        profile: Option<&str>,
     ) -> Result<SyncResult, AppError> {
         let sync_start = Utc::now();
 
@@ -559,9 +569,9 @@ where
             return Ok(SyncResult::cancelled(SyncStats::default()));
         }
 
-        let portal_client = self
-            .portal_factory
-            .create(portal_url, portal_type, language)?;
+        let portal_client =
+            self.portal_factory
+                .create(portal_url, portal_type, language, profile)?;
 
         // Determine sync plan (IDs for full sync, datasets for incremental)
         let (sync_mode, plan) = self
@@ -1236,6 +1246,7 @@ where
                     reporter,
                     cancel_token.clone(),
                     portal.portal_type,
+                    portal.profile(),
                 )
                 .await
             {

--- a/crates/ceres-core/src/job.rs
+++ b/crates/ceres-core/src/job.rs
@@ -213,6 +213,9 @@ pub struct HarvestJob {
 
     /// Optional DCAT profile (e.g., `"sparql"` for SPARQL endpoints).
     pub profile: Option<String>,
+
+    /// Optional SPARQL endpoint override for DCAT harvests.
+    pub sparql_endpoint: Option<String>,
 }
 
 impl HarvestJob {
@@ -254,6 +257,9 @@ pub struct CreateJobRequest {
 
     /// Optional DCAT profile (e.g., `"sparql"` for SPARQL endpoints).
     pub profile: Option<String>,
+
+    /// Optional SPARQL endpoint override for DCAT harvests.
+    pub sparql_endpoint: Option<String>,
 }
 
 impl CreateJobRequest {
@@ -268,6 +274,7 @@ impl CreateJobRequest {
             language: None,
             portal_type: PortalType::default(),
             profile: None,
+            sparql_endpoint: None,
         }
     }
 
@@ -310,6 +317,12 @@ impl CreateJobRequest {
     /// Set the DCAT profile (e.g., `"sparql"`).
     pub fn with_profile(mut self, profile: impl Into<String>) -> Self {
         self.profile = Some(profile.into());
+        self
+    }
+
+    /// Set the SPARQL endpoint override for DCAT harvests.
+    pub fn with_sparql_endpoint(mut self, sparql_endpoint: impl Into<String>) -> Self {
+        self.sparql_endpoint = Some(sparql_endpoint.into());
         self
     }
 }
@@ -468,6 +481,7 @@ mod tests {
             url_template: None,
             language: None,
             profile: None,
+            sparql_endpoint: None,
         };
 
         assert!(job.can_retry());

--- a/crates/ceres-core/src/job.rs
+++ b/crates/ceres-core/src/job.rs
@@ -210,6 +210,9 @@ pub struct HarvestJob {
 
     /// Preferred language for multilingual portals.
     pub language: Option<String>,
+
+    /// Optional DCAT profile (e.g., `"sparql"` for SPARQL endpoints).
+    pub profile: Option<String>,
 }
 
 impl HarvestJob {
@@ -248,6 +251,9 @@ pub struct CreateJobRequest {
 
     /// Type of portal (ckan, dcat, etc.).
     pub portal_type: PortalType,
+
+    /// Optional DCAT profile (e.g., `"sparql"` for SPARQL endpoints).
+    pub profile: Option<String>,
 }
 
 impl CreateJobRequest {
@@ -261,6 +267,7 @@ impl CreateJobRequest {
             url_template: None,
             language: None,
             portal_type: PortalType::default(),
+            profile: None,
         }
     }
 
@@ -297,6 +304,12 @@ impl CreateJobRequest {
     /// Set the portal type.
     pub fn with_portal_type(mut self, portal_type: PortalType) -> Self {
         self.portal_type = portal_type;
+        self
+    }
+
+    /// Set the DCAT profile (e.g., `"sparql"`).
+    pub fn with_profile(mut self, profile: impl Into<String>) -> Self {
+        self.profile = Some(profile.into());
         self
     }
 }
@@ -454,6 +467,7 @@ mod tests {
             force_full_sync: false,
             url_template: None,
             language: None,
+            profile: None,
         };
 
         assert!(job.can_retry());

--- a/crates/ceres-core/src/parquet_export.rs
+++ b/crates/ceres-core/src/parquet_export.rs
@@ -346,7 +346,7 @@ impl<S: DatasetStore> ParquetExportService<S> {
                 }
             })
             .collect();
-        portal_stats.sort_by(|a, b| b.count.cmp(&a.count));
+        portal_stats.sort_by_key(|b| std::cmp::Reverse(b.count));
 
         Ok((
             total_exported,

--- a/crates/ceres-core/src/pipeline.rs
+++ b/crates/ceres-core/src/pipeline.rs
@@ -104,6 +104,7 @@ where
                 "en",
                 &SilentReporter,
                 PortalType::default(),
+                None,
             )
             .await?;
         Ok(result.stats)
@@ -117,6 +118,7 @@ where
         language: &str,
         reporter: &R,
         portal_type: PortalType,
+        profile: Option<&str>,
     ) -> Result<(SyncResult, EmbeddingStats), AppError> {
         self.sync_portal_with_progress_cancellable_with_options(
             portal_url,
@@ -126,6 +128,7 @@ where
             CancellationToken::new(),
             false,
             portal_type,
+            profile,
         )
         .await
     }
@@ -141,6 +144,7 @@ where
         cancel_token: CancellationToken,
         force_full_sync: bool,
         portal_type: PortalType,
+        profile: Option<&str>,
     ) -> Result<(SyncResult, EmbeddingStats), AppError> {
         // Step 1: Harvest metadata
         let sync_result = self
@@ -153,6 +157,7 @@ where
                 cancel_token.clone(),
                 force_full_sync,
                 portal_type,
+                profile,
             )
             .await?;
 

--- a/crates/ceres-core/src/pipeline.rs
+++ b/crates/ceres-core/src/pipeline.rs
@@ -105,12 +105,14 @@ where
                 &SilentReporter,
                 PortalType::default(),
                 None,
+                None,
             )
             .await?;
         Ok(result.stats)
     }
 
     /// Synchronizes a single portal with progress reporting: harvest then embed.
+    #[allow(clippy::too_many_arguments)]
     pub async fn sync_portal_with_progress<R: ProgressReporter>(
         &self,
         portal_url: &str,
@@ -119,6 +121,7 @@ where
         reporter: &R,
         portal_type: PortalType,
         profile: Option<&str>,
+        sparql_endpoint: Option<&str>,
     ) -> Result<(SyncResult, EmbeddingStats), AppError> {
         self.sync_portal_with_progress_cancellable_with_options(
             portal_url,
@@ -129,6 +132,7 @@ where
             false,
             portal_type,
             profile,
+            sparql_endpoint,
         )
         .await
     }
@@ -145,6 +149,7 @@ where
         force_full_sync: bool,
         portal_type: PortalType,
         profile: Option<&str>,
+        sparql_endpoint: Option<&str>,
     ) -> Result<(SyncResult, EmbeddingStats), AppError> {
         // Step 1: Harvest metadata
         let sync_result = self
@@ -158,6 +163,7 @@ where
                 force_full_sync,
                 portal_type,
                 profile,
+                sparql_endpoint,
             )
             .await?;
 

--- a/crates/ceres-core/src/traits.rs
+++ b/crates/ceres-core/src/traits.rs
@@ -217,18 +217,20 @@ pub trait PortalClientFactory: Send + Sync + Clone {
     /// The type of portal client this factory creates.
     type Client: PortalClient;
 
-    /// Creates a new portal client for the given URL and portal type.
+    /// Creates a new portal client for the given URL, portal type, and optional profile.
     ///
     /// # Arguments
     ///
     /// * `portal_url` - The portal API base URL
     /// * `portal_type` - The type of portal to create a client for
     /// * `language` - Preferred language for multilingual portals (e.g. "en", "fr")
+    /// * `profile` - Optional profile for sub-dispatch (e.g. `"sparql"` for DCAT portals)
     fn create(
         &self,
         portal_url: &str,
         portal_type: PortalType,
         language: &str,
+        profile: Option<&str>,
     ) -> Result<Self::Client, AppError>;
 }
 

--- a/crates/ceres-core/src/traits.rs
+++ b/crates/ceres-core/src/traits.rs
@@ -225,12 +225,14 @@ pub trait PortalClientFactory: Send + Sync + Clone {
     /// * `portal_type` - The type of portal to create a client for
     /// * `language` - Preferred language for multilingual portals (e.g. "en", "fr")
     /// * `profile` - Optional profile for sub-dispatch (e.g. `"sparql"` for DCAT portals)
+    /// * `sparql_endpoint` - Optional custom SPARQL endpoint URL (overrides `{url}/sparql`)
     fn create(
         &self,
         portal_url: &str,
         portal_type: PortalType,
         language: &str,
         profile: Option<&str>,
+        sparql_endpoint: Option<&str>,
     ) -> Result<Self::Client, AppError>;
 }
 

--- a/crates/ceres-core/src/worker.rs
+++ b/crates/ceres-core/src/worker.rs
@@ -306,7 +306,7 @@ where
                 job.force_full_sync,
                 job.portal_type,
                 job.profile.as_deref(),
-                None, // sparql_endpoint not stored in job table
+                job.sparql_endpoint.as_deref(),
             )
             .await;
 

--- a/crates/ceres-core/src/worker.rs
+++ b/crates/ceres-core/src/worker.rs
@@ -305,6 +305,7 @@ where
                 job_cancel.clone(),
                 job.force_full_sync,
                 job.portal_type,
+                job.profile.as_deref(),
             )
             .await;
 

--- a/crates/ceres-core/src/worker.rs
+++ b/crates/ceres-core/src/worker.rs
@@ -306,6 +306,7 @@ where
                 job.force_full_sync,
                 job.portal_type,
                 job.profile.as_deref(),
+                None, // sparql_endpoint not stored in job table
             )
             .await;
 

--- a/crates/ceres-core/tests/integration/cancellation_tests.rs
+++ b/crates/ceres-core/tests/integration/cancellation_tests.rs
@@ -112,6 +112,7 @@ async fn test_batch_harvest_cancellable() {
             portal_type: ceres_core::PortalType::Ckan,
             url_template: None,
             language: None,
+            profile: None,
         },
         ceres_core::PortalEntry {
             name: "Portal 2".to_string(),
@@ -121,6 +122,7 @@ async fn test_batch_harvest_cancellable() {
             portal_type: ceres_core::PortalType::Ckan,
             url_template: None,
             language: None,
+            profile: None,
         },
     ];
 

--- a/crates/ceres-core/tests/integration/cancellation_tests.rs
+++ b/crates/ceres-core/tests/integration/cancellation_tests.rs
@@ -113,6 +113,7 @@ async fn test_batch_harvest_cancellable() {
             url_template: None,
             language: None,
             profile: None,
+            sparql_endpoint: None,
         },
         ceres_core::PortalEntry {
             name: "Portal 2".to_string(),
@@ -123,6 +124,7 @@ async fn test_batch_harvest_cancellable() {
             url_template: None,
             language: None,
             profile: None,
+            sparql_endpoint: None,
         },
     ];
 

--- a/crates/ceres-core/tests/integration/common.rs
+++ b/crates/ceres-core/tests/integration/common.rs
@@ -206,6 +206,7 @@ impl PortalClientFactory for MockPortalClientFactory {
         portal_url: &str,
         _portal_type: ceres_core::config::PortalType,
         _language: &str,
+        _profile: Option<&str>,
     ) -> Result<Self::Client, AppError> {
         Ok(MockPortalClient::new(portal_url, self.datasets.clone()))
     }
@@ -602,6 +603,7 @@ impl MockJobQueue {
             force_full_sync: false,
             url_template: None,
             language: None,
+            profile: None,
         };
         self.jobs.lock().unwrap().insert(id, job);
         (self, id)
@@ -653,6 +655,7 @@ impl JobQueue for MockJobQueue {
             force_full_sync: request.force_full_sync,
             url_template: request.url_template,
             language: request.language,
+            profile: request.profile,
         };
         self.jobs.lock().unwrap().insert(id, job.clone());
         Ok(job)

--- a/crates/ceres-core/tests/integration/common.rs
+++ b/crates/ceres-core/tests/integration/common.rs
@@ -756,7 +756,7 @@ impl JobQueue for MockJobQueue {
             .filter(|j| status.is_none_or(|s| j.status == s))
             .cloned()
             .collect();
-        result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        result.sort_by_key(|b| std::cmp::Reverse(b.created_at));
         result.truncate(limit);
         Ok(result)
     }

--- a/crates/ceres-core/tests/integration/common.rs
+++ b/crates/ceres-core/tests/integration/common.rs
@@ -605,6 +605,7 @@ impl MockJobQueue {
             url_template: None,
             language: None,
             profile: None,
+            sparql_endpoint: None,
         };
         self.jobs.lock().unwrap().insert(id, job);
         (self, id)
@@ -657,6 +658,7 @@ impl JobQueue for MockJobQueue {
             url_template: request.url_template,
             language: request.language,
             profile: request.profile,
+            sparql_endpoint: request.sparql_endpoint,
         };
         self.jobs.lock().unwrap().insert(id, job.clone());
         Ok(job)

--- a/crates/ceres-core/tests/integration/common.rs
+++ b/crates/ceres-core/tests/integration/common.rs
@@ -207,6 +207,7 @@ impl PortalClientFactory for MockPortalClientFactory {
         _portal_type: ceres_core::config::PortalType,
         _language: &str,
         _profile: Option<&str>,
+        _sparql_endpoint: Option<&str>,
     ) -> Result<Self::Client, AppError> {
         Ok(MockPortalClient::new(portal_url, self.datasets.clone()))
     }

--- a/crates/ceres-core/tests/integration/worker_tests.rs
+++ b/crates/ceres-core/tests/integration/worker_tests.rs
@@ -54,6 +54,7 @@ impl PortalClientFactory for FailingPortalClientFactory {
         _portal_url: &str,
         _portal_type: PortalType,
         _language: &str,
+        _profile: Option<&str>,
     ) -> Result<Self::Client, AppError> {
         Err(AppError::NetworkError(
             "simulated network failure".to_string(),

--- a/crates/ceres-core/tests/integration/worker_tests.rs
+++ b/crates/ceres-core/tests/integration/worker_tests.rs
@@ -55,6 +55,7 @@ impl PortalClientFactory for FailingPortalClientFactory {
         _portal_type: PortalType,
         _language: &str,
         _profile: Option<&str>,
+        _sparql_endpoint: Option<&str>,
     ) -> Result<Self::Client, AppError> {
         Err(AppError::NetworkError(
             "simulated network failure".to_string(),

--- a/crates/ceres-db/Cargo.toml
+++ b/crates/ceres-db/Cargo.toml
@@ -34,4 +34,4 @@ tracing.workspace = true
 [dev-dependencies]
 testcontainers = "0.27"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-rand = "0.9"
+rand = "0.10.1"

--- a/crates/ceres-db/src/job_repository.rs
+++ b/crates/ceres-db/src/job_repository.rs
@@ -55,6 +55,7 @@ struct JobRow {
     language: Option<String>,
     portal_type: String,
     profile: Option<String>,
+    sparql_endpoint: Option<String>,
 }
 
 /// JSON representation of SyncStats for database storage.
@@ -124,6 +125,7 @@ impl From<JobRow> for HarvestJob {
             url_template: row.url_template,
             language: row.language,
             profile: row.profile,
+            sparql_endpoint: row.sparql_endpoint,
         }
     }
 }
@@ -138,8 +140,8 @@ impl JobQueue for JobRepository {
 
         let row: JobRow = sqlx::query_as(
             r#"
-            INSERT INTO harvest_jobs (portal_url, portal_name, force_full_sync, max_retries, url_template, language, portal_type, profile)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            INSERT INTO harvest_jobs (portal_url, portal_name, force_full_sync, max_retries, url_template, language, portal_type, profile, sparql_endpoint)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
             RETURNING *
             "#,
         )
@@ -151,6 +153,7 @@ impl JobQueue for JobRepository {
         .bind(&request.language)
         .bind(request.portal_type.to_string())
         .bind(&request.profile)
+        .bind(&request.sparql_endpoint)
         .fetch_one(&self.pool)
         .await
         .map_err(|e| AppError::DatabaseError(e.to_string()))?;

--- a/crates/ceres-db/src/job_repository.rs
+++ b/crates/ceres-db/src/job_repository.rs
@@ -54,6 +54,7 @@ struct JobRow {
     url_template: Option<String>,
     language: Option<String>,
     portal_type: String,
+    profile: Option<String>,
 }
 
 /// JSON representation of SyncStats for database storage.
@@ -122,6 +123,7 @@ impl From<JobRow> for HarvestJob {
             force_full_sync: row.force_full_sync,
             url_template: row.url_template,
             language: row.language,
+            profile: row.profile,
         }
     }
 }
@@ -136,8 +138,8 @@ impl JobQueue for JobRepository {
 
         let row: JobRow = sqlx::query_as(
             r#"
-            INSERT INTO harvest_jobs (portal_url, portal_name, force_full_sync, max_retries, url_template, language, portal_type)
-            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            INSERT INTO harvest_jobs (portal_url, portal_name, force_full_sync, max_retries, url_template, language, portal_type, profile)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
             RETURNING *
             "#,
         )
@@ -148,6 +150,7 @@ impl JobQueue for JobRepository {
         .bind(&request.url_template)
         .bind(&request.language)
         .bind(request.portal_type.to_string())
+        .bind(&request.profile)
         .fetch_one(&self.pool)
         .await
         .map_err(|e| AppError::DatabaseError(e.to_string()))?;

--- a/crates/ceres-db/tests/integration/common.rs
+++ b/crates/ceres-db/tests/integration/common.rs
@@ -137,7 +137,7 @@ pub fn sample_new_dataset(id: &str, portal: &str) -> NewDataset {
 /// Useful for testing vector similarity search with varied embeddings.
 #[allow(dead_code)]
 pub fn random_vector(dims: usize) -> Vec<f32> {
-    use rand::Rng;
+    use rand::RngExt;
     let mut rng = rand::rng();
     (0..dims).map(|_| rng.random::<f32>()).collect()
 }

--- a/crates/ceres-server/src/dto/response.rs
+++ b/crates/ceres-server/src/dto/response.rs
@@ -117,6 +117,8 @@ pub struct PortalInfoResponse {
     pub url: String,
     /// Portal type (ckan, socrata, dcat)
     pub portal_type: String,
+    /// DCAT profile (e.g., "sparql"), if applicable
+    pub profile: Option<String>,
     /// Whether the portal is enabled for harvesting
     pub enabled: bool,
     /// Portal description

--- a/crates/ceres-server/src/dto/response.rs
+++ b/crates/ceres-server/src/dto/response.rs
@@ -119,6 +119,8 @@ pub struct PortalInfoResponse {
     pub portal_type: String,
     /// DCAT profile (e.g., "sparql"), if applicable
     pub profile: Option<String>,
+    /// Custom SPARQL endpoint URL, if applicable
+    pub sparql_endpoint: Option<String>,
     /// Whether the portal is enabled for harvesting
     pub enabled: bool,
     /// Portal description

--- a/crates/ceres-server/src/handlers/portals.rs
+++ b/crates/ceres-server/src/handlers/portals.rs
@@ -47,6 +47,7 @@ pub async fn list_portals(
             url: portal.url.clone(),
             portal_type: portal.portal_type.to_string(),
             profile: portal.profile.clone(),
+            sparql_endpoint: portal.sparql_endpoint.clone(),
             enabled: portal.enabled,
             description: portal.description.clone(),
             last_sync: sync_status.as_ref().and_then(|s| s.last_successful_sync),

--- a/crates/ceres-server/src/handlers/portals.rs
+++ b/crates/ceres-server/src/handlers/portals.rs
@@ -46,6 +46,7 @@ pub async fn list_portals(
             name: portal.name.clone(),
             url: portal.url.clone(),
             portal_type: portal.portal_type.to_string(),
+            profile: portal.profile.clone(),
             enabled: portal.enabled,
             description: portal.description.clone(),
             last_sync: sync_status.as_ref().and_then(|s| s.last_successful_sync),
@@ -156,6 +157,10 @@ pub async fn trigger_portal_harvest(
 
     if let Some(ref lang) = portal.language {
         job_request = job_request.with_language(lang);
+    }
+
+    if let Some(ref profile) = portal.profile {
+        job_request = job_request.with_profile(profile);
     }
 
     if request.force_full_sync {

--- a/crates/ceres-server/src/handlers/portals.rs
+++ b/crates/ceres-server/src/handlers/portals.rs
@@ -163,7 +163,9 @@ pub async fn trigger_portal_harvest(
     if let Some(ref profile) = portal.profile {
         job_request = job_request.with_profile(profile);
     }
-
+    if let Some(ref sparql_endpoint) = portal.sparql_endpoint {
+        job_request = job_request.with_sparql_endpoint(sparql_endpoint);
+    }
     if request.force_full_sync {
         job_request = job_request.with_full_sync();
     }

--- a/examples/portals.toml
+++ b/examples/portals.toml
@@ -180,20 +180,50 @@ description = "Luxembourg Open Data Portal (DCAT-AP / udata)"
 # DCAT-AP portals (SPARQL endpoint)
 # =============================================================================
 
-# [[portals]]
-# name = "eu-open-data"
-# url = "https://data.europa.eu"
-# type = "dcat"
-# profile = "sparql"
-# language = "en"
-# enabled = false
-# description = "EU Open Data Portal (SPARQL endpoint, ~1.6M datasets)"
+[[portals]]
+name = "eu-open-data"
+url = "https://data.europa.eu"
+type = "dcat"
+profile = "sparql"
+language = "en"
+enabled = false
+description = "EU Open Data Portal (SPARQL endpoint, ~2M datasets)"
 
-# [[portals]]
-# name = "norway"
-# url = "https://data.norge.no"
-# type = "dcat"
-# profile = "sparql"
-# language = "nb"
-# enabled = false
-# description = "Norwegian Data Portal (SPARQL endpoint)"
+[[portals]]
+name = "norway"
+url = "https://data.norge.no"
+type = "dcat"
+profile = "sparql"
+language = "nb"
+sparql_endpoint = "https://sparql.fellesdatakatalog.digdir.no"
+enabled = false
+description = "Norwegian Data Portal (SPARQL endpoint, ~9k datasets)"
+
+[[portals]]
+name = "spain-datos"
+url = "https://datos.gob.es"
+type = "dcat"
+profile = "sparql"
+language = "es"
+sparql_endpoint = "https://datos.gob.es/virtuoso/sparql"
+enabled = false
+description = "Spanish Government Open Data Portal (SPARQL endpoint, ~113k datasets)"
+
+[[portals]]
+name = "switzerland-lindas"
+url = "https://lindas.admin.ch"
+type = "dcat"
+profile = "sparql"
+language = "de"
+sparql_endpoint = "https://lindas.admin.ch/query"
+enabled = false
+description = "Swiss Federal Linked Data Service (SPARQL endpoint, ~2k datasets)"
+
+[[portals]]
+name = "czech-republic"
+url = "https://data.gov.cz"
+type = "dcat"
+profile = "sparql"
+language = "cs"
+enabled = false
+description = "Czech National Open Data Catalog (SPARQL endpoint)"

--- a/examples/portals.toml
+++ b/examples/portals.toml
@@ -175,3 +175,25 @@ description = "Luxembourg Open Data Portal (DCAT-AP / udata)"
 # language = "fr"
 # enabled = false
 # description = "data.gouv.fr — French Government Open Data Portal (~50,000+ datasets)"
+
+# =============================================================================
+# DCAT-AP portals (SPARQL endpoint)
+# =============================================================================
+
+# [[portals]]
+# name = "eu-open-data"
+# url = "https://data.europa.eu"
+# type = "dcat"
+# profile = "sparql"
+# language = "en"
+# enabled = false
+# description = "EU Open Data Portal (SPARQL endpoint, ~1.6M datasets)"
+
+# [[portals]]
+# name = "norway"
+# url = "https://data.norge.no"
+# type = "dcat"
+# profile = "sparql"
+# language = "nb"
+# enabled = false
+# description = "Norwegian Data Portal (SPARQL endpoint)"

--- a/migrations/202604120001_add_profile_to_harvest_jobs.sql
+++ b/migrations/202604120001_add_profile_to_harvest_jobs.sql
@@ -1,4 +1,8 @@
--- Add profile column to harvest_jobs for DCAT sub-dispatch.
--- Records the access profile (e.g., 'sparql' for SPARQL endpoints).
+-- Add profile and optional SPARQL endpoint override columns to harvest_jobs
+-- for DCAT sub-dispatch.
+-- `profile` records the access profile (e.g., 'sparql' for SPARQL endpoints).
 -- NULL means the default profile for the portal type.
+-- `sparql_endpoint` stores an optional per-job endpoint override; NULL means
+-- use the default endpoint for the selected portal/profile.
 ALTER TABLE harvest_jobs ADD COLUMN profile TEXT;
+ALTER TABLE harvest_jobs ADD COLUMN sparql_endpoint TEXT;

--- a/migrations/202604120001_add_profile_to_harvest_jobs.sql
+++ b/migrations/202604120001_add_profile_to_harvest_jobs.sql
@@ -1,0 +1,4 @@
+-- Add profile column to harvest_jobs for DCAT sub-dispatch.
+-- Records the access profile (e.g., 'sparql' for SPARQL endpoints).
+-- NULL means the default profile for the portal type.
+ALTER TABLE harvest_jobs ADD COLUMN profile TEXT;


### PR DESCRIPTION
Adds a SPARQL DCAT client for harvesting open data portals that expose DCAT-AP metadata via a SPARQL endpoint (e.g. data.europa.eu, data.norge.no, datos.gob.es).

Datasets coverage from 900k to 1.7M.
This only covers verified and harvested portals from myself, as open-data-eu sparql portal boasts 2M datasets, without a real token the connection might prove unstable, so far i could only harvest 1/3 of it, will improve it further.

## Portals verified and added to config

| Portal | URL | Datasets |
|--------|-----|----------|
| EU Open Data | data.europa.eu | ~1.9M |
| Norway | data.norge.no | ~9k |
| Spain | datos.gob.es | ~113k |
| Switzerland LINDAS | lindas.admin.ch | ~2k |
| Czech Republic | data.gov.cz | ~30k |

Also bumps `rand` to 0.10.1 and `rustls-webpki` to 0.103.12.