### PR TITLE
perf: HNSW tuning + ecosystem consolidation (0.4.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ Thumbs.db
 .env.local
 .env.*.local
 .claude/
+.ceres-harvest-runs/
 
 # Database
 /pgdata/

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ Thumbs.db
 .env
 .env.local
 .env.*.local
+.claude/
 
 # Database
 /pgdata/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-05-21
+
+Theme: performance at scale and ecosystem consolidation.
+
+### Added
+
+- HNSW index tuning: dedup migration rebuilding a single named index with
+  `m=16, ef_construction=64`; dynamic per-search `hnsw.ef_search`
+  (env `CERES_HNSW_EF_SEARCH`, default 40) and `iterative_scan=relaxed_order`
+- `scripts/hnsw_benchmark.sql` and `compose.yml` memory/`shm_size` tuning
+- `AppError::IoError` and `AppError::ExportError` variants for export paths
+- `SyncOptions` struct and `DatasetRepository::get_sync_status_batch`
+
+### Changed
+
+- Embedding pass now waits for circuit-breaker recovery and retries deferred
+  batches (bounded) instead of stopping; affected datasets stay pending
+- `list_portals` uses a single batched sync-status query (no more N+1) and
+  propagates DB errors instead of silencing them
+
+### Fixed
+
+- SPARQL incremental sync no longer excludes datasets without `dct:modified`
+
+### Dependencies
+
+- Update yanked `unicode-segmentation` 1.13.1 → 1.13.2
+- Update `astral-tokio-tar` 0.6.1 → 0.6.2 (RUSTSEC-2026-0145)
+
 ## [0.3.5] - 2026-03-30
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "ceres-client"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "ceres-core",
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "ceres-core"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "arrow",
  "chrono",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "ceres-db"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "ceres-core",
  "chrono",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "ceres-search"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "ceres-client",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "ceres-server"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "axum 0.7.9",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -93,7 +93,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -287,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
+checksum = "cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277"
 dependencies = [
  "filetime",
  "futures-core",
@@ -1244,7 +1244,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1318,7 +1318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2433,7 +2433,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3242,7 +3242,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3301,7 +3301,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3629,7 +3629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3986,7 +3986,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4501,9 +4501,9 @@ checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da36089a805484bcccfffe0739803392c8298778a2d2f09febf76fac5ad9025b"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.5"
+version = "0.4.0"
 edition = "2024"
 authors = ["Andrea Bozzo"]
 license = "Apache-2.0"
@@ -72,6 +72,6 @@ arrow = { version = "58", default-features = false, features = ["prettyprint"] }
 parquet = { version = "58", default-features = false, features = ["arrow", "snap", "zstd"] }
 
 # Internal crates
-ceres-core = { version = "0.3.5", path = "crates/ceres-core" }
-ceres-client = { version = "0.3.5", path = "crates/ceres-client" }
-ceres-db = { version = "0.3.5", path = "crates/ceres-db" }
+ceres-core = { version = "0.4.0", path = "crates/ceres-core" }
+ceres-client = { version = "0.4.0", path = "crates/ceres-client" }
+ceres-db = { version = "0.4.0", path = "crates/ceres-db" }

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ Ceres addresses that by splitting the system into two stages:
 
 ## Current Scope
 
-- Harvesting: CKAN and DCAT-AP udata REST portals
+- Harvesting: CKAN, DCAT-AP udata REST, and SPARQL-backed DCAT endpoints (e.g. `data.europa.eu`)
 - Embeddings: Ollama locally, or Gemini/OpenAI if you prefer hosted providers
-- Search: semantic search over datasets that already have embeddings
+- Search: semantic search over datasets that already have embeddings, backed by a tuned HNSW index for catalogs at scale
 - Export: JSONL, JSON, CSV, and curated Parquet
 - Operations: CLI, REST API, database-backed harvest jobs, graceful shutdown, protected admin endpoints
 
@@ -73,6 +73,7 @@ Today, the shipped portal clients cover:
 
 - `ckan`
 - `dcat` for udata-flavored DCAT-AP portals such as `data.public.lu` and `data.gouv.fr`
+- `dcat` with `--profile sparql` for SPARQL-backed DCAT catalogs such as `data.europa.eu`
 
 The codebase already models additional portal types such as `socrata`, but they are not yet implemented in the current client factory.
 
@@ -189,6 +190,9 @@ ceres harvest https://dati.comune.milano.it
 
 # Ad-hoc DCAT harvest
 ceres harvest https://data.public.lu --type dcat
+
+# Ad-hoc SPARQL-backed DCAT harvest
+ceres harvest https://data.europa.eu --type dcat --profile sparql
 
 # Named portal from config
 ceres harvest --portal milano --config examples/portals.toml

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ The website lives in `website/` and documents the same harvest-first model:
 
 ## Version
 
-Current version: `0.3.5`
+Current version: `0.4.0`
 
 ## Contributing
 

--- a/compose.yml
+++ b/compose.yml
@@ -9,6 +9,21 @@ services:
       POSTGRES_DB: ceres_db
     ports:
       - "5432:5432"
+    # HNSW index builds need shared memory for parallel workers; the 64MB default
+    # makes parallel builds fail with "No space left on device" at our scale.
+    # Raising shm_size lets `CREATE INDEX ... USING hnsw` use parallel maintenance
+    # workers. Without this, build the index serially
+    # (SET max_parallel_maintenance_workers = 0).
+    shm_size: "2gb"
+    # Build/query tuning for vector workloads at scale (~360k embeddings):
+    #   maintenance_work_mem: HNSW build quality/speed (≈1.3GB per index)
+    #   shared_buffers:       hot index/page cache for search latency
+    command:
+      - "postgres"
+      - "-c"
+      - "maintenance_work_mem=1GB"
+      - "-c"
+      - "shared_buffers=512MB"
     volumes:
       - ceres_pgdata:/var/lib/postgresql/data
     healthcheck:

--- a/crates/ceres-client/src/portal.rs
+++ b/crates/ceres-client/src/portal.rs
@@ -148,7 +148,7 @@ impl PortalClient for PortalClientEnum {
                 },
             )),
             Self::SparqlDcat(c) => Box::pin(StreamExt::map(
-                c.paginate_sparql_stream(None),
+                c.paginate_sparql_stream(),
                 |r: Result<Vec<DcatDataset>, AppError>| {
                     r.map(|datasets| datasets.into_iter().map(PortalDataEnum::Dcat).collect())
                 },

--- a/crates/ceres-client/src/sparql.rs
+++ b/crates/ceres-client/src/sparql.rs
@@ -244,15 +244,32 @@ impl SparqlDcatClient {
     }
 
     /// Searches for datasets modified since the given timestamp.
+    ///
+    /// `dct:modified` is bound via `OPTIONAL`, so datasets that don't expose it
+    /// would be silently excluded by a plain `?modified > since` filter. Since
+    /// many DCAT catalogs omit `dct:modified` entirely, we also let through any
+    /// dataset where `?modified` is unbound (`!BOUND(?modified)`): those are
+    /// re-fetched and the downstream content-hash delta detector decides whether
+    /// they actually changed. This keeps incremental sync from missing datasets
+    /// that lack a modification timestamp.
     pub async fn search_modified_since(
         &self,
         since: DateTime<Utc>,
     ) -> Result<Vec<DcatDataset>, AppError> {
-        let filter = format!(
-            "FILTER (?modified > \"{}\"^^<http://www.w3.org/2001/XMLSchema#dateTime>)",
-            since.to_rfc3339()
-        );
+        let filter = Self::modified_since_filter(since);
         self.paginate_sparql(Some(&filter)).await
+    }
+
+    /// Builds the SPARQL FILTER clause for incremental sync.
+    ///
+    /// Includes `!BOUND(?modified)` so datasets lacking a `dct:modified` value
+    /// (bound via `OPTIONAL`) are not silently dropped — see
+    /// [`search_modified_since`](Self::search_modified_since).
+    fn modified_since_filter(since: DateTime<Utc>) -> String {
+        format!(
+            "FILTER (!BOUND(?modified) || ?modified > \"{}\"^^<http://www.w3.org/2001/XMLSchema#dateTime>)",
+            since.to_rfc3339()
+        )
     }
 
     /// Fetches all datasets from the portal using paginated SPARQL queries.
@@ -287,10 +304,12 @@ impl SparqlDcatClient {
     ///
     /// Datasets with no `dct:publisher` are harvested in a final pass via a
     /// `FILTER NOT EXISTS` partition.
-    pub fn paginate_sparql_stream(
-        &self,
-        _modified_since: Option<String>,
-    ) -> BoxStream<'_, Result<Vec<DcatDataset>, AppError>> {
+    ///
+    /// This is a full-catalog stream used only for full syncs. Incremental sync
+    /// goes through [`search_modified_since`](Self::search_modified_since), which
+    /// applies the `dct:modified` filter; the streaming path does not filter by
+    /// modification time.
+    pub fn paginate_sparql_stream(&self) -> BoxStream<'_, Result<Vec<DcatDataset>, AppError>> {
         if self.uses_data_europa_registry() {
             return self.paginate_data_europa_registry_stream();
         }
@@ -1512,6 +1531,117 @@ mod tests {
         assert_eq!(datasets[0].title, "Valid Title");
     }
 
+    // ---- multilingual selection robustness ----------------------------------
+
+    /// Helper: build a single-key binding with an optional language tag.
+    fn binding(
+        uri: &str,
+        key: &str,
+        value: &str,
+        lang: Option<&str>,
+    ) -> HashMap<String, SparqlValue> {
+        let mut b = HashMap::new();
+        b.insert(
+            "dataset".to_string(),
+            SparqlValue {
+                value: uri.to_string(),
+                lang: None,
+            },
+        );
+        b.insert(
+            key.to_string(),
+            SparqlValue {
+                value: value.to_string(),
+                lang: lang.map(str::to_string),
+            },
+        );
+        b
+    }
+
+    #[test]
+    fn lang_selection_is_order_independent() {
+        // The preferred-language row must win regardless of SPARQL result ordering.
+        let client = SparqlDcatClient::new("https://example.org", "it", None).unwrap();
+
+        let en_first = vec![
+            binding("https://example.org/d/1", "title", "English", Some("en")),
+            binding("https://example.org/d/1", "title", "Italiano", Some("it")),
+        ];
+        let it_first = vec![
+            binding("https://example.org/d/1", "title", "Italiano", Some("it")),
+            binding("https://example.org/d/1", "title", "English", Some("en")),
+        ];
+
+        assert_eq!(
+            client.best_value(&en_first, "title").unwrap().value,
+            "Italiano"
+        );
+        assert_eq!(
+            client.best_value(&it_first, "title").unwrap().value,
+            "Italiano"
+        );
+    }
+
+    #[test]
+    fn lang_falls_back_to_sibling_then_en_then_untagged() {
+        // Requested "nn"; only the sibling "nb", an "en", and an untagged value exist.
+        // Sibling (rank 2) must beat "en" (rank 1) and untagged (rank 0).
+        let client = SparqlDcatClient::new("https://example.org", "nn", None).unwrap();
+        let rows = vec![
+            binding("https://example.org/d/1", "title", "Untagged", None),
+            binding("https://example.org/d/1", "title", "English", Some("en")),
+            binding("https://example.org/d/1", "title", "Bokmål", Some("nb")),
+        ];
+        assert_eq!(client.best_value(&rows, "title").unwrap().value, "Bokmål");
+
+        // With only en + untagged, "en" wins.
+        let rows = vec![
+            binding("https://example.org/d/2", "title", "Untagged", None),
+            binding("https://example.org/d/2", "title", "English", Some("en")),
+        ];
+        assert_eq!(client.best_value(&rows, "title").unwrap().value, "English");
+    }
+
+    #[test]
+    fn title_and_description_selected_independently() {
+        // A dataset may carry the title in the preferred language but the
+        // description only in a fallback language; each field is chosen on its own.
+        let client = SparqlDcatClient::new("https://example.org", "fr", None).unwrap();
+        let json = r#"{
+            "results": {
+                "bindings": [
+                    {
+                        "dataset": { "type": "uri", "value": "https://example.org/d/1" },
+                        "title": { "type": "literal", "value": "Titre FR", "xml:lang": "fr" },
+                        "description": { "type": "literal", "value": "English description", "xml:lang": "en" }
+                    },
+                    {
+                        "dataset": { "type": "uri", "value": "https://example.org/d/1" },
+                        "title": { "type": "literal", "value": "English Title", "xml:lang": "en" }
+                    }
+                ]
+            }
+        }"#;
+        let resp: SparqlResponse = serde_json::from_str(json).unwrap();
+        let datasets = client.bindings_to_datasets(resp.results.bindings);
+        assert_eq!(datasets.len(), 1);
+        assert_eq!(datasets[0].title, "Titre FR");
+        assert_eq!(
+            datasets[0].description.as_deref(),
+            Some("English description")
+        );
+    }
+
+    #[test]
+    fn lang_rank_orders_preferred_sibling_en_other() {
+        let client = SparqlDcatClient::new("https://example.org", "nb", None).unwrap();
+        assert_eq!(client.lang_rank(Some("nb")), 3); // preferred
+        assert_eq!(client.lang_rank(Some("nn")), 2); // sibling
+        assert_eq!(client.lang_rank(Some("en")), 1); // english fallback
+        assert_eq!(client.lang_rank(Some("de")), 0); // unrelated
+        assert_eq!(client.lang_rank(None), 0); // untagged
+    }
+
     // ---- extract_last_segment -----------------------------------------------
 
     #[test]
@@ -1562,6 +1692,25 @@ mod tests {
         let filter = "FILTER (?modified > \"2026-01-01T00:00:00Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>)";
         let query = client.build_dataset_query(0, Some(filter));
         assert!(query.contains(filter));
+    }
+
+    #[test]
+    fn modified_since_filter_allows_unbound_modified() {
+        // Datasets without dct:modified (OPTIONAL, hence possibly unbound) must not
+        // be excluded from incremental sync, or catalogs that omit dct:modified
+        // would never re-sync changed datasets.
+        let since = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let filter = SparqlDcatClient::modified_since_filter(since);
+        assert!(filter.contains("!BOUND(?modified)"));
+        assert!(filter.contains("?modified > \"2026-01-01T00:00:00+00:00\""));
+
+        // The unbound clause must come first so it short-circuits before the
+        // comparison (which would error on an unbound variable in strict engines).
+        let bound_pos = filter.find("!BOUND(?modified)").unwrap();
+        let cmp_pos = filter.find("?modified >").unwrap();
+        assert!(bound_pos < cmp_pos);
     }
 
     // ---- SparqlDcatClient::new ---------------------------------------------

--- a/crates/ceres-core/src/embedding.rs
+++ b/crates/ceres-core/src/embedding.rs
@@ -197,7 +197,7 @@ where
 
             let embedded_before = stats.embedded;
 
-            for batch in page.chunks(effective_batch_size) {
+            'batches: for batch in page.chunks(effective_batch_size) {
                 if cancel_token.is_cancelled() {
                     tracing::info!("Embedding pass cancelled");
                     break;
@@ -235,8 +235,11 @@ where
                             tokio::select! {
                                 _ = tokio::time::sleep(retry_after) => {}
                                 _ = cancel_token.cancelled() => {
+                                    // Cancelled mid-wait: the batch never reached a
+                                    // terminal outcome, so don't count or report it —
+                                    // it stays pending. Stop the whole pass.
                                     tracing::info!("Embedding pass cancelled during circuit wait");
-                                    break;
+                                    break 'batches;
                                 }
                             }
                         }
@@ -254,10 +257,6 @@ where
                     failed: stats.failed,
                     skipped: stats.skipped,
                 });
-
-                if cancel_token.is_cancelled() {
-                    break;
-                }
             }
 
             // If no datasets were successfully embedded this page, stop to avoid

--- a/crates/ceres-core/src/embedding.rs
+++ b/crates/ceres-core/src/embedding.rs
@@ -51,6 +51,22 @@ impl EmbeddingStats {
     }
 }
 
+/// Outcome of attempting to embed a single batch.
+///
+/// Distinguishes a *recoverable* circuit-open skip (the provider is temporarily
+/// unavailable — Ollama timeout, external rate limit — and the batch should be
+/// retried after the breaker's recovery window) from a *terminal* outcome where
+/// the batch was processed (whether it embedded, failed, or had empty text) and
+/// should not be retried.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BatchOutcome {
+    /// The batch reached a terminal state (embedded, failed, or empty); move on.
+    Processed,
+    /// The circuit breaker was open; the batch is still pending and recoverable
+    /// after `retry_after`.
+    CircuitOpen { retry_after: std::time::Duration },
+}
+
 impl std::fmt::Display for EmbeddingStats {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
@@ -187,8 +203,45 @@ where
                     break;
                 }
 
-                self.process_batch(batch, &circuit_breaker, &mut stats)
-                    .await;
+                // Retry a batch deferred by an open circuit: wait out the breaker's
+                // recovery window (cancellable) so the Open -> HalfOpen transition can
+                // re-test the provider, then retry the *same* batch. After
+                // MAX_CIRCUIT_RETRIES we give up on this batch (counted as skipped,
+                // still pending in DB) and move on — the daemon is never blocked.
+                const MAX_CIRCUIT_RETRIES: u32 = 5;
+                let mut attempt = 0;
+                loop {
+                    match self
+                        .process_batch(batch, &circuit_breaker, &mut stats)
+                        .await
+                    {
+                        BatchOutcome::Processed => break,
+                        BatchOutcome::CircuitOpen { retry_after } => {
+                            attempt += 1;
+                            if attempt > MAX_CIRCUIT_RETRIES {
+                                tracing::warn!(
+                                    batch_size = batch.len(),
+                                    attempts = attempt - 1,
+                                    "Circuit still open after retries — leaving batch pending"
+                                );
+                                stats.skipped += batch.len();
+                                break;
+                            }
+                            tracing::info!(
+                                attempt,
+                                wait_secs = retry_after.as_secs(),
+                                "Circuit open — waiting for recovery before retry"
+                            );
+                            tokio::select! {
+                                _ = tokio::time::sleep(retry_after) => {}
+                                _ = cancel_token.cancelled() => {
+                                    tracing::info!("Embedding pass cancelled during circuit wait");
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
 
                 processed += batch.len();
 
@@ -201,6 +254,10 @@ where
                     failed: stats.failed,
                     skipped: stats.skipped,
                 });
+
+                if cancel_token.is_cancelled() {
+                    break;
+                }
             }
 
             // If no datasets were successfully embedded this page, stop to avoid
@@ -229,12 +286,17 @@ where
 
     /// Processes a batch of datasets: generates embeddings via circuit breaker,
     /// then upserts them back to the database.
+    ///
+    /// Returns [`BatchOutcome::CircuitOpen`] without mutating `stats` when the
+    /// breaker is open, so the caller can wait for recovery and retry the same
+    /// batch. All terminal outcomes update `stats` and return
+    /// [`BatchOutcome::Processed`].
     async fn process_batch(
         &self,
         datasets: &[crate::Dataset],
         circuit_breaker: &CircuitBreaker,
         stats: &mut EmbeddingStats,
-    ) {
+    ) -> BatchOutcome {
         // Compute text to embed for each dataset, filtering out empty text
         let embeddable: Vec<(&crate::Dataset, String)> = datasets
             .iter()
@@ -259,7 +321,7 @@ where
         }
 
         if embeddable.is_empty() {
-            return;
+            return BatchOutcome::Processed;
         }
 
         let texts: Vec<String> = embeddable.iter().map(|(_, t)| t.clone()).collect();
@@ -277,7 +339,7 @@ where
                         "Batch embedding count mismatch, failing batch"
                     );
                     stats.failed += batch_size;
-                    return;
+                    return BatchOutcome::Processed;
                 }
 
                 // Build NewDataset items with embeddings for upsert.
@@ -326,14 +388,17 @@ where
                         stats.failed += upsert_count;
                     }
                 }
+                BatchOutcome::Processed
             }
             Err(CircuitBreakerError::Open { retry_after, .. }) => {
+                // Recoverable: the provider is temporarily down. Don't count the
+                // batch yet — the caller waits for recovery and retries it.
                 tracing::debug!(
                     batch_size,
                     retry_after_secs = retry_after.as_secs(),
-                    "Skipping batch - circuit breaker open"
+                    "Circuit breaker open - batch deferred for retry"
                 );
-                stats.skipped += batch_size;
+                BatchOutcome::CircuitOpen { retry_after }
             }
             Err(CircuitBreakerError::Inner(e)) => {
                 tracing::warn!(
@@ -342,6 +407,7 @@ where
                     "Batch embedding generation failed"
                 );
                 stats.failed += batch_size;
+                BatchOutcome::Processed
             }
         }
     }

--- a/crates/ceres-core/src/error.rs
+++ b/crates/ceres-core/src/error.rs
@@ -159,6 +159,20 @@ pub enum AppError {
     #[error("Configuration error: {0}")]
     ConfigError(String),
 
+    /// Filesystem I/O error.
+    ///
+    /// This error wraps `std::io::Error` failures from reading or writing files,
+    /// typically in export paths (creating output directories, writing files).
+    #[error("I/O error: {0}")]
+    IoError(String),
+
+    /// Data export error.
+    ///
+    /// This error covers failures specific to the export pipeline that are not
+    /// plain I/O — e.g. Arrow/Parquet schema or serialization failures.
+    #[error("Export error: {0}")]
+    ExportError(String),
+
     /// Generic application error for cases not covered by specific variants.
     ///
     /// Use this sparingly - prefer creating specific error variants
@@ -332,6 +346,8 @@ impl AppError {
             | AppError::InvalidPortalUrl(_)
             | AppError::EmptyResponse
             | AppError::ConfigError(_)
+            | AppError::IoError(_)
+            | AppError::ExportError(_)
             | AppError::Generic(_) => false,
         }
     }

--- a/crates/ceres-core/src/export.rs
+++ b/crates/ceres-core/src/export.rs
@@ -102,13 +102,13 @@ where
                     let dataset = result?;
                     let record = create_export_record(&dataset);
                     let json = serde_json::to_string(&record)
-                        .map_err(|e| AppError::Generic(e.to_string()))?;
-                    writeln!(writer, "{}", json).map_err(|e| AppError::Generic(e.to_string()))?;
+                        .map_err(|e| AppError::ExportError(e.to_string()))?;
+                    writeln!(writer, "{}", json).map_err(|e| AppError::IoError(e.to_string()))?;
                     count += 1;
                 }
             }
             ExportFormat::Json => {
-                writeln!(writer, "[").map_err(|e| AppError::Generic(e.to_string()))?;
+                writeln!(writer, "[").map_err(|e| AppError::IoError(e.to_string()))?;
                 let mut first = true;
 
                 while let Some(result) = stream.next().await {
@@ -116,28 +116,28 @@ where
                     let record = create_export_record(&dataset);
 
                     if !first {
-                        writeln!(writer, ",").map_err(|e| AppError::Generic(e.to_string()))?;
+                        writeln!(writer, ",").map_err(|e| AppError::IoError(e.to_string()))?;
                     }
                     first = false;
 
                     let json = serde_json::to_string_pretty(&record)
-                        .map_err(|e| AppError::Generic(e.to_string()))?;
+                        .map_err(|e| AppError::ExportError(e.to_string()))?;
                     // Indent each line for proper formatting
                     for line in json.lines() {
                         writeln!(writer, "  {}", line)
-                            .map_err(|e| AppError::Generic(e.to_string()))?;
+                            .map_err(|e| AppError::IoError(e.to_string()))?;
                     }
                     count += 1;
                 }
 
-                writeln!(writer, "]").map_err(|e| AppError::Generic(e.to_string()))?;
+                writeln!(writer, "]").map_err(|e| AppError::IoError(e.to_string()))?;
             }
             ExportFormat::Csv => {
                 writeln!(
                     writer,
                     "id,original_id,source_portal,url,title,description,first_seen_at,last_updated_at"
                 )
-                .map_err(|e| AppError::Generic(e.to_string()))?;
+                .map_err(|e| AppError::IoError(e.to_string()))?;
 
                 while let Some(result) = stream.next().await {
                     let dataset = result?;
@@ -149,7 +149,7 @@ where
 
         writer
             .flush()
-            .map_err(|e| AppError::Generic(e.to_string()))?;
+            .map_err(|e| AppError::IoError(e.to_string()))?;
         Ok(count)
     }
 
@@ -184,12 +184,12 @@ where
                     let dataset = result?;
                     let record = create_export_record(&dataset);
                     let mut json = serde_json::to_string(&record)
-                        .map_err(|e| AppError::Generic(e.to_string()))?;
+                        .map_err(|e| AppError::ExportError(e.to_string()))?;
                     json.push('\n');
                     writer
                         .write_all(json.as_bytes())
                         .await
-                        .map_err(|e| AppError::Generic(e.to_string()))?;
+                        .map_err(|e| AppError::IoError(e.to_string()))?;
                     count += 1;
                 }
             }
@@ -197,7 +197,7 @@ where
                 writer
                     .write_all(b"[\n")
                     .await
-                    .map_err(|e| AppError::Generic(e.to_string()))?;
+                    .map_err(|e| AppError::IoError(e.to_string()))?;
                 let mut first = true;
 
                 while let Some(result) = stream.next().await {
@@ -208,18 +208,18 @@ where
                         writer
                             .write_all(b",\n")
                             .await
-                            .map_err(|e| AppError::Generic(e.to_string()))?;
+                            .map_err(|e| AppError::IoError(e.to_string()))?;
                     }
                     first = false;
 
                     let json = serde_json::to_string_pretty(&record)
-                        .map_err(|e| AppError::Generic(e.to_string()))?;
+                        .map_err(|e| AppError::ExportError(e.to_string()))?;
                     // Indent each line for proper formatting
                     for line in json.lines() {
                         writer
                             .write_all(format!("  {}\n", line).as_bytes())
                             .await
-                            .map_err(|e| AppError::Generic(e.to_string()))?;
+                            .map_err(|e| AppError::IoError(e.to_string()))?;
                     }
                     count += 1;
                 }
@@ -227,7 +227,7 @@ where
                 writer
                     .write_all(b"]\n")
                     .await
-                    .map_err(|e| AppError::Generic(e.to_string()))?;
+                    .map_err(|e| AppError::IoError(e.to_string()))?;
             }
             ExportFormat::Csv => {
                 writer
@@ -235,7 +235,7 @@ where
                         b"id,original_id,source_portal,url,title,description,first_seen_at,last_updated_at\n",
                     )
                     .await
-                    .map_err(|e| AppError::Generic(e.to_string()))?;
+                    .map_err(|e| AppError::IoError(e.to_string()))?;
 
                 while let Some(result) = stream.next().await {
                     let dataset = result?;
@@ -243,7 +243,7 @@ where
                     writer
                         .write_all(row.as_bytes())
                         .await
-                        .map_err(|e| AppError::Generic(e.to_string()))?;
+                        .map_err(|e| AppError::IoError(e.to_string()))?;
                     count += 1;
                 }
             }
@@ -252,7 +252,7 @@ where
         writer
             .flush()
             .await
-            .map_err(|e| AppError::Generic(e.to_string()))?;
+            .map_err(|e| AppError::IoError(e.to_string()))?;
         Ok(count)
     }
 }
@@ -289,7 +289,7 @@ fn write_csv_row<W: Write>(writer: &mut W, dataset: &Dataset) -> Result<(), AppE
     let row = format_csv_row(dataset);
     writer
         .write_all(row.as_bytes())
-        .map_err(|e| AppError::Generic(e.to_string()))?;
+        .map_err(|e| AppError::IoError(e.to_string()))?;
     Ok(())
 }
 

--- a/crates/ceres-core/src/harvest.rs
+++ b/crates/ceres-core/src/harvest.rs
@@ -191,6 +191,29 @@ impl<PD: Send> SyncPlan<PD> {
 /// let stats = harvest_service.sync_portal("https://data.gov/api/3").await?;
 /// println!("Synced {} datasets ({} created)", stats.total(), stats.created);
 /// ```
+/// Data parameters for a single portal sync.
+///
+/// Groups the descriptive inputs that flow together through the sync pipeline so
+/// the internal sync method does not need a long positional argument list. The
+/// cross-cutting `reporter` and `cancel_token` are passed separately, not here.
+#[derive(Debug, Clone, Copy)]
+pub struct SyncOptions<'a> {
+    /// The portal API URL to synchronize.
+    pub portal_url: &'a str,
+    /// Optional URL template for building dataset page links.
+    pub url_template: Option<&'a str>,
+    /// Preferred language for localized metadata (e.g. `"en"`).
+    pub language: &'a str,
+    /// Force a full sync instead of an incremental one.
+    pub force_full_sync: bool,
+    /// The portal protocol (CKAN, DCAT, ...).
+    pub portal_type: PortalType,
+    /// Optional DCAT profile selector (e.g. `"sparql"`).
+    pub profile: Option<&'a str>,
+    /// Optional SPARQL endpoint override for SPARQL-backed DCAT portals.
+    pub sparql_endpoint: Option<&'a str>,
+}
+
 pub struct HarvestService<S, F, D = ContentHashDetector>
 where
     S: DatasetStore,
@@ -338,15 +361,17 @@ where
     ) -> Result<SyncStats, AppError> {
         let result = self
             .sync_portal_with_progress_cancellable_internal(
-                portal_url,
-                url_template,
-                language,
+                SyncOptions {
+                    portal_url,
+                    url_template,
+                    language,
+                    force_full_sync: self.config.force_full_sync,
+                    portal_type,
+                    profile,
+                    sparql_endpoint,
+                },
                 reporter,
                 CancellationToken::new(), // never cancelled
-                self.config.force_full_sync,
-                portal_type,
-                profile,
-                sparql_endpoint,
             )
             .await?;
         Ok(result.stats)
@@ -476,15 +501,17 @@ where
         cancel_token: CancellationToken,
     ) -> Result<SyncResult, AppError> {
         self.sync_portal_with_progress_cancellable_internal(
-            portal_url,
-            None,
-            "en",
+            SyncOptions {
+                portal_url,
+                url_template: None,
+                language: "en",
+                force_full_sync: self.config.force_full_sync,
+                portal_type: PortalType::default(),
+                profile: None,
+                sparql_endpoint: None,
+            },
             &SilentReporter,
             cancel_token,
-            self.config.force_full_sync,
-            PortalType::default(),
-            None,
-            None,
         )
         .await
     }
@@ -503,15 +530,17 @@ where
         sparql_endpoint: Option<&str>,
     ) -> Result<SyncResult, AppError> {
         self.sync_portal_with_progress_cancellable_internal(
-            portal_url,
-            url_template,
-            language,
+            SyncOptions {
+                portal_url,
+                url_template,
+                language,
+                force_full_sync: self.config.force_full_sync,
+                portal_type,
+                profile,
+                sparql_endpoint,
+            },
             reporter,
             cancel_token,
-            self.config.force_full_sync,
-            portal_type,
-            profile,
-            sparql_endpoint,
         )
         .await
     }
@@ -533,32 +562,37 @@ where
     ) -> Result<SyncResult, AppError> {
         let force_full_sync = self.config.force_full_sync || force_full_sync;
         self.sync_portal_with_progress_cancellable_internal(
-            portal_url,
-            url_template,
-            language,
+            SyncOptions {
+                portal_url,
+                url_template,
+                language,
+                force_full_sync,
+                portal_type,
+                profile,
+                sparql_endpoint,
+            },
             reporter,
             cancel_token,
-            force_full_sync,
-            portal_type,
-            profile,
-            sparql_endpoint,
         )
         .await
     }
 
-    #[allow(clippy::too_many_arguments)]
     async fn sync_portal_with_progress_cancellable_internal<R: ProgressReporter>(
         &self,
-        portal_url: &str,
-        url_template: Option<&str>,
-        language: &str,
+        options: SyncOptions<'_>,
         reporter: &R,
         cancel_token: CancellationToken,
-        force_full_sync: bool,
-        portal_type: PortalType,
-        profile: Option<&str>,
-        sparql_endpoint: Option<&str>,
     ) -> Result<SyncResult, AppError> {
+        let SyncOptions {
+            portal_url,
+            url_template,
+            language,
+            force_full_sync,
+            portal_type,
+            profile,
+            sparql_endpoint,
+        } = options;
+
         let sync_start = Utc::now();
 
         // Check cancellation before starting

--- a/crates/ceres-core/src/harvest.rs
+++ b/crates/ceres-core/src/harvest.rs
@@ -168,29 +168,6 @@ impl<PD: Send> SyncPlan<PD> {
     }
 }
 
-/// Service for harvesting dataset metadata from open data portals.
-///
-/// This service handles metadata fetching, delta detection, and persistence.
-/// Embedding generation is handled separately by [`EmbeddingService`](crate::embedding::EmbeddingService).
-///
-/// # Type Parameters
-///
-/// * `S` - Dataset store implementation (e.g., `DatasetRepository`)
-/// * `F` - Portal client factory implementation
-/// * `D` - Delta detector strategy (defaults to [`ContentHashDetector`])
-///
-/// # Example
-///
-/// ```ignore
-/// use ceres_core::harvest::HarvestService;
-///
-/// // Create service — no embedding provider needed
-/// let harvest_service = HarvestService::new(repo, ckan_factory);
-///
-/// // Sync a portal (metadata only, embedding = NULL)
-/// let stats = harvest_service.sync_portal("https://data.gov/api/3").await?;
-/// println!("Synced {} datasets ({} created)", stats.total(), stats.created);
-/// ```
 /// Data parameters for a single portal sync.
 ///
 /// Groups the descriptive inputs that flow together through the sync pipeline so
@@ -214,6 +191,29 @@ pub struct SyncOptions<'a> {
     pub sparql_endpoint: Option<&'a str>,
 }
 
+/// Service for harvesting dataset metadata from open data portals.
+///
+/// This service handles metadata fetching, delta detection, and persistence.
+/// Embedding generation is handled separately by [`EmbeddingService`](crate::embedding::EmbeddingService).
+///
+/// # Type Parameters
+///
+/// * `S` - Dataset store implementation (e.g., `DatasetRepository`)
+/// * `F` - Portal client factory implementation
+/// * `D` - Delta detector strategy (defaults to [`ContentHashDetector`])
+///
+/// # Example
+///
+/// ```ignore
+/// use ceres_core::harvest::HarvestService;
+///
+/// // Create service — no embedding provider needed
+/// let harvest_service = HarvestService::new(repo, ckan_factory);
+///
+/// // Sync a portal (metadata only, embedding = NULL)
+/// let stats = harvest_service.sync_portal("https://data.gov/api/3").await?;
+/// println!("Synced {} datasets ({} created)", stats.total(), stats.created);
+/// ```
 pub struct HarvestService<S, F, D = ContentHashDetector>
 where
     S: DatasetStore,

--- a/crates/ceres-core/src/lib.rs
+++ b/crates/ceres-core/src/lib.rs
@@ -91,7 +91,7 @@ pub use traits::{DatasetStore, EmbeddingProvider, PortalClient, PortalClientFact
 // Services (generic over trait implementations)
 pub use embedding::{EmbeddingService, EmbeddingStats};
 pub use export::{ExportFormat, ExportService};
-pub use harvest::HarvestService;
+pub use harvest::{HarvestService, SyncOptions};
 pub use parquet_export::{ParquetExportConfig, ParquetExportResult, ParquetExportService};
 pub use pipeline::HarvestPipeline;
 pub use search::SearchService;

--- a/crates/ceres-core/src/parquet_export.rs
+++ b/crates/ceres-core/src/parquet_export.rs
@@ -132,7 +132,7 @@ impl<S: DatasetStore> ParquetExportService<S> {
         // Create directory structure
         let data_dir = output_dir.join("data");
         fs::create_dir_all(&data_dir).map_err(|e| {
-            AppError::Generic(format!(
+            AppError::IoError(format!(
                 "Failed to create output directory {}: {}",
                 data_dir.display(),
                 e
@@ -164,9 +164,9 @@ impl<S: DatasetStore> ParquetExportService<S> {
         // Write metadata.json
         let metadata_path = output_dir.join("metadata.json");
         let metadata_json = serde_json::to_string_pretty(&result)
-            .map_err(|e| AppError::Generic(format!("Failed to serialize metadata: {}", e)))?;
+            .map_err(|e| AppError::ExportError(format!("Failed to serialize metadata: {}", e)))?;
         fs::write(&metadata_path, metadata_json).map_err(|e| {
-            AppError::Generic(format!(
+            AppError::IoError(format!(
                 "Failed to write {}: {}",
                 metadata_path.display(),
                 e
@@ -192,11 +192,12 @@ impl<S: DatasetStore> ParquetExportService<S> {
         // Open the "all" writer
         let all_path = output_dir.join("all.parquet");
         let all_file = fs::File::create(&all_path).map_err(|e| {
-            AppError::Generic(format!("Failed to create {}: {}", all_path.display(), e))
+            AppError::IoError(format!("Failed to create {}: {}", all_path.display(), e))
         })?;
         let mut all_writer =
-            ArrowWriter::try_new(all_file, schema.clone(), Some(writer_props.clone()))
-                .map_err(|e| AppError::Generic(format!("Failed to create ArrowWriter: {}", e)))?;
+            ArrowWriter::try_new(all_file, schema.clone(), Some(writer_props.clone())).map_err(
+                |e| AppError::ExportError(format!("Failed to create ArrowWriter: {}", e)),
+            )?;
 
         // Per-portal state keyed by normalized source_portal URL (stable, unique)
         let mut portal_writers: HashMap<String, ArrowWriter<fs::File>> = HashMap::new();
@@ -268,7 +269,7 @@ impl<S: DatasetStore> ParquetExportService<S> {
                 let batch = build_record_batch(&all_buffer, &schema)?;
                 all_writer
                     .write(&batch)
-                    .map_err(|e| AppError::Generic(format!("Parquet write error: {}", e)))?;
+                    .map_err(|e| AppError::ExportError(format!("Parquet write error: {}", e)))?;
                 all_buffer.clear();
             }
 
@@ -291,7 +292,7 @@ impl<S: DatasetStore> ParquetExportService<S> {
                 )?;
                 writer
                     .write(&batch)
-                    .map_err(|e| AppError::Generic(format!("Parquet write error: {}", e)))?;
+                    .map_err(|e| AppError::ExportError(format!("Parquet write error: {}", e)))?;
             }
         }
 
@@ -300,7 +301,7 @@ impl<S: DatasetStore> ParquetExportService<S> {
             let batch = build_record_batch(&all_buffer, &schema)?;
             all_writer
                 .write(&batch)
-                .map_err(|e| AppError::Generic(format!("Parquet write error: {}", e)))?;
+                .map_err(|e| AppError::ExportError(format!("Parquet write error: {}", e)))?;
         }
 
         // Flush remaining portal buffers
@@ -318,19 +319,19 @@ impl<S: DatasetStore> ParquetExportService<S> {
                 )?;
                 writer
                     .write(&batch)
-                    .map_err(|e| AppError::Generic(format!("Parquet write error: {}", e)))?;
+                    .map_err(|e| AppError::ExportError(format!("Parquet write error: {}", e)))?;
             }
         }
 
         // Close all writers
         all_writer
             .close()
-            .map_err(|e| AppError::Generic(format!("Failed to close all.parquet: {}", e)))?;
+            .map_err(|e| AppError::ExportError(format!("Failed to close all.parquet: {}", e)))?;
 
         for (portal_key, writer) in portal_writers {
             let (_, ref fname) = portal_info[&portal_key];
             writer.close().map_err(|e| {
-                AppError::Generic(format!("Failed to close {}.parquet: {}", fname, e))
+                AppError::ExportError(format!("Failed to close {}.parquet: {}", fname, e))
             })?;
         }
 
@@ -516,7 +517,7 @@ fn build_record_batch(
             Arc::new(is_duplicate.finish()),
         ],
     )
-    .map_err(|e| AppError::Generic(format!("Failed to build RecordBatch: {}", e)))
+    .map_err(|e| AppError::ExportError(format!("Failed to build RecordBatch: {}", e)))
 }
 
 // =============================================================================
@@ -538,10 +539,10 @@ fn get_or_create_portal_writer<'a>(
     if !writers.contains_key(portal_key) {
         let path = data_dir.join(format!("{}.parquet", file_name));
         let file = fs::File::create(&path).map_err(|e| {
-            AppError::Generic(format!("Failed to create {}: {}", path.display(), e))
+            AppError::IoError(format!("Failed to create {}: {}", path.display(), e))
         })?;
         let writer = ArrowWriter::try_new(file, schema.clone(), Some(writer_props.clone()))
-            .map_err(|e| AppError::Generic(format!("Failed to create ArrowWriter: {}", e)))?;
+            .map_err(|e| AppError::ExportError(format!("Failed to create ArrowWriter: {}", e)))?;
         writers.insert(portal_key.to_string(), writer);
     }
     Ok(writers

--- a/crates/ceres-db/src/repository.rs
+++ b/crates/ceres-db/src/repository.rs
@@ -364,20 +364,57 @@ impl DatasetRepository {
     }
 
     /// Semantic search using cosine similarity. Returns results ordered by similarity.
+    ///
+    /// HNSW tuning: the query runs inside a transaction so we can apply `SET LOCAL`
+    /// session GUCs that only affect this search:
+    /// - `hnsw.ef_search` (default 40, override via `CERES_HNSW_EF_SEARCH`) trades
+    ///   recall against latency — higher means better recall, slower queries.
+    /// - `hnsw.iterative_scan = relaxed_order` lets pgvector (>= 0.8) keep scanning the
+    ///   index when the `NOT is_stale` filter discards rows post-retrieval, so we still
+    ///   return up to `limit` results instead of fewer.
     pub async fn search(
         &self,
         query_vector: Vec<f32>,
         limit: usize,
     ) -> Result<Vec<SearchResult>, AppError> {
         let pg_vector = Vector::from(query_vector);
+        let ef_search: i32 = std::env::var("CERES_HNSW_EF_SEARCH")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(40);
+
         let query = format!(
             "SELECT {}, 1 - (embedding <=> $1) as similarity_score FROM datasets WHERE embedding IS NOT NULL AND NOT is_stale ORDER BY embedding <=> $1 LIMIT $2",
             DATASET_COLUMNS
         );
+
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+        // SET LOCAL applies only for the duration of this transaction. ef_search must be
+        // set with a literal (GUCs can't be parameterized), so it is clamped to a sane
+        // range to keep the interpolation injection-safe.
+        let ef_search = ef_search.clamp(1, 1000);
+        sqlx::query(&format!("SET LOCAL hnsw.ef_search = {ef_search}"))
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+        sqlx::query("SET LOCAL hnsw.iterative_scan = relaxed_order")
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
         let results = sqlx::query_as::<_, SearchResultRow>(&query)
             .bind(pg_vector)
             .bind(limit as i64)
-            .fetch_all(&self.pool)
+            .fetch_all(&mut *tx)
+            .await
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+        tx.commit()
             .await
             .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
@@ -520,6 +557,38 @@ impl DatasetRepository {
         .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
         Ok(result)
+    }
+
+    /// Fetches sync status for many portals in a single query.
+    ///
+    /// Avoids the N+1 round-trips of calling [`Self::get_sync_status`] per portal
+    /// (e.g. in the `list_portals` handler). Returns a map keyed by portal URL;
+    /// portals with no recorded status are simply absent from the map.
+    pub async fn get_sync_status_batch(
+        &self,
+        portal_urls: &[&str],
+    ) -> Result<HashMap<String, PortalSyncStatus>, AppError> {
+        if portal_urls.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let urls: Vec<String> = portal_urls.iter().map(|u| u.to_string()).collect();
+        let rows = sqlx::query_as::<_, PortalSyncStatus>(
+            r#"
+            SELECT portal_url, last_successful_sync, last_sync_mode, sync_status, datasets_synced, created_at, updated_at
+            FROM portal_sync_status
+            WHERE portal_url = ANY($1)
+            "#,
+        )
+        .bind(&urls)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+        Ok(rows
+            .into_iter()
+            .map(|s| (s.portal_url.clone(), s))
+            .collect())
     }
 
     /// Updates or inserts the sync status for a portal.

--- a/crates/ceres-server/src/handlers/portals.rs
+++ b/crates/ceres-server/src/handlers/portals.rs
@@ -31,29 +31,29 @@ pub async fn list_portals(
         return Ok(Json(vec![]));
     };
 
-    let mut portals = Vec::new();
+    // Single batched query for all portals (avoids N+1 round-trips, #108).
+    // DB errors now propagate as a 500 instead of being silently flattened away.
+    let urls: Vec<&str> = config.portals.iter().map(|p| p.url.as_str()).collect();
+    let mut sync_statuses = state.dataset_repo.get_sync_status_batch(&urls).await?;
 
-    for portal in &config.portals {
-        // TODO(correctness): .ok().flatten() silences DB errors — log or propagate (#108)
-        let sync_status = state
-            .dataset_repo
-            .get_sync_status(&portal.url)
-            .await
-            .ok()
-            .flatten();
-
-        portals.push(PortalInfoResponse {
-            name: portal.name.clone(),
-            url: portal.url.clone(),
-            portal_type: portal.portal_type.to_string(),
-            profile: portal.profile.clone(),
-            sparql_endpoint: portal.sparql_endpoint.clone(),
-            enabled: portal.enabled,
-            description: portal.description.clone(),
-            last_sync: sync_status.as_ref().and_then(|s| s.last_successful_sync),
-            dataset_count: sync_status.map(|s| s.datasets_synced as i64),
-        });
-    }
+    let portals = config
+        .portals
+        .iter()
+        .map(|portal| {
+            let sync_status = sync_statuses.remove(&portal.url);
+            PortalInfoResponse {
+                name: portal.name.clone(),
+                url: portal.url.clone(),
+                portal_type: portal.portal_type.to_string(),
+                profile: portal.profile.clone(),
+                sparql_endpoint: portal.sparql_endpoint.clone(),
+                enabled: portal.enabled,
+                description: portal.description.clone(),
+                last_sync: sync_status.as_ref().and_then(|s| s.last_successful_sync),
+                dataset_count: sync_status.map(|s| s.datasets_synced as i64),
+            }
+        })
+        .collect();
 
     Ok(Json(portals))
 }

--- a/deny.toml
+++ b/deny.toml
@@ -74,7 +74,6 @@ ignore = [
     #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
-    "RUSTSEC-2025-0134",
     { id = "RUSTSEC-2024-0436", reason = "paste is a transitive dep of parquet/arrow, no security risk, just unmaintained by dtolnay" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.

--- a/migrations/202511290001_init.sql
+++ b/migrations/202511290001_init.sql
@@ -44,4 +44,7 @@ CREATE TABLE IF NOT EXISTS datasets (
 --   SET LOCAL hnsw.ef_search = 40;  -- or higher for better precision
 -- This should be done per-transaction in the search service
 -- to balance precision vs speed dynamically.
-CREATE INDEX ON datasets USING hnsw (embedding vector_cosine_ops);
+-- Named index with IF NOT EXISTS to prevent duplicate anonymous indexes when
+-- this migration is re-applied on dev resets (see migration 202605210001).
+CREATE INDEX IF NOT EXISTS idx_datasets_embedding_hnsw
+    ON datasets USING hnsw (embedding vector_cosine_ops);

--- a/migrations/202605210001_hnsw_tuning.sql
+++ b/migrations/202605210001_hnsw_tuning.sql
@@ -1,0 +1,48 @@
+--- HNSW index dedup + tuning for production scale ---
+--
+-- Context: inspection of the production DB (1.79M datasets, ~362k embeddings)
+-- found THREE duplicate HNSW indexes on datasets.embedding — datasets_embedding_idx,
+-- datasets_embedding_idx1, datasets_embedding_idx2 — ~3.8 GB wasted, all with default
+-- parameters and 0 scans. Root cause: the original migration used an unnamed
+-- `CREATE INDEX ON datasets USING hnsw (...)` (no name, no IF NOT EXISTS), so each
+-- re-application produced a new anonymous index (_idx, _idx1, _idx2).
+--
+-- This migration consolidates them into a single, explicitly-named, tuned index.
+--
+-- IMPORTANT — execution model:
+--   Migrations are applied by the Makefile `migrate` target via `psql -f` WITHOUT
+--   --single-transaction, so each statement autocommits. This is what allows
+--   CREATE/DROP INDEX CONCURRENTLY (which cannot run inside a transaction block).
+--   Do NOT wrap this file in BEGIN/COMMIT.
+--
+-- Memory: HNSW build for 362k × 768d vectors needs ~1.3 GB. The container defaults
+--   (maintenance_work_mem=64MB) force a slow, low-quality on-disk build. We raise it
+--   for this session only. See compose.yml notes for persistent production values.
+--
+-- Shared memory: parallel index builds allocate Postgres shared-memory segments in
+--   /dev/shm, which defaults to 64 MB in the Docker container — far too small, causing
+--   "could not resize shared memory segment ... No space left on device". We therefore
+--   build SERIALLY (max_parallel_maintenance_workers = 0); maintenance_work_mem lives in
+--   private backend memory and spills to disk (ample free space), so it is safe to raise.
+--   To re-enable parallel builds, raise /dev/shm via `shm_size` in compose.yml first.
+
+-- Raise build memory for the index creation in THIS session only (resets on disconnect).
+SET maintenance_work_mem = '1GB';
+SET max_parallel_maintenance_workers = 0;
+
+-- Drop the duplicate anonymous indexes if present (existing production DBs).
+DROP INDEX CONCURRENTLY IF EXISTS datasets_embedding_idx2;
+DROP INDEX CONCURRENTLY IF EXISTS datasets_embedding_idx1;
+DROP INDEX CONCURRENTLY IF EXISTS datasets_embedding_idx;
+
+-- Drop any pre-existing default-parameter named index so we can rebuild it tuned.
+-- (On fresh installs init.sql creates idx_datasets_embedding_hnsw with default params.)
+DROP INDEX CONCURRENTLY IF EXISTS idx_datasets_embedding_hnsw;
+
+-- Recreate a single tuned HNSW index.
+--   m = 16              -> graph connectivity (recall vs memory/build time)
+--   ef_construction = 64 -> index build quality
+-- CONCURRENTLY avoids an exclusive table lock so harvesting/search keep working.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_datasets_embedding_hnsw
+    ON datasets USING hnsw (embedding vector_cosine_ops)
+    WITH (m = 16, ef_construction = 64);

--- a/scripts/hnsw_benchmark.sql
+++ b/scripts/hnsw_benchmark.sql
@@ -29,8 +29,14 @@ WHERE embedding IS NOT NULL AND NOT is_stale
 ORDER BY id
 LIMIT 1;
 
+-- Each section runs inside an explicit transaction: psql is in autocommit mode,
+-- so a bare `SET LOCAL` would be committed on its own and never reach the
+-- following EXPLAIN. BEGIN/COMMIT keeps the SET LOCAL scoped to the query that
+-- uses it, which is exactly the per-search behavior the app relies on.
+
 \echo ''
 \echo '=== ef_search = 40 (default) ==='
+BEGIN;
 SET LOCAL hnsw.ef_search = 40;
 SET LOCAL hnsw.iterative_scan = relaxed_order;
 EXPLAIN (ANALYZE, BUFFERS, TIMING)
@@ -39,9 +45,11 @@ FROM datasets
 WHERE embedding IS NOT NULL AND NOT is_stale
 ORDER BY embedding <=> (SELECT v FROM _probe)
 LIMIT 10;
+COMMIT;
 
 \echo ''
 \echo '=== ef_search = 100 ==='
+BEGIN;
 SET LOCAL hnsw.ef_search = 100;
 SET LOCAL hnsw.iterative_scan = relaxed_order;
 EXPLAIN (ANALYZE, BUFFERS, TIMING)
@@ -50,9 +58,11 @@ FROM datasets
 WHERE embedding IS NOT NULL AND NOT is_stale
 ORDER BY embedding <=> (SELECT v FROM _probe)
 LIMIT 10;
+COMMIT;
 
 \echo ''
 \echo '=== ef_search = 200 ==='
+BEGIN;
 SET LOCAL hnsw.ef_search = 200;
 SET LOCAL hnsw.iterative_scan = relaxed_order;
 EXPLAIN (ANALYZE, BUFFERS, TIMING)
@@ -61,3 +71,4 @@ FROM datasets
 WHERE embedding IS NOT NULL AND NOT is_stale
 ORDER BY embedding <=> (SELECT v FROM _probe)
 LIMIT 10;
+COMMIT;

--- a/scripts/hnsw_benchmark.sql
+++ b/scripts/hnsw_benchmark.sql
@@ -10,6 +10,13 @@
 --
 -- Read the "Execution Time" line under each \echo header. Higher ef_search = better
 -- recall, higher latency. The app default is 40 (CERES_HNSW_EF_SEARCH).
+--
+-- Note: the first query is cold (loads ~1.2GB of index from disk; with a small
+-- shared_buffers it can take seconds). Run a warm-up query first for steady-state
+-- numbers. Reference run on the local catalog (~362k embeddings, 768d), warm cache:
+--   ef_search=40  -> ~1.1 ms
+--   ef_search=100 -> ~2.8 ms
+--   ef_search=200 -> ~3.5 ms
 
 \set ON_ERROR_STOP on
 \timing on

--- a/scripts/hnsw_benchmark.sql
+++ b/scripts/hnsw_benchmark.sql
@@ -1,0 +1,63 @@
+-- HNSW search benchmark — latency at varying hnsw.ef_search values.
+--
+-- Usage:
+--   PGPASSWORD=... psql -h localhost -p 5432 -U ceres_user -d ceres_db \
+--       -f scripts/hnsw_benchmark.sql
+--
+-- Picks a real embedding from the table as the probe vector (deterministic: the
+-- row with the smallest id that has an embedding), then runs the production search
+-- query under several ef_search settings, reporting planner timing via EXPLAIN ANALYZE.
+--
+-- Read the "Execution Time" line under each \echo header. Higher ef_search = better
+-- recall, higher latency. The app default is 40 (CERES_HNSW_EF_SEARCH).
+
+\set ON_ERROR_STOP on
+\timing on
+
+-- Confirm we are hitting the tuned index, not a sequential scan.
+\echo '=== index in use ==='
+SELECT indexname, indexdef
+FROM pg_indexes
+WHERE tablename = 'datasets' AND indexdef LIKE '%hnsw%';
+
+-- Capture a probe vector into a temp table (psql can't easily inline a 768-dim literal).
+DROP TABLE IF EXISTS _probe;
+CREATE TEMP TABLE _probe AS
+SELECT embedding AS v
+FROM datasets
+WHERE embedding IS NOT NULL AND NOT is_stale
+ORDER BY id
+LIMIT 1;
+
+\echo ''
+\echo '=== ef_search = 40 (default) ==='
+SET LOCAL hnsw.ef_search = 40;
+SET LOCAL hnsw.iterative_scan = relaxed_order;
+EXPLAIN (ANALYZE, BUFFERS, TIMING)
+SELECT id, 1 - (embedding <=> (SELECT v FROM _probe)) AS score
+FROM datasets
+WHERE embedding IS NOT NULL AND NOT is_stale
+ORDER BY embedding <=> (SELECT v FROM _probe)
+LIMIT 10;
+
+\echo ''
+\echo '=== ef_search = 100 ==='
+SET LOCAL hnsw.ef_search = 100;
+SET LOCAL hnsw.iterative_scan = relaxed_order;
+EXPLAIN (ANALYZE, BUFFERS, TIMING)
+SELECT id, 1 - (embedding <=> (SELECT v FROM _probe)) AS score
+FROM datasets
+WHERE embedding IS NOT NULL AND NOT is_stale
+ORDER BY embedding <=> (SELECT v FROM _probe)
+LIMIT 10;
+
+\echo ''
+\echo '=== ef_search = 200 ==='
+SET LOCAL hnsw.ef_search = 200;
+SET LOCAL hnsw.iterative_scan = relaxed_order;
+EXPLAIN (ANALYZE, BUFFERS, TIMING)
+SELECT id, 1 - (embedding <=> (SELECT v FROM _probe)) AS score
+FROM datasets
+WHERE embedding IS NOT NULL AND NOT is_stale
+ORDER BY embedding <=> (SELECT v FROM _probe)
+LIMIT 10;

--- a/website/src/content/docs/HARVESTING.md
+++ b/website/src/content/docs/HARVESTING.md
@@ -13,6 +13,7 @@ Today the shipping portal clients cover:
 
 - CKAN portals
 - DCAT-AP portals that expose the udata REST JSON-LD catalog
+- SPARQL-backed DCAT catalogs (via `--profile sparql`, e.g. `data.europa.eu`)
 
 ## Core pipeline
 
@@ -160,6 +161,7 @@ The exact harvest behavior depends on the portal client:
 
 - CKAN clients can use modified-since filters and adaptive page sizing
 - DCAT udata clients stream paginated JSON-LD catalog pages and resolve multilingual fields according to the configured language
+- SPARQL DCAT clients page through the catalog with `LIMIT`/`OFFSET` queries, deduplicate by dataset URI, and pick localized titles/descriptions by language preference (requested language > sibling language > English > untagged)
 
 ## Adaptive Page Size
 
@@ -182,4 +184,5 @@ This converges faster than halving and handles portals with resource-heavy datas
 - Circuit breaker: [`crates/ceres-core/src/circuit_breaker.rs`](../crates/ceres-core/src/circuit_breaker.rs)
 - CKAN client: [`crates/ceres-client/src/ckan.rs`](../crates/ceres-client/src/ckan.rs) (`search_modified_since`, adaptive page size)
 - DCAT client: [`crates/ceres-client/src/dcat.rs`](../crates/ceres-client/src/dcat.rs)
+- SPARQL DCAT client: [`crates/ceres-client/src/sparql.rs`](../crates/ceres-client/src/sparql.rs)
 - DB schema: [`migrations/`](../migrations/)

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -62,7 +62,7 @@ Ceres is designed around that order of work: harvest first, embed later if usefu
 <FeatureGrid>
   <div class="ceres-card animate-fade-in-up animate-delay-2">
     <h3>Harvest First</h3>
-    <p>Stream metadata from CKAN and DCAT udata portals into PostgreSQL, track sync history, detect stale datasets, and keep the catalog current even when embeddings are disabled.</p>
+    <p>Stream metadata from CKAN, DCAT udata, and SPARQL-backed DCAT portals into PostgreSQL, track sync history, detect stale datasets, and keep the catalog current even when embeddings are disabled.</p>
   </div>
   <div class="ceres-card animate-fade-in-up animate-delay-3">
     <h3>Decoupled Pipeline</h3>
@@ -110,11 +110,11 @@ Ceres is designed around that order of work: harvest first, embed later if usefu
 
 <FeatureGrid>
   <div class="ceres-card animate-fade-in-up">
-    <h3>Now (v0.3.5)</h3>
-    <p>Harvest-first sync pipeline, CKAN plus DCAT udata support, standalone embedding passes, local Ollama support, job-driven API operations, and export flows for downstream publishing.</p>
+    <h3>Now (v0.4.0)</h3>
+    <p>Performance at scale and ecosystem consolidation: tuned HNSW vector index, dynamic <code>ef_search</code>, SPARQL-backed DCAT harvesting (e.g. data.europa.eu), more resilient batch embedding under provider failures, and internal refactors for maintainability.</p>
   </div>
   <div class="ceres-card animate-fade-in-up">
-    <h3>Next (v0.4.0)</h3>
-    <p>Scale and ecosystem tuning: HNSW optimization, more portal client coverage, stronger multi-tenant operations, and better downstream dataset publishing ergonomics.</p>
+    <h3>Next (v0.5.0)</h3>
+    <p>Broader portal coverage (Socrata), multi-tenant operations, webhooks, and a Parquet export endpoint on the REST API.</p>
   </div>
 </FeatureGrid>


### PR DESCRIPTION
## Summary

0.4.0: HNSW performance tuning and technical-debt consolidation. Defers Socrata, multi-tenancy, and webhooks to 0.5.0.

## Changes

**HNSW (Closes #92)**
- Migration to drop 3 duplicate HNSW indexes (default params, unused) and rebuild a single named index with `m=16, ef_construction=64`. `init.sql` now names the index with `IF NOT EXISTS` to prevent recurrence.
- Per-search `SET LOCAL hnsw.ef_search` (env `CERES_HNSW_EF_SEARCH`, default 40) and `iterative_scan=relaxed_order`.
- `compose.yml` memory/`shm_size` tuning; `scripts/hnsw_benchmark.sql`.

**Embedding resilience**
- Batches deferred by an open circuit breaker now wait for recovery and retry (bounded), instead of ending the pass. Affected datasets remain pending.

**SPARQL incremental sync**
- `search_modified_since` now allows `!BOUND(?modified)`, so datasets without `dct:modified` are no longer excluded from incremental sync.

**Consolidation**
- `AppError::IoError` / `ExportError`, replacing `Generic` in export paths (Closes #105).
- `SyncOptions` struct replacing positional args in the internal sync method (Closes #107).
- `get_sync_status_batch` removes the N+1 lookup in `list_portals` (Closes #108).

**Docs**: README and website updated for SPARQL support and roadmap. Version bumped to 0.4.0.

## Verification

- `cargo clippy --workspace`: clean. `cargo deny check`: passing. Tests: ceres-core 135, ceres-client 135, green.
- HNSW index rebuilt on the local catalog (~362k embeddings): single valid index, table 13GB → 10GB. Warm-cache `ef_search` latency: 40 → ~1.1ms, 100 → ~2.8ms, 200 → ~3.5ms.
