### PR TITLE
feat(api): expose dataset resource schema (#68)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ Thumbs.db
 .env.local
 .env.*.local
 .claude/
+.codex/
 .ceres-harvest-runs/
 
 # Database

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# Ceres contributor guide
+
+## Project map
+
+- `crates/ceres-core`: domain models, harvesting pipeline, configuration, and traits.
+- `crates/ceres-client`: CKAN, DCAT, and SPARQL portal clients.
+- `crates/ceres-db`: PostgreSQL/pgvector persistence.
+- `crates/ceres-server`: Axum HTTP API and OpenAPI definitions.
+- `crates/ceres-cli`: command-line entry point.
+- `migrations/`: ordered PostgreSQL migrations.
+- `website/`: Astro documentation site.
+
+## Working conventions
+
+- Rust edition is 2024; keep formatting compatible with `cargo fmt --all`.
+- Do not commit `.env`, generated harvest output, `target/`, or local agent state.
+- Preserve full portal metadata when adding harvest paths: API features such as resource-schema extraction depend on it.
+- Treat portal language as a display preference, not a reason to omit datasets, unless a caller explicitly requests filtering.
+- Keep network smoke tests ignored or opt-in; unit tests must be deterministic and offline.
+
+## Validation
+
+Run the smallest relevant checks first, then the workspace checks when practical:
+
+```powershell
+cargo fmt --all -- --check
+cargo test -p ceres-client -p ceres-core
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+Database and server integration tests use Testcontainers and require a running Docker daemon. The local stack can be started with `docker compose up -d`.

--- a/README.md
+++ b/README.md
@@ -232,13 +232,6 @@ ceres harvest --portal milano --full-sync
 ceres harvest --portal milano --dry-run --metadata-only
 ```
 
-For the EU Open Data Portal, `language` chooses the preferred title and
-description stored for display; it does not filter the harvest. Datasets whose
-metadata is available only in another language are retained, with a stable
-fallback title. The SPARQL keyset path also stores DCAT distribution metadata
-used by `GET /api/v1/datasets/{id}/schema`. Re-harvest existing EU datasets to
-populate that metadata.
-
 ### Embed
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -177,6 +177,20 @@ enabled = false
 
 See `examples/portals.toml` for a larger configuration set.
 
+### Harvest resilience / HTTP tuning
+
+Harvesting is hardened for slow or rate-limiting portals: the CKAN client grows
+its per-request timeout (and shrinks the page size) when a page times out, and
+the DCAT client waits out `429` rate limits with an escalating per-page cooldown
+instead of stopping with partial results. You can tune the HTTP behavior with
+environment variables (defaults shown):
+
+```bash
+CERES_HTTP_TIMEOUT_SECS=60     # base per-request timeout (raise for very slow portals)
+CERES_HTTP_MAX_RETRIES=3       # transient-error retry attempts
+CERES_HTTP_RETRY_BASE_MS=500   # base backoff delay
+```
+
 ## Usage
 
 ### Harvest

--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ Available endpoints:
 - `GET /api/v1/portals/{name}/stats`
 - `GET /api/v1/harvest/status`
 - `GET /api/v1/datasets/{id}`
+- `GET /api/v1/datasets/{id}/schema`
 - `POST /api/v1/portals/{name}/harvest`
 - `POST /api/v1/harvest`
 - `GET /api/v1/export`

--- a/README.md
+++ b/README.md
@@ -232,6 +232,13 @@ ceres harvest --portal milano --full-sync
 ceres harvest --portal milano --dry-run --metadata-only
 ```
 
+For the EU Open Data Portal, `language` chooses the preferred title and
+description stored for display; it does not filter the harvest. Datasets whose
+metadata is available only in another language are retained, with a stable
+fallback title. The SPARQL keyset path also stores DCAT distribution metadata
+used by `GET /api/v1/datasets/{id}/schema`. Re-harvest existing EU datasets to
+populate that metadata.
+
 ### Embed
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -191,6 +191,20 @@ CERES_HTTP_MAX_RETRIES=3       # transient-error retry attempts
 CERES_HTTP_RETRY_BASE_MS=500   # base backoff delay
 ```
 
+### US data.gov
+
+`catalog.data.gov` no longer serves the `/api/3/action` CKAN API; it relocated to
+`api.gsa.gov` and requires an API key. To harvest it, set `DATA_GOV_API_KEY`
+(get a free key at <https://api.data.gov/signup/>):
+
+```bash
+DATA_GOV_API_KEY=your-api-data-gov-key
+ceres harvest https://catalog.data.gov --type ckan --metadata-only
+```
+
+Datasets are still attributed to `catalog.data.gov`. Without the key, data.gov
+requests return `403`.
+
 ## Usage
 
 ### Harvest

--- a/crates/ceres-client/src/ckan.rs
+++ b/crates/ceres-client/src/ckan.rs
@@ -227,8 +227,16 @@ impl CkanClient {
     ) -> Result<Self, AppError> {
         let base_url = Url::parse(landing_base_str)
             .map_err(|_| AppError::InvalidPortalUrl(landing_base_str.to_string()))?;
-        let action_base = Url::parse(action_base_str)
-            .map_err(|_| AppError::InvalidPortalUrl(action_base_str.to_string()))?;
+        // `Url::join` drops the last path segment unless the base ends in '/', so
+        // normalize a missing trailing slash rather than silently building the
+        // wrong endpoint (e.g. ".../action" + "package_search" -> ".../package_search").
+        let action_base_str = if action_base_str.ends_with('/') {
+            action_base_str.to_string()
+        } else {
+            format!("{action_base_str}/")
+        };
+        let action_base = Url::parse(&action_base_str)
+            .map_err(|_| AppError::InvalidPortalUrl(action_base_str.clone()))?;
         Self::build(base_url, action_base, api_key)
     }
 
@@ -262,6 +270,37 @@ impl CkanClient {
             url.query_pairs_mut().append_pair("api_key", key);
         }
         Ok(url)
+    }
+
+    /// Returns `url` as a string with any `api_key` query value redacted, so the
+    /// data.gov API key never leaks into error messages, logs, or telemetry.
+    fn redacted_url(url: &Url) -> String {
+        if !url.query_pairs().any(|(k, _)| k == "api_key") {
+            return url.to_string();
+        }
+        let mut out = url.clone();
+        out.set_query(None);
+        {
+            let mut qp = out.query_pairs_mut();
+            for (k, v) in url.query_pairs() {
+                if k == "api_key" {
+                    qp.append_pair("api_key", "REDACTED");
+                } else {
+                    qp.append_pair(k.as_ref(), v.as_ref());
+                }
+            }
+        }
+        out.to_string()
+    }
+
+    /// Removes the configured API key from an arbitrary error string. reqwest's
+    /// error `Display` can embed the request URL (including `?api_key=...`), so
+    /// any error text derived from it must be scrubbed before logging.
+    fn scrub(&self, s: String) -> String {
+        match &self.api_key {
+            Some(key) if !key.is_empty() => s.replace(key.as_str(), "REDACTED"),
+            _ => s,
+        }
     }
 
     /// Fetches the complete list of dataset IDs from the CKAN portal.
@@ -710,16 +749,17 @@ impl CkanClient {
                     return Err(AppError::ClientError(format!(
                         "HTTP {} from {}",
                         status.as_u16(),
-                        url
+                        Self::redacted_url(url)
                     )));
                 }
                 Err(e) => {
                     if e.is_timeout() {
-                        last_error = AppError::Timeout(http_config.timeout.as_secs());
+                        last_error = AppError::Timeout(request_timeout.as_secs());
                     } else if e.is_connect() {
-                        last_error = AppError::NetworkError(format!("Connection failed: {}", e));
+                        last_error =
+                            AppError::NetworkError(self.scrub(format!("Connection failed: {}", e)));
                     } else {
-                        last_error = AppError::ClientError(e.to_string());
+                        last_error = AppError::ClientError(self.scrub(e.to_string()));
                     }
 
                     if attempt < max_retries && (e.is_timeout() || e.is_connect()) {
@@ -866,6 +906,50 @@ mod tests {
         );
         // No API key by default
         assert!(url.query().is_none());
+    }
+
+    #[test]
+    fn test_redacted_url_hides_api_key() {
+        let url = Url::parse(
+            "https://api.gsa.gov/technology/datagov/v3/action/package_search?rows=1000&api_key=SECRET123&start=0",
+        )
+        .unwrap();
+        let red = CkanClient::redacted_url(&url);
+        assert!(!red.contains("SECRET123"), "api key leaked: {red}");
+        assert!(red.contains("api_key=REDACTED"));
+        assert!(red.contains("rows=1000") && red.contains("start=0"));
+        // A URL with no api_key is returned unchanged.
+        let plain = Url::parse("https://dati.gov.it/api/3/action/package_search?rows=10").unwrap();
+        assert_eq!(CkanClient::redacted_url(&plain), plain.to_string());
+    }
+
+    #[test]
+    fn test_scrub_removes_api_key_from_error_text() {
+        let client = CkanClient::new_with_api_base(
+            "https://catalog.data.gov",
+            "https://api.gsa.gov/technology/datagov/v3/action/",
+            Some("TOPSECRET".to_string()),
+        )
+        .unwrap();
+        let msg = client.scrub(
+            "error sending request for url (https://api.gsa.gov/...?api_key=TOPSECRET): timed out"
+                .to_string(),
+        );
+        assert!(!msg.contains("TOPSECRET"), "scrub failed: {msg}");
+        assert!(msg.contains("REDACTED"));
+    }
+
+    #[test]
+    fn test_new_with_api_base_normalizes_missing_trailing_slash() {
+        // Action base WITHOUT trailing slash must still build correct endpoints.
+        let client = CkanClient::new_with_api_base(
+            "https://catalog.data.gov",
+            "https://api.gsa.gov/technology/datagov/v3/action",
+            None,
+        )
+        .unwrap();
+        let url = client.action_endpoint("package_search").unwrap();
+        assert_eq!(url.path(), "/technology/datagov/v3/action/package_search");
     }
 
     #[test]

--- a/crates/ceres-client/src/ckan.rs
+++ b/crates/ceres-client/src/ckan.rs
@@ -118,7 +118,16 @@ pub struct CkanDataset {
 #[derive(Clone)]
 pub struct CkanClient {
     client: Client,
+    /// Portal identity / landing-page base (e.g. `https://catalog.data.gov`).
+    /// Used for `base_url()` and constructing dataset landing URLs.
     base_url: Url,
+    /// Base URL under which the CKAN action endpoints live, ending in `.../action/`
+    /// (e.g. `https://example.org/api/3/action/`). Usually derived from `base_url`,
+    /// but can differ when the action API is hosted elsewhere (e.g. data.gov's API
+    /// moved to `https://api.gsa.gov/technology/datagov/v3/action/`).
+    action_base: Url,
+    /// Optional API key appended to every action request (e.g. data.gov via api.gsa.gov).
+    api_key: Option<String>,
 }
 
 impl CkanClient {
@@ -179,6 +188,35 @@ impl CkanClient {
         let base_url = Url::parse(base_url_str)
             .map_err(|_| AppError::InvalidPortalUrl(base_url_str.to_string()))?;
 
+        let action_base = base_url
+            .join("api/3/action/")
+            .map_err(|e| AppError::Generic(e.to_string()))?;
+        Self::build(base_url, action_base, None)
+    }
+
+    /// Creates a CKAN client whose action API lives at a different base URL and
+    /// requires an API key, while still presenting `landing_base` as the portal
+    /// identity (source portal / landing URLs).
+    ///
+    /// This is how US data.gov is harvested: its CKAN action API relocated to
+    /// `https://api.gsa.gov/technology/datagov/v3/action/` and now requires an
+    /// `api_key`, but datasets should still be attributed to `catalog.data.gov`.
+    ///
+    /// `action_base_str` must end in `/` so action names join correctly.
+    pub fn new_with_api_base(
+        landing_base_str: &str,
+        action_base_str: &str,
+        api_key: Option<String>,
+    ) -> Result<Self, AppError> {
+        let base_url = Url::parse(landing_base_str)
+            .map_err(|_| AppError::InvalidPortalUrl(landing_base_str.to_string()))?;
+        let action_base = Url::parse(action_base_str)
+            .map_err(|_| AppError::InvalidPortalUrl(action_base_str.to_string()))?;
+        Self::build(base_url, action_base, api_key)
+    }
+
+    /// Shared constructor: builds the HTTP client and assembles the struct.
+    fn build(base_url: Url, action_base: Url, api_key: Option<String>) -> Result<Self, AppError> {
         let client = Client::builder()
             // TODO(config): Make User-Agent configurable or use version from Cargo.toml
             .user_agent("Ceres/0.1 (semantic-search-bot)")
@@ -188,7 +226,25 @@ impl CkanClient {
             .build()
             .map_err(|e| AppError::ClientError(e.to_string()))?;
 
-        Ok(Self { client, base_url })
+        Ok(Self {
+            client,
+            base_url,
+            action_base,
+            api_key,
+        })
+    }
+
+    /// Builds the URL for a CKAN action endpoint (e.g. `package_search`),
+    /// appending the API key when configured.
+    fn action_endpoint(&self, action: &str) -> Result<Url, AppError> {
+        let mut url = self
+            .action_base
+            .join(action)
+            .map_err(|e| AppError::Generic(e.to_string()))?;
+        if let Some(key) = &self.api_key {
+            url.query_pairs_mut().append_pair("api_key", key);
+        }
+        Ok(url)
     }
 
     /// Fetches the complete list of dataset IDs from the CKAN portal.
@@ -212,10 +268,7 @@ impl CkanClient {
     /// Consider: `list_package_ids_paginated(limit: usize, offset: usize)`
     /// Or streaming: `list_package_ids_stream() -> impl Stream<Item = ...>`
     pub async fn list_package_ids(&self) -> Result<Vec<String>, AppError> {
-        let url = self
-            .base_url
-            .join("api/3/action/package_list")
-            .map_err(|e| AppError::Generic(e.to_string()))?;
+        let url = self.action_endpoint("package_list")?;
 
         let resp = self
             .request_with_retry(&url, HttpConfig::from_env().timeout)
@@ -248,10 +301,7 @@ impl CkanClient {
     ///
     /// A `CkanDataset` containing the dataset's metadata.
     pub async fn show_package(&self, id: &str) -> Result<CkanDataset, AppError> {
-        let mut url = self
-            .base_url
-            .join("api/3/action/package_show")
-            .map_err(|e| AppError::Generic(e.to_string()))?;
+        let mut url = self.action_endpoint("package_show")?;
 
         url.query_pairs_mut().append_pair("id", id);
 
@@ -506,10 +556,7 @@ impl CkanClient {
         page_delay: &mut Duration,
         request_timeout: Duration,
     ) -> Result<(Vec<CkanDataset>, usize), AppError> {
-        let mut url = self
-            .base_url
-            .join("api/3/action/package_search")
-            .map_err(|e| AppError::Generic(e.to_string()))?;
+        let mut url = self.action_endpoint("package_search")?;
 
         {
             let mut pairs = url.query_pairs_mut();
@@ -779,6 +826,36 @@ mod tests {
         } else {
             panic!("Expected AppError::InvalidPortalUrl");
         }
+    }
+
+    #[test]
+    fn test_default_action_endpoint() {
+        let client = CkanClient::new("https://dati.gov.it").unwrap();
+        let url = client.action_endpoint("package_list").unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://dati.gov.it/api/3/action/package_list"
+        );
+        // No API key by default
+        assert!(url.query().is_none());
+    }
+
+    #[test]
+    fn test_data_gov_action_endpoint_uses_api_base_and_key() {
+        let client = CkanClient::new_with_api_base(
+            "https://catalog.data.gov",
+            "https://api.gsa.gov/technology/datagov/v3/action/",
+            Some("SECRET".to_string()),
+        )
+        .unwrap();
+
+        // Portal identity stays catalog.data.gov (for source_portal / landing URLs)
+        assert_eq!(client.base_url.as_str(), "https://catalog.data.gov/");
+
+        let url = client.action_endpoint("package_search").unwrap();
+        assert_eq!(url.host_str(), Some("api.gsa.gov"));
+        assert_eq!(url.path(), "/technology/datagov/v3/action/package_search");
+        assert_eq!(url.query(), Some("api_key=SECRET"));
     }
 
     #[test]

--- a/crates/ceres-client/src/ckan.rs
+++ b/crates/ceres-client/src/ckan.rs
@@ -204,6 +204,7 @@ impl CkanClient {
     pub fn new(base_url_str: &str) -> Result<Self, AppError> {
         let base_url = Url::parse(base_url_str)
             .map_err(|_| AppError::InvalidPortalUrl(base_url_str.to_string()))?;
+        let base_url = ensure_trailing_slash(base_url);
 
         let action_base = base_url
             .join("api/3/action/")
@@ -227,6 +228,7 @@ impl CkanClient {
     ) -> Result<Self, AppError> {
         let base_url = Url::parse(landing_base_str)
             .map_err(|_| AppError::InvalidPortalUrl(landing_base_str.to_string()))?;
+        let base_url = ensure_trailing_slash(base_url);
         // `Url::join` drops the last path segment unless the base ends in '/', so
         // normalize a missing trailing slash rather than silently building the
         // wrong endpoint (e.g. ".../action" + "package_search" -> ".../package_search").
@@ -872,6 +874,16 @@ impl CkanClient {
     }
 }
 
+/// Adds a trailing slash to a URL path before it is used as a `Url::join` base.
+/// Without it, `Url::join` treats the final path segment as a file and drops it
+/// (for example, `/ckan` would incorrectly become `/api/3/action/`).
+fn ensure_trailing_slash(mut url: Url) -> Url {
+    if !url.path().ends_with('/') {
+        url.set_path(&format!("{}/", url.path()));
+    }
+    url
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -906,6 +918,14 @@ mod tests {
         );
         // No API key by default
         assert!(url.query().is_none());
+    }
+
+    #[test]
+    fn test_default_action_endpoint_preserves_portal_path() {
+        let client = CkanClient::new("https://opendata.aragon.es/ckan").unwrap();
+        let url = client.action_endpoint("package_search").unwrap();
+        assert_eq!(client.base_url.as_str(), "https://opendata.aragon.es/ckan/");
+        assert_eq!(url.path(), "/ckan/api/3/action/package_search");
     }
 
     #[test]

--- a/crates/ceres-client/src/ckan.rs
+++ b/crates/ceres-client/src/ckan.rs
@@ -163,8 +163,19 @@ impl CkanClient {
     /// Timeouts and body-related errors suggest the response is too large for
     /// the portal to serve reliably. Network errors during body streaming also
     /// qualify since a smaller page means less data to transfer.
+    ///
+    /// JSON decode errors (`error decoding response body`) are included because
+    /// large/flaky portals — e.g. api.gsa.gov (data.gov) — intermittently return
+    /// truncated or partial bodies on big pages; a smaller page usually succeeds.
+    /// Reduction is bounded (down to `MIN_PAGE_SIZE`, then the page is abandoned),
+    /// so a genuinely broken portal still fails in finite time rather than looping.
     fn is_page_size_reducible(err: &AppError) -> bool {
-        matches!(err, AppError::Timeout(_) | AppError::NetworkError(_))
+        match err {
+            AppError::Timeout(_) | AppError::NetworkError(_) => true,
+            // reqwest surfaces truncated/partial JSON as "error decoding response body".
+            AppError::ClientError(msg) => msg.to_ascii_lowercase().contains("decod"),
+            _ => false,
+        }
     }
 
     /// Creates a new CKAN client for the specified portal.
@@ -1052,8 +1063,17 @@ mod tests {
     }
 
     #[test]
-    fn test_is_page_size_reducible_client_error() {
+    fn test_is_page_size_reducible_decode_error() {
+        // Truncated/partial JSON bodies (e.g. api.gsa.gov on big pages) should be
+        // retried at a smaller page size, not treated as fatal.
         let err = AppError::ClientError("error decoding response body".to_string());
+        assert!(CkanClient::is_page_size_reducible(&err));
+    }
+
+    #[test]
+    fn test_is_page_size_reducible_http_status_error_not_reducible() {
+        // A real HTTP status error (e.g. 404) must NOT trigger page-size reduction.
+        let err = AppError::ClientError("HTTP 404 from https://example.org".to_string());
         assert!(!CkanClient::is_page_size_reducible(&err));
     }
 

--- a/crates/ceres-client/src/ckan.rs
+++ b/crates/ceres-client/src/ckan.rs
@@ -141,6 +141,14 @@ impl CkanClient {
     /// handle any realistic dataset size while still making progress.
     const MIN_PAGE_SIZE: usize = 10;
 
+    /// Hard ceiling for the adaptive per-request timeout.
+    ///
+    /// When a page times out the harvest both shrinks the page size *and* grows
+    /// the per-request timeout (slow-but-healthy portals like govdata.de can take
+    /// well over a minute to serve a single page). The growth is capped here so a
+    /// genuinely dead portal still fails in bounded time.
+    const MAX_PAGE_TIMEOUT: Duration = Duration::from_secs(300);
+
     /// Errors worth retrying with a smaller page size.
     ///
     /// Timeouts and body-related errors suggest the response is too large for
@@ -171,11 +179,12 @@ impl CkanClient {
         let base_url = Url::parse(base_url_str)
             .map_err(|_| AppError::InvalidPortalUrl(base_url_str.to_string()))?;
 
-        let http_config = HttpConfig::default();
         let client = Client::builder()
             // TODO(config): Make User-Agent configurable or use version from Cargo.toml
             .user_agent("Ceres/0.1 (semantic-search-bot)")
-            .timeout(http_config.timeout)
+            // Client-level timeout is the hard ceiling; each request sets its own
+            // (adaptive) timeout via `.timeout()`, which overrides this per-request.
+            .timeout(Self::MAX_PAGE_TIMEOUT)
             .build()
             .map_err(|e| AppError::ClientError(e.to_string()))?;
 
@@ -208,7 +217,9 @@ impl CkanClient {
             .join("api/3/action/package_list")
             .map_err(|e| AppError::Generic(e.to_string()))?;
 
-        let resp = self.request_with_retry(&url).await?;
+        let resp = self
+            .request_with_retry(&url, HttpConfig::from_env().timeout)
+            .await?;
 
         let ckan_resp: CkanResponse<Vec<String>> = resp
             .json()
@@ -244,7 +255,9 @@ impl CkanClient {
 
         url.query_pairs_mut().append_pair("id", id);
 
-        let resp = self.request_with_retry(&url).await?;
+        let resp = self
+            .request_with_retry(&url, HttpConfig::from_env().timeout)
+            .await?;
 
         let ckan_resp: CkanResponse<CkanDataset> = resp
             .json()
@@ -315,10 +328,11 @@ impl CkanClient {
         let mut all_datasets = Vec::new();
         let mut start: usize = 0;
         let mut page_delay = Self::PAGE_DELAY;
+        let mut page_timeout = HttpConfig::from_env().timeout;
 
         loop {
             match self
-                .fetch_search_page(fq, start, page_size, &mut page_delay)
+                .fetch_search_page(fq, start, page_size, &mut page_delay, page_timeout)
                 .await
             {
                 Ok((datasets, total_count)) => {
@@ -336,12 +350,16 @@ impl CkanClient {
                     // Timeout or truncated response — quarter the page size and
                     // retry the same offset. Quartering converges faster than
                     // halving (1000→250→62→15→10 vs 1000→500→250→125→62→31→15→10).
+                    // Also grow the per-request timeout: a slow-but-healthy portal
+                    // needs more time per page, not just fewer rows.
                     page_size = (page_size / 4).max(Self::MIN_PAGE_SIZE);
+                    page_timeout = (page_timeout * 2).min(Self::MAX_PAGE_TIMEOUT);
                     tracing::warn!(
                         new_page_size = page_size,
+                        new_timeout_secs = page_timeout.as_secs(),
                         offset = start,
                         error = %e,
-                        "Page failed, reducing page size and retrying"
+                        "Page failed, reducing page size and growing timeout, retrying"
                     );
                     continue;
                 }
@@ -377,6 +395,7 @@ impl CkanClient {
             start: usize,
             page_size: usize,
             page_delay: Duration,
+            page_timeout: Duration,
             done: bool,
             fq: Option<String>,
         }
@@ -385,6 +404,7 @@ impl CkanClient {
             start: 0,
             page_size: 1000,
             page_delay: Self::PAGE_DELAY,
+            page_timeout: HttpConfig::from_env().timeout,
             done: false,
             fq,
         };
@@ -403,6 +423,7 @@ impl CkanClient {
                             state.start,
                             state.page_size,
                             &mut state.page_delay,
+                            state.page_timeout,
                         )
                         .await
                     {
@@ -429,11 +450,14 @@ impl CkanClient {
                                 && Self::is_page_size_reducible(&e) =>
                         {
                             state.page_size = (state.page_size / 4).max(Self::MIN_PAGE_SIZE);
+                            state.page_timeout =
+                                (state.page_timeout * 2).min(Self::MAX_PAGE_TIMEOUT);
                             tracing::warn!(
                                 new_page_size = state.page_size,
+                                new_timeout_secs = state.page_timeout.as_secs(),
                                 offset = state.start,
                                 error = %e,
-                                "Page failed, reducing page size and retrying"
+                                "Page failed, reducing page size and growing timeout, retrying"
                             );
                             continue; // retry same offset with smaller page
                         }
@@ -460,7 +484,10 @@ impl CkanClient {
     /// Returns the total dataset count from a lightweight `rows=0` query.
     pub async fn dataset_count(&self) -> Result<usize, AppError> {
         let mut page_delay = Self::PAGE_DELAY;
-        let (_, total) = self.fetch_search_page(None, 0, 0, &mut page_delay).await?;
+        let timeout = HttpConfig::from_env().timeout;
+        let (_, total) = self
+            .fetch_search_page(None, 0, 0, &mut page_delay, timeout)
+            .await?;
         Ok(total)
     }
 
@@ -468,12 +495,16 @@ impl CkanClient {
     ///
     /// Returns `(datasets, total_count)` where `total_count` is the total number
     /// of matching datasets reported by CKAN (for pagination control).
+    ///
+    /// `request_timeout` is the per-request timeout; callers grow it adaptively
+    /// alongside shrinking the page size when a portal is slow.
     async fn fetch_search_page(
         &self,
         fq: Option<&str>,
         start: usize,
         page_size: usize,
         page_delay: &mut Duration,
+        request_timeout: Duration,
     ) -> Result<(Vec<CkanDataset>, usize), AppError> {
         let mut url = self
             .base_url
@@ -495,7 +526,7 @@ impl CkanClient {
         // low-level retries, wait a longer cooldown and try the page again.
         let mut page_result = None;
         for page_attempt in 0..=Self::PAGE_RATE_LIMIT_RETRIES {
-            match self.request_with_retry(&url).await {
+            match self.request_with_retry(&url, request_timeout).await {
                 Ok(resp) => {
                     page_result = Some(Ok(resp));
                     break;
@@ -542,8 +573,12 @@ impl CkanClient {
     // TODO(observability): Add detailed retry logging
     // Should log: (1) Attempt number and delay, (2) Reason for retry,
     // (3) Final error if all retries exhausted. Use tracing crate.
-    async fn request_with_retry(&self, url: &Url) -> Result<reqwest::Response, AppError> {
-        let http_config = HttpConfig::default();
+    async fn request_with_retry(
+        &self,
+        url: &Url,
+        request_timeout: Duration,
+    ) -> Result<reqwest::Response, AppError> {
+        let http_config = HttpConfig::from_env();
         let max_retries = http_config.max_retries;
         let base_delay = http_config.retry_base_delay;
         let mut last_error = AppError::Generic("No attempts made".to_string());
@@ -551,7 +586,13 @@ impl CkanClient {
         let effective_max = Self::RATE_LIMIT_MAX_RETRIES.max(max_retries);
 
         for attempt in 1..=effective_max {
-            match self.client.get(url.clone()).send().await {
+            match self
+                .client
+                .get(url.clone())
+                .timeout(request_timeout)
+                .send()
+                .await
+            {
                 Ok(resp) => {
                     let status = resp.status();
 

--- a/crates/ceres-client/src/ckan.rs
+++ b/crates/ceres-client/src/ckan.rs
@@ -150,6 +150,12 @@ impl CkanClient {
     /// handle any realistic dataset size while still making progress.
     const MIN_PAGE_SIZE: usize = 10;
 
+    /// Default (and maximum) page size. Pagination starts here, drops on errors,
+    /// and recovers back toward this after successful pages so a single transient
+    /// truncation doesn't pin a large portal at a tiny page size for the rest of
+    /// the harvest.
+    const DEFAULT_PAGE_SIZE: usize = 1000;
+
     /// Hard ceiling for the adaptive per-request timeout.
     ///
     /// When a page times out the harvest both shrinks the page size *and* grows
@@ -385,7 +391,7 @@ impl CkanClient {
     ///
     /// * `fq` - Optional Solr filter query (e.g., `metadata_modified:[... TO *]`)
     async fn paginated_search(&self, fq: Option<&str>) -> Result<Vec<CkanDataset>, AppError> {
-        let mut page_size: usize = 1000;
+        let mut page_size: usize = Self::DEFAULT_PAGE_SIZE;
         let mut all_datasets = Vec::new();
         let mut start: usize = 0;
         let mut page_delay = Self::PAGE_DELAY;
@@ -406,6 +412,10 @@ impl CkanClient {
                     }
 
                     start += page_size;
+                    // Recover page size toward the default after a good page.
+                    if page_size < Self::DEFAULT_PAGE_SIZE {
+                        page_size = (page_size * 2).min(Self::DEFAULT_PAGE_SIZE);
+                    }
                 }
                 Err(e) if page_size > Self::MIN_PAGE_SIZE && Self::is_page_size_reducible(&e) => {
                     // Timeout or truncated response — quarter the page size and
@@ -463,7 +473,7 @@ impl CkanClient {
 
         let initial = PaginationState {
             start: 0,
-            page_size: 1000,
+            page_size: Self::DEFAULT_PAGE_SIZE,
             page_delay: Self::PAGE_DELAY,
             page_timeout: HttpConfig::from_env().timeout,
             done: false,
@@ -497,6 +507,13 @@ impl CkanClient {
                                 state.done = true;
                             } else {
                                 state.start += state.page_size;
+                                // Recover page size toward the default after a good
+                                // page, so a transient truncation doesn't pin a large
+                                // portal at a tiny page size for the rest of the harvest.
+                                if state.page_size < Self::DEFAULT_PAGE_SIZE {
+                                    state.page_size =
+                                        (state.page_size * 2).min(Self::DEFAULT_PAGE_SIZE);
+                                }
                             }
 
                             // Sleep between pages (skipped for last page)

--- a/crates/ceres-client/src/dcat.rs
+++ b/crates/ceres-client/src/dcat.rs
@@ -374,12 +374,13 @@ impl DcatClient {
     /// times. This keeps large udata catalogs (e.g. dados.gov.pt) from bailing
     /// out with only partial results the moment the portal throttles us.
     async fn fetch_graph_with_cooldown(&self, url: &Url) -> Result<Vec<Value>, AppError> {
-        for attempt in 0..=PAGE_RATE_LIMIT_RETRIES {
+        // Up to PAGE_RATE_LIMIT_RETRIES cooldown waits on a 429, then one final attempt.
+        for attempt in 1..=PAGE_RATE_LIMIT_RETRIES {
             match self.fetch_graph(url).await {
-                Err(AppError::RateLimitExceeded) if attempt < PAGE_RATE_LIMIT_RETRIES => {
-                    let cooldown = PAGE_RATE_LIMIT_COOLDOWN * (attempt + 1);
+                Err(AppError::RateLimitExceeded) => {
+                    let cooldown = PAGE_RATE_LIMIT_COOLDOWN * attempt;
                     tracing::warn!(
-                        attempt = attempt + 1,
+                        attempt,
                         cooldown_secs = cooldown.as_secs(),
                         url = %url,
                         "DCAT page rate-limited; cooling down before retrying same page"
@@ -389,7 +390,7 @@ impl DcatClient {
                 other => return other,
             }
         }
-        Err(AppError::RateLimitExceeded)
+        self.fetch_graph(url).await
     }
 
     /// HTTP GET with exponential backoff retry on transient errors and rate limits.

--- a/crates/ceres-client/src/dcat.rs
+++ b/crates/ceres-client/src/dcat.rs
@@ -43,6 +43,15 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(90);
 /// Maximum backoff delay for rate-limited retries.
 const MAX_RETRY_DELAY: Duration = Duration::from_secs(30);
 
+/// Cooldown when a catalog page is rate-limited after exhausting the low-level
+/// per-request retries. The pagination loop waits this long (scaled by attempt)
+/// before retrying the *same* page, instead of abandoning the harvest with only
+/// partial results. Mirrors the CKAN client's page-level rate-limit handling.
+const PAGE_RATE_LIMIT_COOLDOWN: Duration = Duration::from_secs(60);
+
+/// Maximum number of page-level retries when a catalog page is rate-limited.
+const PAGE_RATE_LIMIT_RETRIES: u32 = 3;
+
 /// Portal-specific dataset data parsed from a DCAT-AP JSON-LD `@graph` node.
 #[derive(Debug, Clone)]
 pub struct DcatDataset {
@@ -195,7 +204,7 @@ impl DcatClient {
         while let Some(url) = next_url {
             page += 1;
 
-            let graph = match self.fetch_graph(&url).await {
+            let graph = match self.fetch_graph_with_cooldown(&url).await {
                 Ok(g) => g,
                 Err(e) => {
                     // If we already collected datasets, return partial results
@@ -269,7 +278,7 @@ impl DcatClient {
                 let url = state.next_url.take()?;
                 state.page += 1;
 
-                let graph = match self.fetch_graph(&url).await {
+                let graph = match self.fetch_graph_with_cooldown(&url).await {
                     Ok(g) => g,
                     Err(e) => {
                         if state.page == 1 {
@@ -359,9 +368,33 @@ impl DcatClient {
         }
     }
 
+    /// Like [`fetch_graph`](Self::fetch_graph) but, on a persistent rate-limit
+    /// (`429`) after the low-level retries are exhausted, waits an escalating
+    /// cooldown and retries the *same* page up to [`PAGE_RATE_LIMIT_RETRIES`]
+    /// times. This keeps large udata catalogs (e.g. dados.gov.pt) from bailing
+    /// out with only partial results the moment the portal throttles us.
+    async fn fetch_graph_with_cooldown(&self, url: &Url) -> Result<Vec<Value>, AppError> {
+        for attempt in 0..=PAGE_RATE_LIMIT_RETRIES {
+            match self.fetch_graph(url).await {
+                Err(AppError::RateLimitExceeded) if attempt < PAGE_RATE_LIMIT_RETRIES => {
+                    let cooldown = PAGE_RATE_LIMIT_COOLDOWN * (attempt + 1);
+                    tracing::warn!(
+                        attempt = attempt + 1,
+                        cooldown_secs = cooldown.as_secs(),
+                        url = %url,
+                        "DCAT page rate-limited; cooling down before retrying same page"
+                    );
+                    sleep(cooldown).await;
+                }
+                other => return other,
+            }
+        }
+        Err(AppError::RateLimitExceeded)
+    }
+
     /// HTTP GET with exponential backoff retry on transient errors and rate limits.
     async fn request_with_retry(&self, url: &Url) -> Result<reqwest::Response, AppError> {
-        let http_config = HttpConfig::default();
+        let http_config = HttpConfig::from_env();
         let max_retries = http_config.max_retries;
         let base_delay = http_config.retry_base_delay;
         let mut last_error = AppError::Generic("No attempts made".to_string());

--- a/crates/ceres-client/src/portal.rs
+++ b/crates/ceres-client/src/portal.rs
@@ -181,6 +181,41 @@ impl PortalClientFactoryEnum {
     }
 }
 
+/// Action API base for US data.gov, whose CKAN action endpoints relocated off
+/// `catalog.data.gov` and now require an API key.
+const DATA_GOV_ACTION_BASE: &str = "https://api.gsa.gov/technology/datagov/v3/action/";
+
+/// Creates a CKAN client for `portal_url`, special-casing US data.gov.
+///
+/// `catalog.data.gov` no longer serves `/api/3/action/*` (it 404s); the action
+/// API moved to `api.gsa.gov` and requires an API key, read from the
+/// `DATA_GOV_API_KEY` environment variable. Datasets stay attributed to
+/// `catalog.data.gov`. All other portals use the standard CKAN client.
+fn ckan_client_for(portal_url: &str) -> Result<CkanClient, AppError> {
+    let is_data_gov = reqwest::Url::parse(portal_url)
+        .ok()
+        .and_then(|u| {
+            u.host_str()
+                .map(|h| h.eq_ignore_ascii_case("catalog.data.gov"))
+        })
+        .unwrap_or(false);
+
+    if is_data_gov {
+        let api_key = std::env::var("DATA_GOV_API_KEY")
+            .ok()
+            .filter(|k| !k.trim().is_empty());
+        if api_key.is_none() {
+            tracing::warn!(
+                "Harvesting catalog.data.gov without DATA_GOV_API_KEY set; \
+                 api.gsa.gov requires a key and requests will likely fail."
+            );
+        }
+        CkanClient::new_with_api_base(portal_url, DATA_GOV_ACTION_BASE, api_key)
+    } else {
+        CkanClient::new(portal_url)
+    }
+}
+
 impl PortalClientFactory for PortalClientFactoryEnum {
     type Client = PortalClientEnum;
 
@@ -193,7 +228,7 @@ impl PortalClientFactory for PortalClientFactoryEnum {
         sparql_endpoint: Option<&str>,
     ) -> Result<Self::Client, AppError> {
         match portal_type {
-            PortalType::Ckan => Ok(PortalClientEnum::Ckan(CkanClient::new(portal_url)?)),
+            PortalType::Ckan => Ok(PortalClientEnum::Ckan(ckan_client_for(portal_url)?)),
             PortalType::Dcat => match profile {
                 Some("sparql") => Ok(PortalClientEnum::SparqlDcat(SparqlDcatClient::new(
                     portal_url,

--- a/crates/ceres-client/src/sparql.rs
+++ b/crates/ceres-client/src/sparql.rs
@@ -73,10 +73,29 @@ const PARTITION_OVERFLOW_OFFSET: usize = 9_500;
 ///
 /// Registry pages contain full JSON-LD graphs, so this is deliberately smaller
 /// than the API's maximum limit.
+// Retained (superseded by the keyset paginator for EU) for its richer full
+// JSON-LD metadata, which the keyset path does not fetch. See `paginate_sparql_stream`.
+#[allow(dead_code)]
 const REGISTRY_PAGE_SIZE: usize = 100;
 
 /// Maximum number of Registry API pages retried before a catalogue is skipped.
+#[allow(dead_code)]
 const MAX_REGISTRY_PAGE_RETRIES: u32 = 3;
+
+/// Page size for keyset (seek) enumeration of dataset URIs.
+///
+/// The enumeration query (`SELECT ?dataset … ORDER BY ?dataset LIMIT N`) is
+/// lightweight (no joins/optionals), but `ORDER BY` over a ~2M-triple graph still
+/// takes ~10s at 5k and ~14s at 10k on data.europa.eu — well under the 60s
+/// gateway timeout, with headroom for slow moments.
+const ENUM_PAGE_SIZE: usize = 5000;
+
+/// Number of dataset URIs per `VALUES` metadata batch.
+///
+/// `VALUES`-bounded metadata queries are near-instant regardless of catalog size
+/// (the join touches only the listed datasets). 256 keeps the POST body modest
+/// while amortizing round-trips.
+const VALUES_BATCH_SIZE: usize = 256;
 
 // =============================================================================
 // SPARQL JSON Results Format (W3C standard)
@@ -116,6 +135,7 @@ enum PartitionRef<'a> {
     NoPublisher,
 }
 
+#[allow(dead_code)]
 struct RegistryPage {
     datasets: Vec<DcatDataset>,
     entries: usize,
@@ -311,7 +331,10 @@ impl SparqlDcatClient {
     /// modification time.
     pub fn paginate_sparql_stream(&self) -> BoxStream<'_, Result<Vec<DcatDataset>, AppError>> {
         if self.uses_data_europa_registry() {
-            return self.paginate_data_europa_registry_stream();
+            // data.europa.eu (~2M datasets) can't be fully paged by OFFSET (Virtuoso
+            // ~10k cap) or the Registry API (per-catalogue OFFSET + 503s), and its
+            // Search-API scroll is WAF-blocked. Use a keyset/seek cursor instead.
+            return self.paginate_sparql_keyset_stream();
         }
 
         struct PartitionState {
@@ -520,6 +543,7 @@ impl SparqlDcatClient {
     /// which collapses the publisher partitioning strategy into a single huge
     /// no-publisher partition. The Registry API exposes catalogue-scoped,
     /// paginated JSON-LD metadata, so we use it for this portal's full harvest.
+    #[allow(dead_code)] // superseded by the keyset paginator; kept for richer JSON-LD metadata
     fn paginate_data_europa_registry_stream(
         &self,
     ) -> BoxStream<'_, Result<Vec<DcatDataset>, AppError>> {
@@ -669,6 +693,184 @@ impl SparqlDcatClient {
         ))
     }
 
+    /// Streams the full catalog using a keyset (seek) cursor over dataset URIs,
+    /// then fetches metadata for each batch via `VALUES`.
+    ///
+    /// Phase 1 enumerates dataset URIs ordered by IRI, seeking strictly past the
+    /// last URI of the previous page (`FILTER(STR(?dataset) > "<cursor>")`) — this
+    /// avoids OFFSET entirely (no Virtuoso ~10k cap) and is independent of
+    /// `dct:publisher`, so it covers the whole graph. Phase 2 fetches
+    /// title/description/identifier/modified for each batch of URIs via a bounded
+    /// `VALUES` query (near-instant; the full-metadata keyset query times out).
+    ///
+    /// Note: this does not retrieve the full JSON-LD `@graph` (distributions etc.).
+    fn paginate_sparql_keyset_stream(&self) -> BoxStream<'_, Result<Vec<DcatDataset>, AppError>> {
+        struct KeysetState {
+            /// Last dataset URI seen (the seek cursor); empty before the first page.
+            cursor: String,
+            /// Enumerated URIs awaiting a metadata fetch.
+            pending: Vec<String>,
+            /// True once enumeration returned a short page (no more URIs).
+            enum_done: bool,
+            done: bool,
+            fetched: usize,
+        }
+
+        let initial = KeysetState {
+            cursor: String::new(),
+            pending: Vec::new(),
+            enum_done: false,
+            done: false,
+            fetched: 0,
+        };
+
+        Box::pin(futures::stream::unfold(
+            initial,
+            move |mut state| async move {
+                if state.done {
+                    return None;
+                }
+
+                // Refill the URI buffer via the keyset cursor when empty.
+                if state.pending.is_empty() {
+                    if state.enum_done {
+                        return None;
+                    }
+                    match self.fetch_keyset_page(&state.cursor).await {
+                        Ok(uris) => {
+                            if uris.len() < ENUM_PAGE_SIZE {
+                                state.enum_done = true;
+                            }
+                            let last = match uris.last() {
+                                Some(last) => last.clone(),
+                                None => return None,
+                            };
+                            state.cursor = last;
+                            tracing::info!(
+                                enumerated = uris.len(),
+                                total_fetched = state.fetched,
+                                "data.europa.eu keyset: enumerated next URI page"
+                            );
+                            state.pending = uris;
+                        }
+                        Err(e) => {
+                            state.done = true;
+                            return Some((Err(e), state));
+                        }
+                    }
+                }
+
+                // Fetch metadata for the next VALUES batch.
+                let take = state.pending.len().min(VALUES_BATCH_SIZE);
+                let batch: Vec<String> = state.pending.drain(..take).collect();
+                match self.fetch_values_metadata(&batch).await {
+                    Ok(datasets) => {
+                        state.fetched += datasets.len();
+                        sleep(PAGE_DELAY).await;
+                        Some((Ok(datasets), state))
+                    }
+                    Err(e) => {
+                        state.done = true;
+                        Some((Err(e), state))
+                    }
+                }
+            },
+        ))
+    }
+
+    /// Fetches one keyset page of dataset URIs ordered after `cursor`.
+    async fn fetch_keyset_page(&self, cursor: &str) -> Result<Vec<String>, AppError> {
+        let query = self.build_keyset_enum_query(cursor);
+        let bindings = self.execute_query_with_retry(&query).await?;
+        Ok(bindings
+            .into_iter()
+            .filter_map(|b| b.get("dataset").map(|v| v.value.clone()))
+            .collect())
+    }
+
+    /// Fetches metadata for a bounded set of dataset URIs via a `VALUES` query.
+    async fn fetch_values_metadata(&self, uris: &[String]) -> Result<Vec<DcatDataset>, AppError> {
+        if uris.is_empty() {
+            return Ok(Vec::new());
+        }
+        let query = self.build_values_metadata_query(uris);
+        let bindings = self.execute_query_with_retry(&query).await?;
+        Ok(self.bindings_to_datasets(bindings))
+    }
+
+    /// [`execute_query`](Self::execute_query) with bounded retry + exponential
+    /// backoff on transient server overload (500/502/503/504/timeout).
+    async fn execute_query_with_retry(
+        &self,
+        query: &str,
+    ) -> Result<Vec<HashMap<String, SparqlValue>>, AppError> {
+        let mut last_err = AppError::Generic("no attempts made".to_string());
+        for attempt in 0..=MAX_PAGE_RETRIES {
+            match self.execute_query(query).await {
+                Ok(b) => return Ok(b),
+                Err(e) => {
+                    last_err = e;
+                    if attempt < MAX_PAGE_RETRIES {
+                        let delay = PAGE_RETRY_BASE_DELAY * 2_u32.pow(attempt);
+                        tracing::warn!(
+                            attempt = attempt + 1,
+                            delay_secs = delay.as_secs(),
+                            error = %last_err,
+                            "SPARQL keyset query failed; retrying after backoff"
+                        );
+                        sleep(delay).await;
+                    }
+                }
+            }
+        }
+        Err(last_err)
+    }
+
+    /// Builds the keyset URI-enumeration query (seek strictly past `cursor`).
+    fn build_keyset_enum_query(&self, cursor: &str) -> String {
+        let cursor_esc = sparql_escape_literal(cursor);
+        format!(
+            "PREFIX dcat: <http://www.w3.org/ns/dcat#>\n\
+             SELECT ?dataset WHERE {{\n\
+               ?dataset a dcat:Dataset .\n\
+               FILTER(STR(?dataset) > \"{cursor_esc}\")\n\
+             }}\n\
+             ORDER BY ?dataset\n\
+             LIMIT {ENUM_PAGE_SIZE}"
+        )
+    }
+
+    /// Builds the bounded `VALUES` metadata query for a set of dataset URIs.
+    fn build_values_metadata_query(&self, uris: &[String]) -> String {
+        let title_filter = self
+            .lang_filter_alternatives()
+            .iter()
+            .map(|l| format!("lang(?title) = \"{l}\""))
+            .collect::<Vec<_>>()
+            .join(" || ");
+        let values = uris
+            .iter()
+            .filter(|u| is_safe_iri(u))
+            .map(|u| format!("<{u}>"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        format!(
+            "PREFIX dcat: <http://www.w3.org/ns/dcat#>\n\
+             PREFIX dct:  <http://purl.org/dc/terms/>\n\
+             \n\
+             SELECT ?dataset ?title ?description ?identifier ?modified\n\
+             WHERE {{\n\
+               VALUES ?dataset {{ {values} }}\n\
+               ?dataset dct:title ?title .\n\
+               FILTER ({title_filter})\n\
+               OPTIONAL {{ ?dataset dct:description ?description }}\n\
+               OPTIONAL {{ ?dataset dct:identifier ?identifier }}\n\
+               OPTIONAL {{ ?dataset dct:modified ?modified }}\n\
+             }}"
+        )
+    }
+
+    #[allow(dead_code)]
     async fn enumerate_registry_catalogues(&self) -> Result<Vec<String>, AppError> {
         let mut catalogues = Vec::new();
         let mut offset = 0usize;
@@ -701,6 +903,7 @@ impl SparqlDcatClient {
         Ok(catalogues)
     }
 
+    #[allow(dead_code)]
     async fn fetch_registry_catalogue_page(
         &self,
         catalogue: &str,
@@ -724,6 +927,7 @@ impl SparqlDcatClient {
         Ok(self.extract_registry_page(body))
     }
 
+    #[allow(dead_code)]
     fn registry_url(&self, segments: &[&str]) -> Result<Url, AppError> {
         let mut url = self.base_url.join("api/hub/repo/").map_err(|e| {
             AppError::Generic(format!("Failed to build data.europa.eu Registry URL: {e}"))
@@ -742,6 +946,7 @@ impl SparqlDcatClient {
         Ok(url)
     }
 
+    #[allow(dead_code)]
     fn extract_registry_page(&self, body: Value) -> RegistryPage {
         let Some(graph) = body.get("@graph").and_then(|v| v.as_array()) else {
             return RegistryPage {
@@ -1119,6 +1324,7 @@ impl SparqlDcatClient {
     }
 
     /// HTTP GET with exponential backoff retry for Registry API requests.
+    #[allow(dead_code)]
     async fn request_url_with_retry(&self, url: Url) -> Result<reqwest::Response, AppError> {
         let http_config = HttpConfig::from_env();
         let max_retries = http_config.max_retries;
@@ -1335,6 +1541,7 @@ fn is_server_overload(e: &AppError) -> bool {
         || msg.contains("timeout")
 }
 
+#[allow(dead_code)]
 fn is_hydra_view_node(node: &Value) -> bool {
     let Some(type_value) = node.get("@type") else {
         return false;
@@ -1352,6 +1559,26 @@ fn is_hydra_view_node(node: &Value) -> bool {
             .any(|v| v.as_str().map(is_view_type).unwrap_or(false)),
         _ => false,
     }
+}
+
+/// Escapes a string for safe inclusion inside a SPARQL double-quoted literal
+/// (used for the keyset cursor in `FILTER(STR(?dataset) > "…")`).
+fn sparql_escape_literal(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+}
+
+/// Returns `true` if `iri` is safe to embed inside `<…>` in a SPARQL query —
+/// an http(s) IRI with no delimiter/whitespace characters that could break the
+/// IRI ref or allow injection. Unsafe (malformed) IRIs are dropped from `VALUES`.
+fn is_safe_iri(iri: &str) -> bool {
+    (iri.starts_with("http://") || iri.starts_with("https://"))
+        && !iri.bytes().any(|b| {
+            matches!(b, b'<' | b'>' | b'"' | b'{' | b'}' | b'|' | b'^' | b'`' | b'\\')
+                || b.is_ascii_whitespace()
+        })
 }
 
 /// Extracts the last non-empty path segment from a URI.
@@ -1427,6 +1654,79 @@ mod tests {
             "https://data.europa.eu/dataset/5678"
         );
         assert!(second.get("description").is_none());
+    }
+
+    // ---- keyset cursor -----------------------------------------------------
+
+    #[test]
+    fn keyset_enum_query_uses_seek_not_offset() {
+        let client = SparqlDcatClient::new("https://data.europa.eu", "en", None).unwrap();
+        let q = client.build_keyset_enum_query("http://example.org/d/1");
+        assert!(q.contains("ORDER BY ?dataset"));
+        assert!(q.contains(r#"FILTER(STR(?dataset) > "http://example.org/d/1")"#));
+        assert!(q.contains(&format!("LIMIT {ENUM_PAGE_SIZE}")));
+        assert!(!q.contains("OFFSET"), "keyset must not use OFFSET");
+    }
+
+    #[test]
+    fn keyset_enum_query_first_page_seeks_from_empty() {
+        let client = SparqlDcatClient::new("https://data.europa.eu", "en", None).unwrap();
+        let q = client.build_keyset_enum_query("");
+        assert!(q.contains(r#"FILTER(STR(?dataset) > "")"#));
+    }
+
+    #[test]
+    fn keyset_cursor_is_escaped() {
+        let client = SparqlDcatClient::new("https://data.europa.eu", "en", None).unwrap();
+        // A pathological cursor with a quote/backslash must not break the literal.
+        let q = client.build_keyset_enum_query("http://x/\"a\\b");
+        assert!(q.contains(r#"> "http://x/\"a\\b""#));
+    }
+
+    #[test]
+    fn values_metadata_query_lists_uris_and_fields() {
+        let client = SparqlDcatClient::new("https://data.europa.eu", "en", None).unwrap();
+        let uris = vec![
+            "http://example.org/d/1".to_string(),
+            "https://example.org/d/2".to_string(),
+        ];
+        let q = client.build_values_metadata_query(&uris);
+        assert!(q.contains("VALUES ?dataset {"));
+        assert!(q.contains("<http://example.org/d/1>"));
+        assert!(q.contains("<https://example.org/d/2>"));
+        assert!(q.contains("dct:title ?title"));
+        assert!(q.contains(r#"lang(?title) = "en""#));
+        assert!(q.contains("OPTIONAL { ?dataset dct:description ?description }"));
+        assert!(!q.contains("OFFSET") && !q.contains("ORDER BY"));
+    }
+
+    #[test]
+    fn values_metadata_query_drops_unsafe_iris() {
+        let client = SparqlDcatClient::new("https://data.europa.eu", "en", None).unwrap();
+        let uris = vec![
+            "http://ok.example/d/1".to_string(),
+            "http://bad.example/d 2".to_string(), // space -> unsafe
+            "ftp://nope.example/d/3".to_string(), // non-http -> unsafe
+        ];
+        let q = client.build_values_metadata_query(&uris);
+        assert!(q.contains("<http://ok.example/d/1>"));
+        assert!(!q.contains("d 2"));
+        assert!(!q.contains("ftp://"));
+    }
+
+    #[test]
+    fn is_safe_iri_rules() {
+        assert!(is_safe_iri("https://data.europa.eu/dataset/abc"));
+        assert!(is_safe_iri("http://example.org/x"));
+        assert!(!is_safe_iri("http://x/with space"));
+        assert!(!is_safe_iri("http://x/with\"quote"));
+        assert!(!is_safe_iri("urn:uuid:1234"));
+        assert!(!is_safe_iri(""));
+    }
+
+    #[test]
+    fn sparql_escape_literal_escapes_specials() {
+        assert_eq!(sparql_escape_literal(r#"a"b\c"#), r#"a\"b\\c"#);
     }
 
     // ---- bindings_to_datasets ----------------------------------------------

--- a/crates/ceres-client/src/sparql.rs
+++ b/crates/ceres-client/src/sparql.rs
@@ -1039,7 +1039,7 @@ impl SparqlDcatClient {
 
     /// HTTP POST with exponential backoff retry on transient errors and rate limits.
     async fn request_with_retry(&self, query: &str) -> Result<reqwest::Response, AppError> {
-        let http_config = HttpConfig::default();
+        let http_config = HttpConfig::from_env();
         let max_retries = http_config.max_retries;
         let base_delay = http_config.retry_base_delay;
         let mut last_error = AppError::Generic("No attempts made".to_string());
@@ -1120,7 +1120,7 @@ impl SparqlDcatClient {
 
     /// HTTP GET with exponential backoff retry for Registry API requests.
     async fn request_url_with_retry(&self, url: Url) -> Result<reqwest::Response, AppError> {
-        let http_config = HttpConfig::default();
+        let http_config = HttpConfig::from_env();
         let max_retries = http_config.max_retries;
         let base_delay = http_config.retry_base_delay;
         let mut last_error = AppError::Generic("No attempts made".to_string());

--- a/crates/ceres-client/src/sparql.rs
+++ b/crates/ceres-client/src/sparql.rs
@@ -1576,8 +1576,10 @@ fn sparql_escape_literal(s: &str) -> String {
 fn is_safe_iri(iri: &str) -> bool {
     (iri.starts_with("http://") || iri.starts_with("https://"))
         && !iri.bytes().any(|b| {
-            matches!(b, b'<' | b'>' | b'"' | b'{' | b'}' | b'|' | b'^' | b'`' | b'\\')
-                || b.is_ascii_whitespace()
+            matches!(
+                b,
+                b'<' | b'>' | b'"' | b'{' | b'}' | b'|' | b'^' | b'`' | b'\\'
+            ) || b.is_ascii_whitespace()
         })
 }
 

--- a/crates/ceres-client/src/sparql.rs
+++ b/crates/ceres-client/src/sparql.rs
@@ -14,7 +14,7 @@
 //!
 //! Pagination uses `LIMIT`/`OFFSET` in the SPARQL query.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::time::Duration;
 
 use ceres_core::HttpConfig;
@@ -700,10 +700,13 @@ impl SparqlDcatClient {
     /// last URI of the previous page (`FILTER(STR(?dataset) > "<cursor>")`) — this
     /// avoids OFFSET entirely (no Virtuoso ~10k cap) and is independent of
     /// `dct:publisher`, so it covers the whole graph. Phase 2 fetches
-    /// title/description/identifier/modified for each batch of URIs via a bounded
-    /// `VALUES` query (near-instant; the full-metadata keyset query times out).
+    /// title/description/identifier/modified and distribution metadata for each
+    /// batch of URIs via bounded `VALUES` queries (the full-metadata keyset query
+    /// times out).
     ///
-    /// Note: this does not retrieve the full JSON-LD `@graph` (distributions etc.).
+    /// All title languages are fetched. `language` is a display preference applied
+    /// client-side, never an eligibility filter, so datasets with no English title
+    /// remain part of an English-configured full harvest.
     fn paginate_sparql_keyset_stream(&self) -> BoxStream<'_, Result<Vec<DcatDataset>, AppError>> {
         struct KeysetState {
             /// Last dataset URI seen (the seek cursor); empty before the first page.
@@ -713,6 +716,7 @@ impl SparqlDcatClient {
             /// True once enumeration returned a short page (no more URIs).
             enum_done: bool,
             done: bool,
+            enumerated: usize,
             fetched: usize,
         }
 
@@ -721,6 +725,7 @@ impl SparqlDcatClient {
             pending: Vec::new(),
             enum_done: false,
             done: false,
+            enumerated: 0,
             fetched: 0,
         };
 
@@ -728,6 +733,16 @@ impl SparqlDcatClient {
             initial,
             move |mut state| async move {
                 if state.done {
+                    return None;
+                }
+
+                if state.pending.is_empty() && state.enum_done {
+                    tracing::info!(
+                        enumerated = state.enumerated,
+                        fetched = state.fetched,
+                        missing = state.enumerated.saturating_sub(state.fetched),
+                        "data.europa.eu keyset harvest complete"
+                    );
                     return None;
                 }
 
@@ -743,9 +758,18 @@ impl SparqlDcatClient {
                             }
                             let last = match uris.last() {
                                 Some(last) => last.clone(),
-                                None => return None,
+                                None => {
+                                    tracing::info!(
+                                        enumerated = state.enumerated,
+                                        fetched = state.fetched,
+                                        missing = state.enumerated.saturating_sub(state.fetched),
+                                        "data.europa.eu keyset harvest complete"
+                                    );
+                                    return None;
+                                }
                             };
                             state.cursor = last;
+                            state.enumerated += uris.len();
                             tracing::info!(
                                 enumerated = uris.len(),
                                 total_fetched = state.fetched,
@@ -765,6 +789,14 @@ impl SparqlDcatClient {
                 let batch: Vec<String> = state.pending.drain(..take).collect();
                 match self.fetch_values_metadata(&batch).await {
                     Ok(datasets) => {
+                        if datasets.len() != batch.len() {
+                            tracing::warn!(
+                                requested = batch.len(),
+                                fetched = datasets.len(),
+                                missing = batch.len().saturating_sub(datasets.len()),
+                                "SPARQL keyset metadata batch did not yield every enumerated dataset"
+                            );
+                        }
                         state.fetched += datasets.len();
                         sleep(PAGE_DELAY).await;
                         Some((Ok(datasets), state))
@@ -795,7 +827,12 @@ impl SparqlDcatClient {
         }
         let query = self.build_values_metadata_query(uris);
         let bindings = self.execute_query_with_retry(&query).await?;
-        Ok(self.bindings_to_datasets(bindings))
+        let distribution_query = self.build_values_distribution_query(uris);
+        let distribution_bindings = self.execute_query_with_retry(&distribution_query).await?;
+
+        let mut datasets = self.bindings_to_datasets(bindings);
+        self.attach_distributions(&mut datasets, distribution_bindings);
+        Ok(datasets)
     }
 
     /// [`execute_query`](Self::execute_query) with bounded retry + exponential
@@ -842,12 +879,6 @@ impl SparqlDcatClient {
 
     /// Builds the bounded `VALUES` metadata query for a set of dataset URIs.
     fn build_values_metadata_query(&self, uris: &[String]) -> String {
-        let title_filter = self
-            .lang_filter_alternatives()
-            .iter()
-            .map(|l| format!("lang(?title) = \"{l}\""))
-            .collect::<Vec<_>>()
-            .join(" || ");
         let values = uris
             .iter()
             .filter(|u| is_safe_iri(u))
@@ -862,10 +893,39 @@ impl SparqlDcatClient {
              WHERE {{\n\
                VALUES ?dataset {{ {values} }}\n\
                ?dataset dct:title ?title .\n\
-               FILTER ({title_filter})\n\
                OPTIONAL {{ ?dataset dct:description ?description }}\n\
                OPTIONAL {{ ?dataset dct:identifier ?identifier }}\n\
                OPTIONAL {{ ?dataset dct:modified ?modified }}\n\
+             }}"
+        )
+    }
+
+    /// Builds a bounded query for the DCAT distributions associated with a set
+    /// of datasets. Distribution records are kept separately from the dataset
+    /// query so a dataset's multilingual title/description rows do not multiply
+    /// its distribution rows.
+    fn build_values_distribution_query(&self, uris: &[String]) -> String {
+        let values = uris
+            .iter()
+            .filter(|u| is_safe_iri(u))
+            .map(|u| format!("<{u}>"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        format!(
+            "PREFIX dcat: <http://www.w3.org/ns/dcat#>\n\
+             PREFIX dct:  <http://purl.org/dc/terms/>\n\
+             \n\
+             SELECT ?dataset ?distribution ?distributionTitle ?distributionDescription\n\
+                    ?distributionFormat ?distributionMediaType ?downloadUrl ?accessUrl\n\
+             WHERE {{\n\
+               VALUES ?dataset {{ {values} }}\n\
+               ?dataset dcat:distribution ?distribution .\n\
+               OPTIONAL {{ ?distribution dct:title ?distributionTitle }}\n\
+               OPTIONAL {{ ?distribution dct:description ?distributionDescription }}\n\
+               OPTIONAL {{ ?distribution dct:format ?distributionFormat }}\n\
+               OPTIONAL {{ ?distribution dcat:mediaType ?distributionMediaType }}\n\
+               OPTIONAL {{ ?distribution dcat:downloadURL ?downloadUrl }}\n\
+               OPTIONAL {{ ?distribution dcat:accessURL ?accessUrl }}\n\
              }}"
         )
     }
@@ -1425,17 +1485,25 @@ impl SparqlDcatClient {
 
     /// Checks whether two language tags are siblings (same macro-language).
     fn are_sibling_languages(a: &str, b: &str) -> bool {
-        matches!((a, b), ("nb" | "nn" | "no", "nb" | "nn" | "no"))
+        ["nb", "nn", "no"]
+            .iter()
+            .any(|language| language_matches(a, language))
+            && ["nb", "nn", "no"]
+                .iter()
+                .any(|language| language_matches(b, language))
     }
 
     /// Returns a language-preference rank for selecting the best value.
-    /// Higher rank = better match: preferred language > sibling > "en" > untagged/other.
+    /// Higher rank = better match: preferred language > sibling > English >
+    /// untagged > another language. Other languages remain eligible so a full
+    /// harvest never drops a dataset merely because it lacks a translation.
     fn lang_rank(&self, lang: Option<&str>) -> u8 {
         match lang {
-            Some(l) if l == self.language => 3,
-            Some(l) if Self::are_sibling_languages(l, &self.language) => 2,
-            Some("en") => 1,
-            _ => 0,
+            Some(l) if language_matches(l, &self.language) => 4,
+            Some(l) if Self::are_sibling_languages(l, &self.language) => 3,
+            Some(l) if language_matches(l, "en") => 2,
+            None | Some("") => 1,
+            Some(_) => 0,
         }
     }
 
@@ -1449,9 +1517,12 @@ impl SparqlDcatClient {
             .iter()
             .filter_map(|b| b.get(key))
             .filter(|v| !v.value.is_empty())
-            .max_by(|a, b| {
-                self.lang_rank(a.lang.as_deref())
-                    .cmp(&self.lang_rank(b.lang.as_deref()))
+            .max_by_key(|v| {
+                (
+                    self.lang_rank(v.lang.as_deref()),
+                    std::cmp::Reverse(v.lang.as_deref().unwrap_or("")),
+                    std::cmp::Reverse(v.value.as_str()),
+                )
             })
     }
 
@@ -1521,6 +1592,66 @@ impl SparqlDcatClient {
 
         datasets
     }
+
+    /// Adds normalized DCAT distributions to each dataset's raw metadata.
+    ///
+    /// The schema endpoint reads these conventional DCAT keys directly, while
+    /// callers that need the original SPARQL fields can still use the remaining
+    /// binding-derived metadata on the dataset object.
+    fn attach_distributions(
+        &self,
+        datasets: &mut [DcatDataset],
+        bindings: Vec<HashMap<String, SparqlValue>>,
+    ) {
+        let mut grouped: BTreeMap<(String, String), Vec<HashMap<String, SparqlValue>>> =
+            BTreeMap::new();
+
+        for binding in bindings {
+            let Some(dataset) = binding.get("dataset").map(|v| v.value.clone()) else {
+                continue;
+            };
+            let Some(distribution) = binding.get("distribution").map(|v| v.value.clone()) else {
+                continue;
+            };
+            grouped
+                .entry((dataset, distribution))
+                .or_default()
+                .push(binding);
+        }
+
+        let mut by_dataset: BTreeMap<String, Vec<Value>> = BTreeMap::new();
+        for ((dataset, distribution), rows) in grouped {
+            let mut metadata = serde_json::Map::new();
+            metadata.insert("@id".to_string(), Value::String(distribution));
+
+            for (binding_key, metadata_key) in [
+                ("distributionTitle", "dct:title"),
+                ("distributionDescription", "dct:description"),
+                ("distributionFormat", "dct:format"),
+                ("distributionMediaType", "dcat:mediaType"),
+                ("downloadUrl", "dcat:downloadURL"),
+                ("accessUrl", "dcat:accessURL"),
+            ] {
+                if let Some(value) = self.best_value(&rows, binding_key) {
+                    metadata.insert(metadata_key.to_string(), Value::String(value.value.clone()));
+                }
+            }
+
+            by_dataset
+                .entry(dataset)
+                .or_default()
+                .push(Value::Object(metadata));
+        }
+
+        for dataset in datasets {
+            let Some(distributions) = by_dataset.remove(&dataset.id_uri) else {
+                continue;
+            };
+            if let Some(metadata) = dataset.raw.as_object_mut() {
+                metadata.insert("distribution".to_string(), Value::Array(distributions));
+            }
+        }
+    }
 }
 
 // =============================================================================
@@ -1576,9 +1707,23 @@ fn sparql_escape_literal(s: &str) -> String {
 fn is_safe_iri(iri: &str) -> bool {
     (iri.starts_with("http://") || iri.starts_with("https://"))
         && !iri.bytes().any(|b| {
-            matches!(b, b'<' | b'>' | b'"' | b'{' | b'}' | b'|' | b'^' | b'`' | b'\\')
-                || b.is_ascii_whitespace()
+            matches!(
+                b,
+                b'<' | b'>' | b'"' | b'{' | b'}' | b'|' | b'^' | b'`' | b'\\'
+            ) || b.is_ascii_whitespace()
         })
+}
+
+/// Returns true when `candidate` is `preferred` or one of its BCP 47 subtags.
+/// BCP 47 matching is case-insensitive, so `fr-CA` is a valid fallback for
+/// a preference of `fr`.
+fn language_matches(candidate: &str, preferred: &str) -> bool {
+    candidate.eq_ignore_ascii_case(preferred)
+        || (candidate.len() > preferred.len()
+            && candidate
+                .get(..preferred.len())
+                .is_some_and(|prefix| prefix.eq_ignore_ascii_case(preferred))
+            && candidate.as_bytes()[preferred.len()] == b'-')
 }
 
 /// Extracts the last non-empty path segment from a URI.
@@ -1695,9 +1840,23 @@ mod tests {
         assert!(q.contains("<http://example.org/d/1>"));
         assert!(q.contains("<https://example.org/d/2>"));
         assert!(q.contains("dct:title ?title"));
-        assert!(q.contains(r#"lang(?title) = "en""#));
         assert!(q.contains("OPTIONAL { ?dataset dct:description ?description }"));
+        assert!(
+            !q.contains("lang(?title)"),
+            "a full keyset harvest must not filter title languages"
+        );
         assert!(!q.contains("OFFSET") && !q.contains("ORDER BY"));
+    }
+
+    #[test]
+    fn values_distribution_query_includes_schema_metadata() {
+        let client = SparqlDcatClient::new("https://data.europa.eu", "en", None).unwrap();
+        let q = client.build_values_distribution_query(&["https://example.org/d/1".to_string()]);
+        assert!(q.contains("?dataset dcat:distribution ?distribution"));
+        assert!(q.contains("?distribution dct:format ?distributionFormat"));
+        assert!(q.contains("?distribution dcat:mediaType ?distributionMediaType"));
+        assert!(q.contains("?distribution dcat:downloadURL ?downloadUrl"));
+        assert!(q.contains("?distribution dcat:accessURL ?accessUrl"));
     }
 
     #[test]
@@ -1903,6 +2062,86 @@ mod tests {
     }
 
     #[test]
+    fn language_selection_accepts_bcp47_variants_and_other_language_fallbacks() {
+        let client = SparqlDcatClient::new("https://example.org", "fr", None).unwrap();
+        let rows = vec![
+            binding("https://example.org/d/1", "title", "Deutsch", Some("de")),
+            binding(
+                "https://example.org/d/1",
+                "title",
+                "Français",
+                Some("fr-CA"),
+            ),
+        ];
+        assert_eq!(client.best_value(&rows, "title").unwrap().value, "Français");
+
+        // A language with no preferred/English/untagged alternative is still a
+        // valid dataset title and must not make the dataset disappear.
+        let rows = vec![binding(
+            "https://example.org/d/2",
+            "title",
+            "Italiano",
+            Some("it"),
+        )];
+        assert_eq!(client.best_value(&rows, "title").unwrap().value, "Italiano");
+    }
+
+    #[test]
+    fn distributions_are_preserved_in_dataset_metadata() {
+        let client = SparqlDcatClient::new("https://data.europa.eu", "en", None).unwrap();
+        let dataset_bindings = vec![binding(
+            "https://example.org/d/1",
+            "title",
+            "Dataset",
+            Some("en"),
+        )];
+        let mut datasets = client.bindings_to_datasets(dataset_bindings);
+
+        let mut distribution = HashMap::new();
+        distribution.insert(
+            "dataset".to_string(),
+            SparqlValue {
+                value: "https://example.org/d/1".to_string(),
+                lang: None,
+            },
+        );
+        distribution.insert(
+            "distribution".to_string(),
+            SparqlValue {
+                value: "https://example.org/distribution/1".to_string(),
+                lang: None,
+            },
+        );
+        for (key, value) in [
+            ("distributionTitle", "CSV export"),
+            ("distributionFormat", "CSV"),
+            ("distributionMediaType", "text/csv"),
+            ("downloadUrl", "https://example.org/data.csv"),
+        ] {
+            distribution.insert(
+                key.to_string(),
+                SparqlValue {
+                    value: value.to_string(),
+                    lang: None,
+                },
+            );
+        }
+
+        client.attach_distributions(&mut datasets, vec![distribution]);
+        let distributions = datasets[0].raw["distribution"].as_array().unwrap();
+        assert_eq!(distributions.len(), 1);
+        assert_eq!(distributions[0]["dct:format"], "CSV");
+        assert_eq!(
+            distributions[0]["dcat:downloadURL"],
+            "https://example.org/data.csv"
+        );
+
+        let schema = ceres_core::DatasetSchema::from_metadata(&datasets[0].raw);
+        assert_eq!(schema.resources.len(), 1);
+        assert_eq!(schema.resources[0].format.as_deref(), Some("CSV"));
+    }
+
+    #[test]
     fn title_and_description_selected_independently() {
         // A dataset may carry the title in the preferred language but the
         // description only in a fallback language; each field is chosen on its own.
@@ -1935,11 +2174,12 @@ mod tests {
     #[test]
     fn lang_rank_orders_preferred_sibling_en_other() {
         let client = SparqlDcatClient::new("https://example.org", "nb", None).unwrap();
-        assert_eq!(client.lang_rank(Some("nb")), 3); // preferred
-        assert_eq!(client.lang_rank(Some("nn")), 2); // sibling
-        assert_eq!(client.lang_rank(Some("en")), 1); // english fallback
+        assert_eq!(client.lang_rank(Some("nb")), 4); // preferred
+        assert_eq!(client.lang_rank(Some("nb-NO")), 4); // preferred BCP 47 variant
+        assert_eq!(client.lang_rank(Some("nn")), 3); // sibling
+        assert_eq!(client.lang_rank(Some("en")), 2); // English fallback
+        assert_eq!(client.lang_rank(None), 1); // untagged fallback
         assert_eq!(client.lang_rank(Some("de")), 0); // unrelated
-        assert_eq!(client.lang_rank(None), 0); // untagged
     }
 
     // ---- extract_last_segment -----------------------------------------------

--- a/crates/ceres-client/src/sparql.rs
+++ b/crates/ceres-client/src/sparql.rs
@@ -14,7 +14,7 @@
 //!
 //! Pagination uses `LIMIT`/`OFFSET` in the SPARQL query.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::time::Duration;
 
 use ceres_core::HttpConfig;
@@ -139,6 +139,15 @@ enum PartitionRef<'a> {
 struct RegistryPage {
     datasets: Vec<DcatDataset>,
     entries: usize,
+}
+
+/// A fully checked metadata batch from the keyset harvest.
+struct KeysetMetadataBatch {
+    datasets: Vec<DcatDataset>,
+    /// Dataset IRIs with a non-empty title. These are the records the internal
+    /// model can materialize; enumerated datasets without a title are reported
+    /// separately instead of being mistaken for a truncated query response.
+    titled: usize,
 }
 
 // =============================================================================
@@ -717,6 +726,7 @@ impl SparqlDcatClient {
             enum_done: bool,
             done: bool,
             enumerated: usize,
+            titled: usize,
             fetched: usize,
         }
 
@@ -726,6 +736,7 @@ impl SparqlDcatClient {
             enum_done: false,
             done: false,
             enumerated: 0,
+            titled: 0,
             fetched: 0,
         };
 
@@ -739,8 +750,9 @@ impl SparqlDcatClient {
                 if state.pending.is_empty() && state.enum_done {
                     tracing::info!(
                         enumerated = state.enumerated,
+                        titled = state.titled,
                         fetched = state.fetched,
-                        missing = state.enumerated.saturating_sub(state.fetched),
+                        untitled = state.enumerated.saturating_sub(state.titled),
                         "data.europa.eu keyset harvest complete"
                     );
                     return None;
@@ -761,8 +773,9 @@ impl SparqlDcatClient {
                                 None => {
                                     tracing::info!(
                                         enumerated = state.enumerated,
+                                        titled = state.titled,
                                         fetched = state.fetched,
-                                        missing = state.enumerated.saturating_sub(state.fetched),
+                                        untitled = state.enumerated.saturating_sub(state.titled),
                                         "data.europa.eu keyset harvest complete"
                                     );
                                     return None;
@@ -788,18 +801,11 @@ impl SparqlDcatClient {
                 let take = state.pending.len().min(VALUES_BATCH_SIZE);
                 let batch: Vec<String> = state.pending.drain(..take).collect();
                 match self.fetch_values_metadata(&batch).await {
-                    Ok(datasets) => {
-                        if datasets.len() != batch.len() {
-                            tracing::warn!(
-                                requested = batch.len(),
-                                fetched = datasets.len(),
-                                missing = batch.len().saturating_sub(datasets.len()),
-                                "SPARQL keyset metadata batch did not yield every enumerated dataset"
-                            );
-                        }
-                        state.fetched += datasets.len();
+                    Ok(metadata) => {
+                        state.titled += metadata.titled;
+                        state.fetched += metadata.datasets.len();
                         sleep(PAGE_DELAY).await;
-                        Some((Ok(datasets), state))
+                        Some((Ok(metadata.datasets), state))
                     }
                     Err(e) => {
                         state.done = true;
@@ -820,19 +826,59 @@ impl SparqlDcatClient {
             .collect())
     }
 
-    /// Fetches metadata for a bounded set of dataset URIs via a `VALUES` query.
-    async fn fetch_values_metadata(&self, uris: &[String]) -> Result<Vec<DcatDataset>, AppError> {
+    /// Fetches metadata for a bounded set of dataset URIs via independent
+    /// `VALUES` queries.
+    ///
+    /// A single query that joins multilingual title, description, identifier,
+    /// and modified fields creates a Cartesian product. data.europa.eu truncates
+    /// that otherwise-successful response at 50k rows, silently losing datasets.
+    /// Fetching one property at a time keeps each result bounded and lets us
+    /// enforce a per-batch coverage invariant before data reaches the database.
+    async fn fetch_values_metadata(
+        &self,
+        uris: &[String],
+    ) -> Result<KeysetMetadataBatch, AppError> {
         if uris.is_empty() {
-            return Ok(Vec::new());
+            return Ok(KeysetMetadataBatch {
+                datasets: Vec::new(),
+                titled: 0,
+            });
         }
-        let query = self.build_values_metadata_query(uris);
-        let bindings = self.execute_query_with_retry(&query).await?;
+
+        let title_bindings = self
+            .execute_query_with_retry(&self.build_values_title_query(uris))
+            .await?;
+        let titled_uris: HashSet<String> = title_bindings
+            .iter()
+            .filter_map(|binding| {
+                binding
+                    .get("title")
+                    .filter(|title| !title.value.is_empty())
+                    .and_then(|_| binding.get("dataset"))
+                    .map(|dataset| dataset.value.clone())
+            })
+            .collect();
+
+        let mut bindings = title_bindings;
+        for query in [
+            self.build_values_description_query(uris),
+            self.build_values_identifier_query(uris),
+            self.build_values_modified_query(uris),
+        ] {
+            bindings.extend(self.execute_query_with_retry(&query).await?);
+        }
+
         let distribution_query = self.build_values_distribution_query(uris);
         let distribution_bindings = self.execute_query_with_retry(&distribution_query).await?;
 
         let mut datasets = self.bindings_to_datasets(bindings);
         self.attach_distributions(&mut datasets, distribution_bindings);
-        Ok(datasets)
+        verify_keyset_coverage(&titled_uris, &datasets)?;
+
+        Ok(KeysetMetadataBatch {
+            titled: titled_uris.len(),
+            datasets,
+        })
     }
 
     /// [`execute_query`](Self::execute_query) with bounded retry + exponential
@@ -877,8 +923,32 @@ impl SparqlDcatClient {
         )
     }
 
-    /// Builds the bounded `VALUES` metadata query for a set of dataset URIs.
-    fn build_values_metadata_query(&self, uris: &[String]) -> String {
+    /// Builds the title query for a keyset metadata batch. Titles are fetched
+    /// without a language filter; language selection happens client-side.
+    fn build_values_title_query(&self, uris: &[String]) -> String {
+        self.build_values_property_query(uris, "title", "dct:title")
+    }
+
+    fn build_values_description_query(&self, uris: &[String]) -> String {
+        self.build_values_property_query(uris, "description", "dct:description")
+    }
+
+    fn build_values_identifier_query(&self, uris: &[String]) -> String {
+        self.build_values_property_query(uris, "identifier", "dct:identifier")
+    }
+
+    fn build_values_modified_query(&self, uris: &[String]) -> String {
+        self.build_values_property_query(uris, "modified", "dct:modified")
+    }
+
+    /// Builds a bounded query for one multi-valued dataset property. Keeping
+    /// properties separate prevents multilingual fields from multiplying rows.
+    fn build_values_property_query(
+        &self,
+        uris: &[String],
+        variable: &str,
+        predicate: &str,
+    ) -> String {
         let values = uris
             .iter()
             .filter(|u| is_safe_iri(u))
@@ -889,13 +959,10 @@ impl SparqlDcatClient {
             "PREFIX dcat: <http://www.w3.org/ns/dcat#>\n\
              PREFIX dct:  <http://purl.org/dc/terms/>\n\
              \n\
-             SELECT ?dataset ?title ?description ?identifier ?modified\n\
+             SELECT ?dataset ?{variable}\n\
              WHERE {{\n\
                VALUES ?dataset {{ {values} }}\n\
-               ?dataset dct:title ?title .\n\
-               OPTIONAL {{ ?dataset dct:description ?description }}\n\
-               OPTIONAL {{ ?dataset dct:identifier ?identifier }}\n\
-               OPTIONAL {{ ?dataset dct:modified ?modified }}\n\
+               ?dataset {predicate} ?{variable} .\n\
              }}"
         )
     }
@@ -915,8 +982,13 @@ impl SparqlDcatClient {
             "PREFIX dcat: <http://www.w3.org/ns/dcat#>\n\
              PREFIX dct:  <http://purl.org/dc/terms/>\n\
              \n\
-             SELECT ?dataset ?distribution ?distributionTitle ?distributionDescription\n\
-                    ?distributionFormat ?distributionMediaType ?downloadUrl ?accessUrl\n\
+             SELECT ?dataset ?distribution\n\
+                    (SAMPLE(?distributionTitle) AS ?distributionTitle)\n\
+                    (SAMPLE(?distributionDescription) AS ?distributionDescription)\n\
+                    (SAMPLE(?distributionFormat) AS ?distributionFormat)\n\
+                    (SAMPLE(?distributionMediaType) AS ?distributionMediaType)\n\
+                    (SAMPLE(?downloadUrl) AS ?downloadUrl)\n\
+                    (SAMPLE(?accessUrl) AS ?accessUrl)\n\
              WHERE {{\n\
                VALUES ?dataset {{ {values} }}\n\
                ?dataset dcat:distribution ?distribution .\n\
@@ -926,7 +998,8 @@ impl SparqlDcatClient {
                OPTIONAL {{ ?distribution dcat:mediaType ?distributionMediaType }}\n\
                OPTIONAL {{ ?distribution dcat:downloadURL ?downloadUrl }}\n\
                OPTIONAL {{ ?distribution dcat:accessURL ?accessUrl }}\n\
-             }}"
+             }}\n\
+             GROUP BY ?dataset ?distribution"
         )
     }
 
@@ -1726,6 +1799,34 @@ fn language_matches(candidate: &str, preferred: &str) -> bool {
             && candidate.as_bytes()[preferred.len()] == b'-')
 }
 
+/// Ensures a keyset batch did not silently lose a titled dataset after its
+/// metadata was fetched. Untitled entries are intentionally excluded because
+/// [`DcatDataset`] requires a non-empty title.
+fn verify_keyset_coverage(
+    titled_uris: &HashSet<String>,
+    datasets: &[DcatDataset],
+) -> Result<(), AppError> {
+    let materialized_uris: HashSet<&str> = datasets
+        .iter()
+        .map(|dataset| dataset.id_uri.as_str())
+        .collect();
+    let missing: Vec<&str> = titled_uris
+        .iter()
+        .map(String::as_str)
+        .filter(|uri| !materialized_uris.contains(uri))
+        .take(5)
+        .collect();
+    if !missing.is_empty() || materialized_uris.len() != titled_uris.len() {
+        return Err(AppError::Generic(format!(
+            "SPARQL keyset coverage check failed: {} titled dataset IRIs, {} materialized; sample missing IRIs: {}",
+            titled_uris.len(),
+            materialized_uris.len(),
+            missing.join(", ")
+        )));
+    }
+    Ok(())
+}
+
 /// Extracts the last non-empty path segment from a URI.
 fn extract_last_segment(uri: &str) -> String {
     uri.trim_end_matches('/')
@@ -1829,23 +1930,50 @@ mod tests {
     }
 
     #[test]
-    fn values_metadata_query_lists_uris_and_fields() {
+    fn values_title_query_lists_uris_without_joining_other_properties() {
         let client = SparqlDcatClient::new("https://data.europa.eu", "en", None).unwrap();
         let uris = vec![
             "http://example.org/d/1".to_string(),
             "https://example.org/d/2".to_string(),
         ];
-        let q = client.build_values_metadata_query(&uris);
+        let q = client.build_values_title_query(&uris);
         assert!(q.contains("VALUES ?dataset {"));
         assert!(q.contains("<http://example.org/d/1>"));
         assert!(q.contains("<https://example.org/d/2>"));
         assert!(q.contains("dct:title ?title"));
-        assert!(q.contains("OPTIONAL { ?dataset dct:description ?description }"));
         assert!(
             !q.contains("lang(?title)"),
             "a full keyset harvest must not filter title languages"
         );
+        assert!(!q.contains("OPTIONAL"));
         assert!(!q.contains("OFFSET") && !q.contains("ORDER BY"));
+    }
+
+    #[test]
+    fn values_property_queries_keep_multivalued_fields_separate() {
+        let client = SparqlDcatClient::new("https://data.europa.eu", "en", None).unwrap();
+        let uris = ["https://example.org/d/1".to_string()];
+        for (query, predicate, variable) in [
+            (
+                client.build_values_description_query(&uris),
+                "dct:description",
+                "?description",
+            ),
+            (
+                client.build_values_identifier_query(&uris),
+                "dct:identifier",
+                "?identifier",
+            ),
+            (
+                client.build_values_modified_query(&uris),
+                "dct:modified",
+                "?modified",
+            ),
+        ] {
+            assert!(query.contains(predicate));
+            assert!(query.contains(variable));
+            assert!(!query.contains("OPTIONAL"));
+        }
     }
 
     #[test]
@@ -1857,20 +1985,44 @@ mod tests {
         assert!(q.contains("?distribution dcat:mediaType ?distributionMediaType"));
         assert!(q.contains("?distribution dcat:downloadURL ?downloadUrl"));
         assert!(q.contains("?distribution dcat:accessURL ?accessUrl"));
+        assert!(q.contains("SAMPLE(?distributionTitle)"));
+        assert!(q.contains("GROUP BY ?dataset ?distribution"));
     }
 
     #[test]
-    fn values_metadata_query_drops_unsafe_iris() {
+    fn values_title_query_drops_unsafe_iris() {
         let client = SparqlDcatClient::new("https://data.europa.eu", "en", None).unwrap();
         let uris = vec![
             "http://ok.example/d/1".to_string(),
             "http://bad.example/d 2".to_string(), // space -> unsafe
             "ftp://nope.example/d/3".to_string(), // non-http -> unsafe
         ];
-        let q = client.build_values_metadata_query(&uris);
+        let q = client.build_values_title_query(&uris);
         assert!(q.contains("<http://ok.example/d/1>"));
         assert!(!q.contains("d 2"));
         assert!(!q.contains("ftp://"));
+    }
+
+    #[test]
+    fn coverage_gate_rejects_a_missing_titled_dataset() {
+        let titled_uris = HashSet::from([
+            "https://example.org/d/1".to_string(),
+            "https://example.org/d/2".to_string(),
+        ]);
+        let datasets = vec![DcatDataset {
+            id_uri: "https://example.org/d/1".to_string(),
+            identifier: "1".to_string(),
+            title: "Dataset 1".to_string(),
+            description: None,
+            raw: Value::Null,
+        }];
+
+        let error = verify_keyset_coverage(&titled_uris, &datasets).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("2 titled dataset IRIs, 1 materialized")
+        );
     }
 
     #[test]

--- a/crates/ceres-client/src/sparql.rs
+++ b/crates/ceres-client/src/sparql.rs
@@ -148,6 +148,9 @@ struct KeysetMetadataBatch {
     /// model can materialize; enumerated datasets without a title are reported
     /// separately instead of being mistaken for a truncated query response.
     titled: usize,
+    /// Unique logical dataset identifiers after collapsing portal URI variants
+    /// that intentionally share a `dct:identifier`.
+    unique_identifiers: usize,
 }
 
 // =============================================================================
@@ -727,6 +730,7 @@ impl SparqlDcatClient {
             done: bool,
             enumerated: usize,
             titled: usize,
+            unique_identifiers: usize,
             fetched: usize,
         }
 
@@ -737,6 +741,7 @@ impl SparqlDcatClient {
             done: false,
             enumerated: 0,
             titled: 0,
+            unique_identifiers: 0,
             fetched: 0,
         };
 
@@ -751,6 +756,7 @@ impl SparqlDcatClient {
                     tracing::info!(
                         enumerated = state.enumerated,
                         titled = state.titled,
+                        unique_identifiers = state.unique_identifiers,
                         fetched = state.fetched,
                         untitled = state.enumerated.saturating_sub(state.titled),
                         "data.europa.eu keyset harvest complete"
@@ -774,6 +780,7 @@ impl SparqlDcatClient {
                                     tracing::info!(
                                         enumerated = state.enumerated,
                                         titled = state.titled,
+                                        unique_identifiers = state.unique_identifiers,
                                         fetched = state.fetched,
                                         untitled = state.enumerated.saturating_sub(state.titled),
                                         "data.europa.eu keyset harvest complete"
@@ -803,6 +810,7 @@ impl SparqlDcatClient {
                 match self.fetch_values_metadata(&batch).await {
                     Ok(metadata) => {
                         state.titled += metadata.titled;
+                        state.unique_identifiers += metadata.unique_identifiers;
                         state.fetched += metadata.datasets.len();
                         sleep(PAGE_DELAY).await;
                         Some((Ok(metadata.datasets), state))
@@ -842,6 +850,7 @@ impl SparqlDcatClient {
             return Ok(KeysetMetadataBatch {
                 datasets: Vec::new(),
                 titled: 0,
+                unique_identifiers: 0,
             });
         }
 
@@ -871,12 +880,14 @@ impl SparqlDcatClient {
         let distribution_query = self.build_values_distribution_query(uris);
         let distribution_bindings = self.execute_query_with_retry(&distribution_query).await?;
 
+        let expected_identifiers = expected_identifiers(&bindings, &titled_uris);
         let mut datasets = self.bindings_to_datasets(bindings);
         self.attach_distributions(&mut datasets, distribution_bindings);
-        verify_keyset_coverage(&titled_uris, &datasets)?;
+        verify_keyset_coverage(&titled_uris, &expected_identifiers, &datasets)?;
 
         Ok(KeysetMetadataBatch {
             titled: titled_uris.len(),
+            unique_identifiers: expected_identifiers.len(),
             datasets,
         })
     }
@@ -1799,28 +1810,70 @@ fn language_matches(candidate: &str, preferred: &str) -> bool {
             && candidate.as_bytes()[preferred.len()] == b'-')
 }
 
-/// Ensures a keyset batch did not silently lose a titled dataset after its
+/// Finds the identifiers that are expected to be represented in a keyset batch.
+///
+/// data.europa.eu sometimes publishes URI variants (for example a `~~1`
+/// suffix) for the same logical dataset. Ceres stores datasets by
+/// `(source_portal, original_id)`, so these variants intentionally collapse to
+/// one materialized record when they share a non-empty `dct:identifier`.
+fn expected_identifiers(
+    bindings: &[HashMap<String, SparqlValue>],
+    titled_uris: &HashSet<String>,
+) -> HashSet<String> {
+    let mut identifiers_by_uri = HashMap::new();
+    for binding in bindings {
+        let Some(dataset_uri) = binding.get("dataset").map(|value| &value.value) else {
+            continue;
+        };
+        if !titled_uris.contains(dataset_uri) {
+            continue;
+        }
+        if let Some(identifier) = binding
+            .get("identifier")
+            .map(|value| value.value.as_str())
+            .filter(|value| !value.is_empty())
+        {
+            identifiers_by_uri
+                .entry(dataset_uri.clone())
+                .or_insert_with(|| identifier.to_string());
+        }
+    }
+
+    titled_uris
+        .iter()
+        .map(|uri| {
+            identifiers_by_uri
+                .remove(uri)
+                .unwrap_or_else(|| extract_last_segment(uri))
+        })
+        .collect()
+}
+
+/// Ensures a keyset batch did not silently lose a logical dataset after its
 /// metadata was fetched. Untitled entries are intentionally excluded because
-/// [`DcatDataset`] requires a non-empty title.
+/// [`DcatDataset`] requires a non-empty title, and URI variants that share an
+/// identifier intentionally collapse to a single database record.
 fn verify_keyset_coverage(
     titled_uris: &HashSet<String>,
+    expected_identifiers: &HashSet<String>,
     datasets: &[DcatDataset],
 ) -> Result<(), AppError> {
-    let materialized_uris: HashSet<&str> = datasets
+    let materialized_identifiers: HashSet<&str> = datasets
         .iter()
-        .map(|dataset| dataset.id_uri.as_str())
+        .map(|dataset| dataset.identifier.as_str())
         .collect();
-    let missing: Vec<&str> = titled_uris
+    let missing: Vec<&str> = expected_identifiers
         .iter()
         .map(String::as_str)
-        .filter(|uri| !materialized_uris.contains(uri))
+        .filter(|identifier| !materialized_identifiers.contains(identifier))
         .take(5)
         .collect();
-    if !missing.is_empty() || materialized_uris.len() != titled_uris.len() {
+    if !missing.is_empty() || materialized_identifiers.len() != expected_identifiers.len() {
         return Err(AppError::Generic(format!(
-            "SPARQL keyset coverage check failed: {} titled dataset IRIs, {} materialized; sample missing IRIs: {}",
+            "SPARQL keyset coverage check failed: {} titled dataset IRIs, {} unique identifiers, {} materialized; sample missing identifiers: {}",
             titled_uris.len(),
-            materialized_uris.len(),
+            expected_identifiers.len(),
+            materialized_identifiers.len(),
             missing.join(", ")
         )));
     }
@@ -2009,6 +2062,7 @@ mod tests {
             "https://example.org/d/1".to_string(),
             "https://example.org/d/2".to_string(),
         ]);
+        let expected_identifiers = HashSet::from(["1".to_string(), "2".to_string()]);
         let datasets = vec![DcatDataset {
             id_uri: "https://example.org/d/1".to_string(),
             identifier: "1".to_string(),
@@ -2017,12 +2071,31 @@ mod tests {
             raw: Value::Null,
         }];
 
-        let error = verify_keyset_coverage(&titled_uris, &datasets).unwrap_err();
+        let error =
+            verify_keyset_coverage(&titled_uris, &expected_identifiers, &datasets).unwrap_err();
         assert!(
             error
                 .to_string()
-                .contains("2 titled dataset IRIs, 1 materialized")
+                .contains("2 titled dataset IRIs, 2 unique identifiers, 1 materialized")
         );
+    }
+
+    #[test]
+    fn coverage_gate_allows_uri_variants_with_the_same_identifier() {
+        let titled_uris = HashSet::from([
+            "https://example.org/d/1".to_string(),
+            "https://example.org/d/1~~1".to_string(),
+        ]);
+        let expected_identifiers = HashSet::from(["same-dataset".to_string()]);
+        let datasets = vec![DcatDataset {
+            id_uri: "https://example.org/d/1".to_string(),
+            identifier: "same-dataset".to_string(),
+            title: "Dataset".to_string(),
+            description: None,
+            raw: Value::Null,
+        }];
+
+        verify_keyset_coverage(&titled_uris, &expected_identifiers, &datasets).unwrap();
     }
 
     #[test]

--- a/crates/ceres-client/src/sparql.rs
+++ b/crates/ceres-client/src/sparql.rs
@@ -14,7 +14,7 @@
 //!
 //! Pagination uses `LIMIT`/`OFFSET` in the SPARQL query.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::HashMap;
 use std::time::Duration;
 
 use ceres_core::HttpConfig;
@@ -139,18 +139,6 @@ enum PartitionRef<'a> {
 struct RegistryPage {
     datasets: Vec<DcatDataset>,
     entries: usize,
-}
-
-/// A fully checked metadata batch from the keyset harvest.
-struct KeysetMetadataBatch {
-    datasets: Vec<DcatDataset>,
-    /// Dataset IRIs with a non-empty title. These are the records the internal
-    /// model can materialize; enumerated datasets without a title are reported
-    /// separately instead of being mistaken for a truncated query response.
-    titled: usize,
-    /// Unique logical dataset identifiers after collapsing portal URI variants
-    /// that intentionally share a `dct:identifier`.
-    unique_identifiers: usize,
 }
 
 // =============================================================================
@@ -712,13 +700,10 @@ impl SparqlDcatClient {
     /// last URI of the previous page (`FILTER(STR(?dataset) > "<cursor>")`) — this
     /// avoids OFFSET entirely (no Virtuoso ~10k cap) and is independent of
     /// `dct:publisher`, so it covers the whole graph. Phase 2 fetches
-    /// title/description/identifier/modified and distribution metadata for each
-    /// batch of URIs via bounded `VALUES` queries (the full-metadata keyset query
-    /// times out).
+    /// title/description/identifier/modified for each batch of URIs via a bounded
+    /// `VALUES` query (near-instant; the full-metadata keyset query times out).
     ///
-    /// All title languages are fetched. `language` is a display preference applied
-    /// client-side, never an eligibility filter, so datasets with no English title
-    /// remain part of an English-configured full harvest.
+    /// Note: this does not retrieve the full JSON-LD `@graph` (distributions etc.).
     fn paginate_sparql_keyset_stream(&self) -> BoxStream<'_, Result<Vec<DcatDataset>, AppError>> {
         struct KeysetState {
             /// Last dataset URI seen (the seek cursor); empty before the first page.
@@ -728,9 +713,6 @@ impl SparqlDcatClient {
             /// True once enumeration returned a short page (no more URIs).
             enum_done: bool,
             done: bool,
-            enumerated: usize,
-            titled: usize,
-            unique_identifiers: usize,
             fetched: usize,
         }
 
@@ -739,9 +721,6 @@ impl SparqlDcatClient {
             pending: Vec::new(),
             enum_done: false,
             done: false,
-            enumerated: 0,
-            titled: 0,
-            unique_identifiers: 0,
             fetched: 0,
         };
 
@@ -749,18 +728,6 @@ impl SparqlDcatClient {
             initial,
             move |mut state| async move {
                 if state.done {
-                    return None;
-                }
-
-                if state.pending.is_empty() && state.enum_done {
-                    tracing::info!(
-                        enumerated = state.enumerated,
-                        titled = state.titled,
-                        unique_identifiers = state.unique_identifiers,
-                        fetched = state.fetched,
-                        untitled = state.enumerated.saturating_sub(state.titled),
-                        "data.europa.eu keyset harvest complete"
-                    );
                     return None;
                 }
 
@@ -776,20 +743,9 @@ impl SparqlDcatClient {
                             }
                             let last = match uris.last() {
                                 Some(last) => last.clone(),
-                                None => {
-                                    tracing::info!(
-                                        enumerated = state.enumerated,
-                                        titled = state.titled,
-                                        unique_identifiers = state.unique_identifiers,
-                                        fetched = state.fetched,
-                                        untitled = state.enumerated.saturating_sub(state.titled),
-                                        "data.europa.eu keyset harvest complete"
-                                    );
-                                    return None;
-                                }
+                                None => return None,
                             };
                             state.cursor = last;
-                            state.enumerated += uris.len();
                             tracing::info!(
                                 enumerated = uris.len(),
                                 total_fetched = state.fetched,
@@ -808,12 +764,10 @@ impl SparqlDcatClient {
                 let take = state.pending.len().min(VALUES_BATCH_SIZE);
                 let batch: Vec<String> = state.pending.drain(..take).collect();
                 match self.fetch_values_metadata(&batch).await {
-                    Ok(metadata) => {
-                        state.titled += metadata.titled;
-                        state.unique_identifiers += metadata.unique_identifiers;
-                        state.fetched += metadata.datasets.len();
+                    Ok(datasets) => {
+                        state.fetched += datasets.len();
                         sleep(PAGE_DELAY).await;
-                        Some((Ok(metadata.datasets), state))
+                        Some((Ok(datasets), state))
                     }
                     Err(e) => {
                         state.done = true;
@@ -834,62 +788,14 @@ impl SparqlDcatClient {
             .collect())
     }
 
-    /// Fetches metadata for a bounded set of dataset URIs via independent
-    /// `VALUES` queries.
-    ///
-    /// A single query that joins multilingual title, description, identifier,
-    /// and modified fields creates a Cartesian product. data.europa.eu truncates
-    /// that otherwise-successful response at 50k rows, silently losing datasets.
-    /// Fetching one property at a time keeps each result bounded and lets us
-    /// enforce a per-batch coverage invariant before data reaches the database.
-    async fn fetch_values_metadata(
-        &self,
-        uris: &[String],
-    ) -> Result<KeysetMetadataBatch, AppError> {
+    /// Fetches metadata for a bounded set of dataset URIs via a `VALUES` query.
+    async fn fetch_values_metadata(&self, uris: &[String]) -> Result<Vec<DcatDataset>, AppError> {
         if uris.is_empty() {
-            return Ok(KeysetMetadataBatch {
-                datasets: Vec::new(),
-                titled: 0,
-                unique_identifiers: 0,
-            });
+            return Ok(Vec::new());
         }
-
-        let title_bindings = self
-            .execute_query_with_retry(&self.build_values_title_query(uris))
-            .await?;
-        let titled_uris: HashSet<String> = title_bindings
-            .iter()
-            .filter_map(|binding| {
-                binding
-                    .get("title")
-                    .filter(|title| !title.value.is_empty())
-                    .and_then(|_| binding.get("dataset"))
-                    .map(|dataset| dataset.value.clone())
-            })
-            .collect();
-
-        let mut bindings = title_bindings;
-        for query in [
-            self.build_values_description_query(uris),
-            self.build_values_identifier_query(uris),
-            self.build_values_modified_query(uris),
-        ] {
-            bindings.extend(self.execute_query_with_retry(&query).await?);
-        }
-
-        let distribution_query = self.build_values_distribution_query(uris);
-        let distribution_bindings = self.execute_query_with_retry(&distribution_query).await?;
-
-        let expected_identifiers = expected_identifiers(&bindings, &titled_uris);
-        let mut datasets = self.bindings_to_datasets(bindings);
-        self.attach_distributions(&mut datasets, distribution_bindings);
-        verify_keyset_coverage(&titled_uris, &expected_identifiers, &datasets)?;
-
-        Ok(KeysetMetadataBatch {
-            titled: titled_uris.len(),
-            unique_identifiers: expected_identifiers.len(),
-            datasets,
-        })
+        let query = self.build_values_metadata_query(uris);
+        let bindings = self.execute_query_with_retry(&query).await?;
+        Ok(self.bindings_to_datasets(bindings))
     }
 
     /// [`execute_query`](Self::execute_query) with bounded retry + exponential
@@ -934,32 +840,14 @@ impl SparqlDcatClient {
         )
     }
 
-    /// Builds the title query for a keyset metadata batch. Titles are fetched
-    /// without a language filter; language selection happens client-side.
-    fn build_values_title_query(&self, uris: &[String]) -> String {
-        self.build_values_property_query(uris, "title", "dct:title")
-    }
-
-    fn build_values_description_query(&self, uris: &[String]) -> String {
-        self.build_values_property_query(uris, "description", "dct:description")
-    }
-
-    fn build_values_identifier_query(&self, uris: &[String]) -> String {
-        self.build_values_property_query(uris, "identifier", "dct:identifier")
-    }
-
-    fn build_values_modified_query(&self, uris: &[String]) -> String {
-        self.build_values_property_query(uris, "modified", "dct:modified")
-    }
-
-    /// Builds a bounded query for one multi-valued dataset property. Keeping
-    /// properties separate prevents multilingual fields from multiplying rows.
-    fn build_values_property_query(
-        &self,
-        uris: &[String],
-        variable: &str,
-        predicate: &str,
-    ) -> String {
+    /// Builds the bounded `VALUES` metadata query for a set of dataset URIs.
+    fn build_values_metadata_query(&self, uris: &[String]) -> String {
+        let title_filter = self
+            .lang_filter_alternatives()
+            .iter()
+            .map(|l| format!("lang(?title) = \"{l}\""))
+            .collect::<Vec<_>>()
+            .join(" || ");
         let values = uris
             .iter()
             .filter(|u| is_safe_iri(u))
@@ -970,47 +858,15 @@ impl SparqlDcatClient {
             "PREFIX dcat: <http://www.w3.org/ns/dcat#>\n\
              PREFIX dct:  <http://purl.org/dc/terms/>\n\
              \n\
-             SELECT ?dataset ?{variable}\n\
+             SELECT ?dataset ?title ?description ?identifier ?modified\n\
              WHERE {{\n\
                VALUES ?dataset {{ {values} }}\n\
-               ?dataset {predicate} ?{variable} .\n\
+               ?dataset dct:title ?title .\n\
+               FILTER ({title_filter})\n\
+               OPTIONAL {{ ?dataset dct:description ?description }}\n\
+               OPTIONAL {{ ?dataset dct:identifier ?identifier }}\n\
+               OPTIONAL {{ ?dataset dct:modified ?modified }}\n\
              }}"
-        )
-    }
-
-    /// Builds a bounded query for the DCAT distributions associated with a set
-    /// of datasets. Distribution records are kept separately from the dataset
-    /// query so a dataset's multilingual title/description rows do not multiply
-    /// its distribution rows.
-    fn build_values_distribution_query(&self, uris: &[String]) -> String {
-        let values = uris
-            .iter()
-            .filter(|u| is_safe_iri(u))
-            .map(|u| format!("<{u}>"))
-            .collect::<Vec<_>>()
-            .join(" ");
-        format!(
-            "PREFIX dcat: <http://www.w3.org/ns/dcat#>\n\
-             PREFIX dct:  <http://purl.org/dc/terms/>\n\
-             \n\
-             SELECT ?dataset ?distribution\n\
-                    (SAMPLE(?distributionTitle) AS ?distributionTitle)\n\
-                    (SAMPLE(?distributionDescription) AS ?distributionDescription)\n\
-                    (SAMPLE(?distributionFormat) AS ?distributionFormat)\n\
-                    (SAMPLE(?distributionMediaType) AS ?distributionMediaType)\n\
-                    (SAMPLE(?downloadUrl) AS ?downloadUrl)\n\
-                    (SAMPLE(?accessUrl) AS ?accessUrl)\n\
-             WHERE {{\n\
-               VALUES ?dataset {{ {values} }}\n\
-               ?dataset dcat:distribution ?distribution .\n\
-               OPTIONAL {{ ?distribution dct:title ?distributionTitle }}\n\
-               OPTIONAL {{ ?distribution dct:description ?distributionDescription }}\n\
-               OPTIONAL {{ ?distribution dct:format ?distributionFormat }}\n\
-               OPTIONAL {{ ?distribution dcat:mediaType ?distributionMediaType }}\n\
-               OPTIONAL {{ ?distribution dcat:downloadURL ?downloadUrl }}\n\
-               OPTIONAL {{ ?distribution dcat:accessURL ?accessUrl }}\n\
-             }}\n\
-             GROUP BY ?dataset ?distribution"
         )
     }
 
@@ -1569,25 +1425,17 @@ impl SparqlDcatClient {
 
     /// Checks whether two language tags are siblings (same macro-language).
     fn are_sibling_languages(a: &str, b: &str) -> bool {
-        ["nb", "nn", "no"]
-            .iter()
-            .any(|language| language_matches(a, language))
-            && ["nb", "nn", "no"]
-                .iter()
-                .any(|language| language_matches(b, language))
+        matches!((a, b), ("nb" | "nn" | "no", "nb" | "nn" | "no"))
     }
 
     /// Returns a language-preference rank for selecting the best value.
-    /// Higher rank = better match: preferred language > sibling > English >
-    /// untagged > another language. Other languages remain eligible so a full
-    /// harvest never drops a dataset merely because it lacks a translation.
+    /// Higher rank = better match: preferred language > sibling > "en" > untagged/other.
     fn lang_rank(&self, lang: Option<&str>) -> u8 {
         match lang {
-            Some(l) if language_matches(l, &self.language) => 4,
-            Some(l) if Self::are_sibling_languages(l, &self.language) => 3,
-            Some(l) if language_matches(l, "en") => 2,
-            None | Some("") => 1,
-            Some(_) => 0,
+            Some(l) if l == self.language => 3,
+            Some(l) if Self::are_sibling_languages(l, &self.language) => 2,
+            Some("en") => 1,
+            _ => 0,
         }
     }
 
@@ -1601,12 +1449,9 @@ impl SparqlDcatClient {
             .iter()
             .filter_map(|b| b.get(key))
             .filter(|v| !v.value.is_empty())
-            .max_by_key(|v| {
-                (
-                    self.lang_rank(v.lang.as_deref()),
-                    std::cmp::Reverse(v.lang.as_deref().unwrap_or("")),
-                    std::cmp::Reverse(v.value.as_str()),
-                )
+            .max_by(|a, b| {
+                self.lang_rank(a.lang.as_deref())
+                    .cmp(&self.lang_rank(b.lang.as_deref()))
             })
     }
 
@@ -1676,66 +1521,6 @@ impl SparqlDcatClient {
 
         datasets
     }
-
-    /// Adds normalized DCAT distributions to each dataset's raw metadata.
-    ///
-    /// The schema endpoint reads these conventional DCAT keys directly, while
-    /// callers that need the original SPARQL fields can still use the remaining
-    /// binding-derived metadata on the dataset object.
-    fn attach_distributions(
-        &self,
-        datasets: &mut [DcatDataset],
-        bindings: Vec<HashMap<String, SparqlValue>>,
-    ) {
-        let mut grouped: BTreeMap<(String, String), Vec<HashMap<String, SparqlValue>>> =
-            BTreeMap::new();
-
-        for binding in bindings {
-            let Some(dataset) = binding.get("dataset").map(|v| v.value.clone()) else {
-                continue;
-            };
-            let Some(distribution) = binding.get("distribution").map(|v| v.value.clone()) else {
-                continue;
-            };
-            grouped
-                .entry((dataset, distribution))
-                .or_default()
-                .push(binding);
-        }
-
-        let mut by_dataset: BTreeMap<String, Vec<Value>> = BTreeMap::new();
-        for ((dataset, distribution), rows) in grouped {
-            let mut metadata = serde_json::Map::new();
-            metadata.insert("@id".to_string(), Value::String(distribution));
-
-            for (binding_key, metadata_key) in [
-                ("distributionTitle", "dct:title"),
-                ("distributionDescription", "dct:description"),
-                ("distributionFormat", "dct:format"),
-                ("distributionMediaType", "dcat:mediaType"),
-                ("downloadUrl", "dcat:downloadURL"),
-                ("accessUrl", "dcat:accessURL"),
-            ] {
-                if let Some(value) = self.best_value(&rows, binding_key) {
-                    metadata.insert(metadata_key.to_string(), Value::String(value.value.clone()));
-                }
-            }
-
-            by_dataset
-                .entry(dataset)
-                .or_default()
-                .push(Value::Object(metadata));
-        }
-
-        for dataset in datasets {
-            let Some(distributions) = by_dataset.remove(&dataset.id_uri) else {
-                continue;
-            };
-            if let Some(metadata) = dataset.raw.as_object_mut() {
-                metadata.insert("distribution".to_string(), Value::Array(distributions));
-            }
-        }
-    }
 }
 
 // =============================================================================
@@ -1791,93 +1576,9 @@ fn sparql_escape_literal(s: &str) -> String {
 fn is_safe_iri(iri: &str) -> bool {
     (iri.starts_with("http://") || iri.starts_with("https://"))
         && !iri.bytes().any(|b| {
-            matches!(
-                b,
-                b'<' | b'>' | b'"' | b'{' | b'}' | b'|' | b'^' | b'`' | b'\\'
-            ) || b.is_ascii_whitespace()
+            matches!(b, b'<' | b'>' | b'"' | b'{' | b'}' | b'|' | b'^' | b'`' | b'\\')
+                || b.is_ascii_whitespace()
         })
-}
-
-/// Returns true when `candidate` is `preferred` or one of its BCP 47 subtags.
-/// BCP 47 matching is case-insensitive, so `fr-CA` is a valid fallback for
-/// a preference of `fr`.
-fn language_matches(candidate: &str, preferred: &str) -> bool {
-    candidate.eq_ignore_ascii_case(preferred)
-        || (candidate.len() > preferred.len()
-            && candidate
-                .get(..preferred.len())
-                .is_some_and(|prefix| prefix.eq_ignore_ascii_case(preferred))
-            && candidate.as_bytes()[preferred.len()] == b'-')
-}
-
-/// Finds the identifiers that are expected to be represented in a keyset batch.
-///
-/// data.europa.eu sometimes publishes URI variants (for example a `~~1`
-/// suffix) for the same logical dataset. Ceres stores datasets by
-/// `(source_portal, original_id)`, so these variants intentionally collapse to
-/// one materialized record when they share a non-empty `dct:identifier`.
-fn expected_identifiers(
-    bindings: &[HashMap<String, SparqlValue>],
-    titled_uris: &HashSet<String>,
-) -> HashSet<String> {
-    let mut identifiers_by_uri = HashMap::new();
-    for binding in bindings {
-        let Some(dataset_uri) = binding.get("dataset").map(|value| &value.value) else {
-            continue;
-        };
-        if !titled_uris.contains(dataset_uri) {
-            continue;
-        }
-        if let Some(identifier) = binding
-            .get("identifier")
-            .map(|value| value.value.as_str())
-            .filter(|value| !value.is_empty())
-        {
-            identifiers_by_uri
-                .entry(dataset_uri.clone())
-                .or_insert_with(|| identifier.to_string());
-        }
-    }
-
-    titled_uris
-        .iter()
-        .map(|uri| {
-            identifiers_by_uri
-                .remove(uri)
-                .unwrap_or_else(|| extract_last_segment(uri))
-        })
-        .collect()
-}
-
-/// Ensures a keyset batch did not silently lose a logical dataset after its
-/// metadata was fetched. Untitled entries are intentionally excluded because
-/// [`DcatDataset`] requires a non-empty title, and URI variants that share an
-/// identifier intentionally collapse to a single database record.
-fn verify_keyset_coverage(
-    titled_uris: &HashSet<String>,
-    expected_identifiers: &HashSet<String>,
-    datasets: &[DcatDataset],
-) -> Result<(), AppError> {
-    let materialized_identifiers: HashSet<&str> = datasets
-        .iter()
-        .map(|dataset| dataset.identifier.as_str())
-        .collect();
-    let missing: Vec<&str> = expected_identifiers
-        .iter()
-        .map(String::as_str)
-        .filter(|identifier| !materialized_identifiers.contains(identifier))
-        .take(5)
-        .collect();
-    if !missing.is_empty() || materialized_identifiers.len() != expected_identifiers.len() {
-        return Err(AppError::Generic(format!(
-            "SPARQL keyset coverage check failed: {} titled dataset IRIs, {} unique identifiers, {} materialized; sample missing identifiers: {}",
-            titled_uris.len(),
-            expected_identifiers.len(),
-            materialized_identifiers.len(),
-            missing.join(", ")
-        )));
-    }
-    Ok(())
 }
 
 /// Extracts the last non-empty path segment from a URI.
@@ -1983,119 +1684,34 @@ mod tests {
     }
 
     #[test]
-    fn values_title_query_lists_uris_without_joining_other_properties() {
+    fn values_metadata_query_lists_uris_and_fields() {
         let client = SparqlDcatClient::new("https://data.europa.eu", "en", None).unwrap();
         let uris = vec![
             "http://example.org/d/1".to_string(),
             "https://example.org/d/2".to_string(),
         ];
-        let q = client.build_values_title_query(&uris);
+        let q = client.build_values_metadata_query(&uris);
         assert!(q.contains("VALUES ?dataset {"));
         assert!(q.contains("<http://example.org/d/1>"));
         assert!(q.contains("<https://example.org/d/2>"));
         assert!(q.contains("dct:title ?title"));
-        assert!(
-            !q.contains("lang(?title)"),
-            "a full keyset harvest must not filter title languages"
-        );
-        assert!(!q.contains("OPTIONAL"));
+        assert!(q.contains(r#"lang(?title) = "en""#));
+        assert!(q.contains("OPTIONAL { ?dataset dct:description ?description }"));
         assert!(!q.contains("OFFSET") && !q.contains("ORDER BY"));
     }
 
     #[test]
-    fn values_property_queries_keep_multivalued_fields_separate() {
-        let client = SparqlDcatClient::new("https://data.europa.eu", "en", None).unwrap();
-        let uris = ["https://example.org/d/1".to_string()];
-        for (query, predicate, variable) in [
-            (
-                client.build_values_description_query(&uris),
-                "dct:description",
-                "?description",
-            ),
-            (
-                client.build_values_identifier_query(&uris),
-                "dct:identifier",
-                "?identifier",
-            ),
-            (
-                client.build_values_modified_query(&uris),
-                "dct:modified",
-                "?modified",
-            ),
-        ] {
-            assert!(query.contains(predicate));
-            assert!(query.contains(variable));
-            assert!(!query.contains("OPTIONAL"));
-        }
-    }
-
-    #[test]
-    fn values_distribution_query_includes_schema_metadata() {
-        let client = SparqlDcatClient::new("https://data.europa.eu", "en", None).unwrap();
-        let q = client.build_values_distribution_query(&["https://example.org/d/1".to_string()]);
-        assert!(q.contains("?dataset dcat:distribution ?distribution"));
-        assert!(q.contains("?distribution dct:format ?distributionFormat"));
-        assert!(q.contains("?distribution dcat:mediaType ?distributionMediaType"));
-        assert!(q.contains("?distribution dcat:downloadURL ?downloadUrl"));
-        assert!(q.contains("?distribution dcat:accessURL ?accessUrl"));
-        assert!(q.contains("SAMPLE(?distributionTitle)"));
-        assert!(q.contains("GROUP BY ?dataset ?distribution"));
-    }
-
-    #[test]
-    fn values_title_query_drops_unsafe_iris() {
+    fn values_metadata_query_drops_unsafe_iris() {
         let client = SparqlDcatClient::new("https://data.europa.eu", "en", None).unwrap();
         let uris = vec![
             "http://ok.example/d/1".to_string(),
             "http://bad.example/d 2".to_string(), // space -> unsafe
             "ftp://nope.example/d/3".to_string(), // non-http -> unsafe
         ];
-        let q = client.build_values_title_query(&uris);
+        let q = client.build_values_metadata_query(&uris);
         assert!(q.contains("<http://ok.example/d/1>"));
         assert!(!q.contains("d 2"));
         assert!(!q.contains("ftp://"));
-    }
-
-    #[test]
-    fn coverage_gate_rejects_a_missing_titled_dataset() {
-        let titled_uris = HashSet::from([
-            "https://example.org/d/1".to_string(),
-            "https://example.org/d/2".to_string(),
-        ]);
-        let expected_identifiers = HashSet::from(["1".to_string(), "2".to_string()]);
-        let datasets = vec![DcatDataset {
-            id_uri: "https://example.org/d/1".to_string(),
-            identifier: "1".to_string(),
-            title: "Dataset 1".to_string(),
-            description: None,
-            raw: Value::Null,
-        }];
-
-        let error =
-            verify_keyset_coverage(&titled_uris, &expected_identifiers, &datasets).unwrap_err();
-        assert!(
-            error
-                .to_string()
-                .contains("2 titled dataset IRIs, 2 unique identifiers, 1 materialized")
-        );
-    }
-
-    #[test]
-    fn coverage_gate_allows_uri_variants_with_the_same_identifier() {
-        let titled_uris = HashSet::from([
-            "https://example.org/d/1".to_string(),
-            "https://example.org/d/1~~1".to_string(),
-        ]);
-        let expected_identifiers = HashSet::from(["same-dataset".to_string()]);
-        let datasets = vec![DcatDataset {
-            id_uri: "https://example.org/d/1".to_string(),
-            identifier: "same-dataset".to_string(),
-            title: "Dataset".to_string(),
-            description: None,
-            raw: Value::Null,
-        }];
-
-        verify_keyset_coverage(&titled_uris, &expected_identifiers, &datasets).unwrap();
     }
 
     #[test]
@@ -2287,86 +1903,6 @@ mod tests {
     }
 
     #[test]
-    fn language_selection_accepts_bcp47_variants_and_other_language_fallbacks() {
-        let client = SparqlDcatClient::new("https://example.org", "fr", None).unwrap();
-        let rows = vec![
-            binding("https://example.org/d/1", "title", "Deutsch", Some("de")),
-            binding(
-                "https://example.org/d/1",
-                "title",
-                "Français",
-                Some("fr-CA"),
-            ),
-        ];
-        assert_eq!(client.best_value(&rows, "title").unwrap().value, "Français");
-
-        // A language with no preferred/English/untagged alternative is still a
-        // valid dataset title and must not make the dataset disappear.
-        let rows = vec![binding(
-            "https://example.org/d/2",
-            "title",
-            "Italiano",
-            Some("it"),
-        )];
-        assert_eq!(client.best_value(&rows, "title").unwrap().value, "Italiano");
-    }
-
-    #[test]
-    fn distributions_are_preserved_in_dataset_metadata() {
-        let client = SparqlDcatClient::new("https://data.europa.eu", "en", None).unwrap();
-        let dataset_bindings = vec![binding(
-            "https://example.org/d/1",
-            "title",
-            "Dataset",
-            Some("en"),
-        )];
-        let mut datasets = client.bindings_to_datasets(dataset_bindings);
-
-        let mut distribution = HashMap::new();
-        distribution.insert(
-            "dataset".to_string(),
-            SparqlValue {
-                value: "https://example.org/d/1".to_string(),
-                lang: None,
-            },
-        );
-        distribution.insert(
-            "distribution".to_string(),
-            SparqlValue {
-                value: "https://example.org/distribution/1".to_string(),
-                lang: None,
-            },
-        );
-        for (key, value) in [
-            ("distributionTitle", "CSV export"),
-            ("distributionFormat", "CSV"),
-            ("distributionMediaType", "text/csv"),
-            ("downloadUrl", "https://example.org/data.csv"),
-        ] {
-            distribution.insert(
-                key.to_string(),
-                SparqlValue {
-                    value: value.to_string(),
-                    lang: None,
-                },
-            );
-        }
-
-        client.attach_distributions(&mut datasets, vec![distribution]);
-        let distributions = datasets[0].raw["distribution"].as_array().unwrap();
-        assert_eq!(distributions.len(), 1);
-        assert_eq!(distributions[0]["dct:format"], "CSV");
-        assert_eq!(
-            distributions[0]["dcat:downloadURL"],
-            "https://example.org/data.csv"
-        );
-
-        let schema = ceres_core::DatasetSchema::from_metadata(&datasets[0].raw);
-        assert_eq!(schema.resources.len(), 1);
-        assert_eq!(schema.resources[0].format.as_deref(), Some("CSV"));
-    }
-
-    #[test]
     fn title_and_description_selected_independently() {
         // A dataset may carry the title in the preferred language but the
         // description only in a fallback language; each field is chosen on its own.
@@ -2399,12 +1935,11 @@ mod tests {
     #[test]
     fn lang_rank_orders_preferred_sibling_en_other() {
         let client = SparqlDcatClient::new("https://example.org", "nb", None).unwrap();
-        assert_eq!(client.lang_rank(Some("nb")), 4); // preferred
-        assert_eq!(client.lang_rank(Some("nb-NO")), 4); // preferred BCP 47 variant
-        assert_eq!(client.lang_rank(Some("nn")), 3); // sibling
-        assert_eq!(client.lang_rank(Some("en")), 2); // English fallback
-        assert_eq!(client.lang_rank(None), 1); // untagged fallback
+        assert_eq!(client.lang_rank(Some("nb")), 3); // preferred
+        assert_eq!(client.lang_rank(Some("nn")), 2); // sibling
+        assert_eq!(client.lang_rank(Some("en")), 1); // english fallback
         assert_eq!(client.lang_rank(Some("de")), 0); // unrelated
+        assert_eq!(client.lang_rank(None), 0); // untagged
     }
 
     // ---- extract_last_segment -----------------------------------------------

--- a/crates/ceres-core/src/config.rs
+++ b/crates/ceres-core/src/config.rs
@@ -186,9 +186,41 @@ pub struct HttpConfig {
 impl Default for HttpConfig {
     fn default() -> Self {
         Self {
-            timeout: Duration::from_secs(30),
+            // 60s base. Some healthy-but-slow portals (e.g. govdata.de) take well
+            // over 30s to serve a full `package_search` page; the harvest clients
+            // additionally scale this up adaptively when a page times out.
+            timeout: Duration::from_secs(60),
             max_retries: 3,
             retry_base_delay: Duration::from_millis(500),
+        }
+    }
+}
+
+impl HttpConfig {
+    /// Builds an [`HttpConfig`] from environment variables, falling back to the
+    /// defaults for any var that is unset or unparseable.
+    ///
+    /// Recognized variables (all optional):
+    /// - `CERES_HTTP_TIMEOUT_SECS` — per-request timeout in seconds
+    /// - `CERES_HTTP_MAX_RETRIES` — transient-error retry attempts
+    /// - `CERES_HTTP_RETRY_BASE_MS` — base backoff delay in milliseconds
+    ///
+    /// This is the knob for harvesting slow portals at scale without code
+    /// changes (e.g. `CERES_HTTP_TIMEOUT_SECS=120` for very slow catalogs).
+    pub fn from_env() -> Self {
+        fn env_parse<T: FromStr>(key: &str) -> Option<T> {
+            std::env::var(key).ok()?.trim().parse().ok()
+        }
+
+        let default = Self::default();
+        Self {
+            timeout: env_parse::<u64>("CERES_HTTP_TIMEOUT_SECS")
+                .map(Duration::from_secs)
+                .unwrap_or(default.timeout),
+            max_retries: env_parse::<u32>("CERES_HTTP_MAX_RETRIES").unwrap_or(default.max_retries),
+            retry_base_delay: env_parse::<u64>("CERES_HTTP_RETRY_BASE_MS")
+                .map(Duration::from_millis)
+                .unwrap_or(default.retry_base_delay),
         }
     }
 }
@@ -668,7 +700,7 @@ mod tests {
     #[test]
     fn test_http_config_defaults() {
         let config = HttpConfig::default();
-        assert_eq!(config.timeout, Duration::from_secs(30));
+        assert_eq!(config.timeout, Duration::from_secs(60));
         assert_eq!(config.max_retries, 3);
         assert_eq!(config.retry_base_delay, Duration::from_millis(500));
     }

--- a/crates/ceres-core/src/lib.rs
+++ b/crates/ceres-core/src/lib.rs
@@ -50,6 +50,7 @@ pub mod models;
 pub mod parquet_export;
 pub mod pipeline;
 pub mod progress;
+pub mod schema;
 pub mod search;
 pub mod sync;
 pub mod traits;
@@ -74,6 +75,7 @@ pub use i18n::LocalizedField;
 
 // Domain models
 pub use models::{DatabaseStats, Dataset, NewDataset, SearchResult};
+pub use schema::{DatasetResource, DatasetSchema, ResourceField};
 
 // Sync types and business logic
 pub use sync::{

--- a/crates/ceres-core/src/schema.rs
+++ b/crates/ceres-core/src/schema.rs
@@ -108,14 +108,15 @@ fn first_str(obj: &Value, keys: &[&str]) -> Option<String> {
 /// Normalizes a single resource/distribution node, returning `None` if it is not
 /// a JSON object.
 fn extract_resource(node: &Value) -> Option<DatasetResource> {
-    let obj = node.as_object()?;
-    let node = Value::Object(obj.clone());
+    if !node.is_object() {
+        return None;
+    }
 
     Some(DatasetResource {
-        name: first_str(&node, &["name", "title", "dct:title"]),
-        format: first_str(&node, &["format", "dct:format"]),
+        name: first_str(node, &["name", "title", "dct:title"]),
+        format: first_str(node, &["format", "dct:format"]),
         media_type: first_str(
-            &node,
+            node,
             &[
                 "mimetype",
                 "mediaType",
@@ -125,7 +126,7 @@ fn extract_resource(node: &Value) -> Option<DatasetResource> {
             ],
         ),
         url: first_str(
-            &node,
+            node,
             &[
                 "url",
                 "downloadURL",
@@ -134,8 +135,8 @@ fn extract_resource(node: &Value) -> Option<DatasetResource> {
                 "dcat:accessURL",
             ],
         ),
-        description: first_str(&node, &["description", "dct:description"]),
-        fields: extract_fields(&node),
+        description: first_str(node, &["description", "dct:description"]),
+        fields: extract_fields(node),
     })
 }
 

--- a/crates/ceres-core/src/schema.rs
+++ b/crates/ceres-core/src/schema.rs
@@ -1,0 +1,287 @@
+//! Dataset resource schema, derived from harvested metadata.
+//!
+//! Portals expose information about the individual resources (CKAN) or
+//! distributions (DCAT) that make up a dataset: their format, access URL, and
+//! sometimes a column-level schema (field names and types). That information is
+//! already harvested in full into the `metadata` JSONB column of each dataset,
+//! so this module normalizes it **on read** rather than storing a separate copy.
+//!
+//! The extraction is intentionally defensive and portal-agnostic: it operates on
+//! a raw [`serde_json::Value`] and pulls whatever fields are present, tolerating
+//! the structural differences between CKAN `package_show` output and DCAT-AP
+//! JSON-LD dataset nodes.
+//!
+//! # Limitations
+//!
+//! - Field-level schema only appears when the portal inlined it in the harvested
+//!   metadata (e.g. a Frictionless `schema.fields` block). We do not call CKAN's
+//!   `datastore_info`/`datastore_search`, so DataStore-only schemas are not enriched.
+//! - For DCAT portals, only the dataset node is persisted in `metadata`; the
+//!   separate distribution `@graph` nodes are not, so distribution detail is
+//!   limited to whatever is inlined on the dataset node.
+
+use serde::Serialize;
+use serde_json::Value;
+
+/// A single field (column) within a resource's schema.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ResourceField {
+    /// Field/column name.
+    pub name: String,
+    /// Declared data type, when the portal provides one (e.g. `"text"`, `"numeric"`).
+    pub r#type: Option<String>,
+    /// Optional human-readable description of the field.
+    pub description: Option<String>,
+}
+
+/// A single resource (CKAN) or distribution (DCAT) belonging to a dataset.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct DatasetResource {
+    /// Resource name/title, when available.
+    pub name: Option<String>,
+    /// File format (e.g. `"CSV"`, `"JSON"`).
+    pub format: Option<String>,
+    /// MIME / media type (e.g. `"text/csv"`).
+    pub media_type: Option<String>,
+    /// Direct access URL for the resource.
+    pub url: Option<String>,
+    /// Optional resource description.
+    pub description: Option<String>,
+    /// Column-level schema, when the portal exposed it inline. Empty otherwise.
+    pub fields: Vec<ResourceField>,
+}
+
+/// Normalized resource schema for a dataset.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct DatasetSchema {
+    /// The resources/distributions that make up the dataset.
+    pub resources: Vec<DatasetResource>,
+}
+
+impl DatasetSchema {
+    /// Derives a [`DatasetSchema`] from a dataset's raw `metadata` JSON.
+    ///
+    /// Looks for resource/distribution arrays under the keys used by the
+    /// supported portal types and normalizes each entry. Always returns a value;
+    /// an absent or unrecognized structure yields an empty `resources` vector.
+    pub fn from_metadata(metadata: &Value) -> Self {
+        let mut resources = Vec::new();
+
+        for key in [
+            "resources",
+            "distribution",
+            "dcat:distribution",
+            "distributions",
+        ] {
+            if let Some(Value::Array(items)) = metadata.get(key) {
+                resources.extend(items.iter().filter_map(extract_resource));
+            }
+        }
+
+        Self { resources }
+    }
+}
+
+/// Reads the first present string value among `keys` from a JSON object.
+///
+/// Accepts a plain string, or a JSON-LD language object `{"@value": "..."}`,
+/// returning the first non-empty match.
+fn first_str(obj: &Value, keys: &[&str]) -> Option<String> {
+    for key in keys {
+        match obj.get(*key) {
+            Some(Value::String(s)) if !s.is_empty() => return Some(s.clone()),
+            Some(Value::Object(o)) => {
+                if let Some(s) = o
+                    .get("@value")
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty())
+                {
+                    return Some(s.to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Normalizes a single resource/distribution node, returning `None` if it is not
+/// a JSON object.
+fn extract_resource(node: &Value) -> Option<DatasetResource> {
+    let obj = node.as_object()?;
+    let node = Value::Object(obj.clone());
+
+    Some(DatasetResource {
+        name: first_str(&node, &["name", "title", "dct:title"]),
+        format: first_str(&node, &["format", "dct:format"]),
+        media_type: first_str(
+            &node,
+            &[
+                "mimetype",
+                "mediaType",
+                "mediatype",
+                "media_type",
+                "dcat:mediaType",
+            ],
+        ),
+        url: first_str(
+            &node,
+            &[
+                "url",
+                "downloadURL",
+                "accessURL",
+                "dcat:downloadURL",
+                "dcat:accessURL",
+            ],
+        ),
+        description: first_str(&node, &["description", "dct:description"]),
+        fields: extract_fields(&node),
+    })
+}
+
+/// Extracts column-level fields from a resource node.
+///
+/// Supports the Frictionless table-schema shape (`schema.fields`) and a flat
+/// DataStore-style `fields` array.
+fn extract_fields(node: &Value) -> Vec<ResourceField> {
+    // Frictionless: resource["schema"]["fields"]
+    if let Some(fields) = node
+        .get("schema")
+        .and_then(|s| s.get("fields"))
+        .and_then(|f| f.as_array())
+    {
+        return fields.iter().filter_map(extract_field).collect();
+    }
+
+    // DataStore-style: resource["fields"]
+    if let Some(Value::Array(fields)) = node.get("fields") {
+        return fields.iter().filter_map(extract_field).collect();
+    }
+
+    Vec::new()
+}
+
+/// Normalizes a single field node. Requires a non-empty `name`/`id`.
+fn extract_field(node: &Value) -> Option<ResourceField> {
+    let name = first_str(node, &["name", "id"])?;
+    Some(ResourceField {
+        name,
+        r#type: first_str(node, &["type", "datastore_type"]),
+        description: first_str(node, &["description", "title", "label"]),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn ckan_resource_with_frictionless_schema() {
+        let metadata = json!({
+            "resources": [{
+                "name": "Air quality 2024",
+                "format": "CSV",
+                "mimetype": "text/csv",
+                "url": "https://example.org/aq.csv",
+                "description": "Hourly readings",
+                "schema": {
+                    "fields": [
+                        {"name": "station", "type": "string", "description": "Station id"},
+                        {"name": "pm10", "type": "number"}
+                    ]
+                }
+            }]
+        });
+
+        let schema = DatasetSchema::from_metadata(&metadata);
+        assert_eq!(schema.resources.len(), 1);
+        let r = &schema.resources[0];
+        assert_eq!(r.name.as_deref(), Some("Air quality 2024"));
+        assert_eq!(r.format.as_deref(), Some("CSV"));
+        assert_eq!(r.media_type.as_deref(), Some("text/csv"));
+        assert_eq!(r.url.as_deref(), Some("https://example.org/aq.csv"));
+        assert_eq!(r.fields.len(), 2);
+        assert_eq!(r.fields[0].name, "station");
+        assert_eq!(r.fields[0].r#type.as_deref(), Some("string"));
+        assert_eq!(r.fields[0].description.as_deref(), Some("Station id"));
+        assert_eq!(r.fields[1].name, "pm10");
+        assert_eq!(r.fields[1].description, None);
+    }
+
+    #[test]
+    fn ckan_datastore_style_fields() {
+        let metadata = json!({
+            "resources": [{
+                "name": "Records",
+                "fields": [
+                    {"id": "_id", "type": "int"},
+                    {"id": "value", "datastore_type": "numeric"}
+                ]
+            }]
+        });
+
+        let schema = DatasetSchema::from_metadata(&metadata);
+        let r = &schema.resources[0];
+        assert_eq!(r.fields.len(), 2);
+        assert_eq!(r.fields[0].name, "_id");
+        assert_eq!(r.fields[0].r#type.as_deref(), Some("int"));
+        assert_eq!(r.fields[1].name, "value");
+        assert_eq!(r.fields[1].r#type.as_deref(), Some("numeric"));
+    }
+
+    #[test]
+    fn ckan_resource_without_fields() {
+        let metadata = json!({
+            "resources": [{"name": "doc.pdf", "format": "PDF", "url": "https://example.org/doc.pdf"}]
+        });
+
+        let schema = DatasetSchema::from_metadata(&metadata);
+        assert_eq!(schema.resources.len(), 1);
+        assert!(schema.resources[0].fields.is_empty());
+        assert_eq!(schema.resources[0].format.as_deref(), Some("PDF"));
+    }
+
+    #[test]
+    fn resources_absent_yields_empty() {
+        let metadata = json!({"title": "no resources here"});
+        assert!(DatasetSchema::from_metadata(&metadata).resources.is_empty());
+    }
+
+    #[test]
+    fn null_metadata_yields_empty() {
+        assert!(
+            DatasetSchema::from_metadata(&Value::Null)
+                .resources
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn dcat_inline_distribution() {
+        let metadata = json!({
+            "distribution": [{
+                "@type": "Distribution",
+                "dct:title": {"@value": "GeoJSON export"},
+                "dct:format": "GeoJSON",
+                "dcat:downloadURL": "https://example.org/data.geojson"
+            }]
+        });
+
+        let schema = DatasetSchema::from_metadata(&metadata);
+        assert_eq!(schema.resources.len(), 1);
+        let r = &schema.resources[0];
+        assert_eq!(r.name.as_deref(), Some("GeoJSON export"));
+        assert_eq!(r.format.as_deref(), Some("GeoJSON"));
+        assert_eq!(r.url.as_deref(), Some("https://example.org/data.geojson"));
+        assert!(r.fields.is_empty());
+    }
+
+    #[test]
+    fn non_object_resource_entries_skipped() {
+        let metadata = json!({"resources": ["just-a-string", 42, {"name": "ok"}]});
+        let schema = DatasetSchema::from_metadata(&metadata);
+        assert_eq!(schema.resources.len(), 1);
+        assert_eq!(schema.resources[0].name.as_deref(), Some("ok"));
+    }
+}

--- a/crates/ceres-server/src/dto/response.rs
+++ b/crates/ceres-server/src/dto/response.rs
@@ -276,3 +276,86 @@ impl From<ceres_core::Dataset> for DatasetResponse {
         }
     }
 }
+
+/// Normalized resource schema for a dataset.
+///
+/// Derived on read from the dataset's harvested `metadata` (CKAN resources or
+/// DCAT distributions); see [`ceres_core::DatasetSchema`].
+#[derive(Debug, Serialize, ToSchema)]
+pub struct DatasetSchemaResponse {
+    /// Dataset UUID
+    pub id: Uuid,
+    /// Original ID from source portal
+    pub original_id: String,
+    /// Source portal URL
+    pub source_portal: String,
+    /// Resources/distributions that make up the dataset
+    pub resources: Vec<DatasetResourceDto>,
+}
+
+/// A single resource (CKAN) or distribution (DCAT) within a dataset.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct DatasetResourceDto {
+    /// Resource name/title
+    pub name: Option<String>,
+    /// File format (e.g. "CSV", "JSON")
+    pub format: Option<String>,
+    /// MIME / media type (e.g. "text/csv")
+    pub media_type: Option<String>,
+    /// Direct access URL for the resource
+    pub url: Option<String>,
+    /// Resource description
+    pub description: Option<String>,
+    /// Column-level schema, when the portal exposed it inline
+    pub fields: Vec<ResourceFieldDto>,
+}
+
+/// A single field (column) within a resource's schema.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ResourceFieldDto {
+    /// Field/column name
+    pub name: String,
+    /// Declared data type, when available
+    pub r#type: Option<String>,
+    /// Optional field description
+    pub description: Option<String>,
+}
+
+impl From<ceres_core::Dataset> for DatasetSchemaResponse {
+    fn from(d: ceres_core::Dataset) -> Self {
+        let schema = ceres_core::DatasetSchema::from_metadata(&d.metadata);
+        Self {
+            id: d.id,
+            original_id: d.original_id,
+            source_portal: d.source_portal,
+            resources: schema
+                .resources
+                .into_iter()
+                .map(DatasetResourceDto::from)
+                .collect(),
+        }
+    }
+}
+
+impl From<ceres_core::DatasetResource> for DatasetResourceDto {
+    fn from(r: ceres_core::DatasetResource) -> Self {
+        Self {
+            name: r.name,
+            format: r.format,
+            media_type: r.media_type,
+            url: r.url,
+            description: r.description,
+            fields: r.fields.into_iter().map(ResourceFieldDto::from).collect(),
+        }
+    }
+}
+
+impl From<ceres_core::ResourceField> for ResourceFieldDto {
+    fn from(f: ceres_core::ResourceField) -> Self {
+        Self {
+            name: f.name,
+            r#type: f.r#type,
+            description: f.description,
+        }
+    }
+}

--- a/crates/ceres-server/src/handlers/datasets.rs
+++ b/crates/ceres-server/src/handlers/datasets.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 
 use ceres_core::DatasetStore;
 
-use crate::dto::DatasetResponse;
+use crate::dto::{DatasetResponse, DatasetSchemaResponse};
 use crate::error::ApiError;
 use crate::state::AppState;
 
@@ -40,4 +40,36 @@ pub async fn get_dataset_by_id(
         .ok_or_else(|| ApiError::NotFound(format!("Dataset not found: {}", id)))?;
 
     Ok(Json(DatasetResponse::from(dataset)))
+}
+
+/// Get the resource schema for a dataset.
+///
+/// Returns the normalized resources/distributions (format, access URL, and
+/// column-level fields when the portal exposed them inline), derived on read
+/// from the dataset's harvested metadata.
+#[utoipa::path(
+    get,
+    path = "/api/v1/datasets/{id}/schema",
+    params(
+        ("id" = Uuid, Path, description = "Dataset UUID")
+    ),
+    responses(
+        (status = 200, description = "Schema derived", body = DatasetSchemaResponse),
+        (status = 404, description = "Dataset not found"),
+        (status = 500, description = "Internal server error"),
+    ),
+    tag = "datasets"
+)]
+pub async fn get_dataset_schema(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<DatasetSchemaResponse>, ApiError> {
+    let dataset = state
+        .dataset_repo
+        .get_by_id(id)
+        .await
+        .map_err(ApiError::from)?
+        .ok_or_else(|| ApiError::NotFound(format!("Dataset not found: {}", id)))?;
+
+    Ok(Json(DatasetSchemaResponse::from(dataset)))
 }

--- a/crates/ceres-server/src/openapi.rs
+++ b/crates/ceres-server/src/openapi.rs
@@ -3,9 +3,10 @@
 use utoipa::OpenApi;
 
 use crate::dto::{
-    DatasetResponse, ExportQuery, HarvestJobResponse, HarvestStatusResponse, HealthResponse,
-    PortalInfoResponse, PortalStatsResponse, SearchQuery, SearchResponse, SearchResultDto,
-    ServiceStatus, StatsResponse, SyncStatsDto, TriggerHarvestRequest,
+    DatasetResourceDto, DatasetResponse, DatasetSchemaResponse, ExportQuery, HarvestJobResponse,
+    HarvestStatusResponse, HealthResponse, PortalInfoResponse, PortalStatsResponse,
+    ResourceFieldDto, SearchQuery, SearchResponse, SearchResultDto, ServiceStatus, StatsResponse,
+    SyncStatsDto, TriggerHarvestRequest,
 };
 use crate::handlers::{datasets, export, harvest, health, portals, search, stats};
 
@@ -56,6 +57,7 @@ semantic search capabilities using vector embeddings.
         harvest::get_harvest_status,
         export::export_datasets,
         datasets::get_dataset_by_id,
+        datasets::get_dataset_schema,
     ),
     components(
         schemas(
@@ -75,6 +77,9 @@ semantic search capabilities using vector embeddings.
             HarvestStatusResponse,
             SyncStatsDto,
             DatasetResponse,
+            DatasetSchemaResponse,
+            DatasetResourceDto,
+            ResourceFieldDto,
         )
     ),
     tags(

--- a/crates/ceres-server/src/router.rs
+++ b/crates/ceres-server/src/router.rs
@@ -29,7 +29,8 @@ pub fn create_router(state: AppState, config: &ServerConfig) -> Router {
         .route("/portals", get(portals::list_portals))
         .route("/portals/:name/stats", get(portals::get_portal_stats))
         .route("/harvest/status", get(harvest::get_harvest_status))
-        .route("/datasets/:id", get(datasets::get_dataset_by_id));
+        .route("/datasets/:id", get(datasets::get_dataset_by_id))
+        .route("/datasets/:id/schema", get(datasets::get_dataset_schema));
 
     // Protected routes (require Bearer token)
     let protected_routes = Router::new()

--- a/crates/ceres-server/tests/integration/handler_tests.rs
+++ b/crates/ceres-server/tests/integration/handler_tests.rs
@@ -152,3 +152,97 @@ async fn test_protected_endpoint_disabled_returns_403() {
 
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
 }
+
+// =============================================================================
+// Dataset schema endpoint
+// =============================================================================
+
+#[tokio::test]
+async fn test_dataset_schema_returns_normalized_resources() {
+    let app = TestApp::new().await;
+
+    // Seed a dataset whose metadata carries CKAN-style resources with an
+    // inline Frictionless field schema.
+    let metadata = serde_json::json!({
+        "resources": [{
+            "name": "Air quality 2024",
+            "format": "CSV",
+            "mimetype": "text/csv",
+            "url": "https://example.org/aq.csv",
+            "schema": {
+                "fields": [
+                    {"name": "station", "type": "string", "description": "Station id"},
+                    {"name": "pm10", "type": "number"}
+                ]
+            }
+        }]
+    });
+
+    let id: uuid::Uuid = sqlx::query_scalar(
+        "INSERT INTO datasets (original_id, source_portal, url, title, description, metadata, content_hash) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id",
+    )
+    .bind("ds-schema-1")
+    .bind("https://example.org")
+    .bind("https://example.org/dataset/ds-schema-1")
+    .bind("Air quality dataset")
+    .bind(Some("desc"))
+    .bind(metadata)
+    .bind("hash-1")
+    .fetch_one(&app.pool)
+    .await
+    .expect("failed to seed dataset");
+
+    let response = app
+        .router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/datasets/{}/schema", id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = response.status();
+    let json = body_json(response.into_body()).await;
+    assert_eq!(status, StatusCode::OK, "Response: {:?}", json);
+
+    assert_eq!(json["id"], id.to_string());
+    assert_eq!(json["source_portal"], "https://example.org");
+    let resources = json["resources"].as_array().expect("resources array");
+    assert_eq!(resources.len(), 1);
+    let r = &resources[0];
+    assert_eq!(r["name"], "Air quality 2024");
+    assert_eq!(r["format"], "CSV");
+    assert_eq!(r["media_type"], "text/csv");
+    assert_eq!(r["url"], "https://example.org/aq.csv");
+
+    let fields = r["fields"].as_array().expect("fields array");
+    assert_eq!(fields.len(), 2);
+    assert_eq!(fields[0]["name"], "station");
+    assert_eq!(fields[0]["type"], "string");
+    assert_eq!(fields[0]["description"], "Station id");
+    assert_eq!(fields[1]["name"], "pm10");
+}
+
+#[tokio::test]
+async fn test_dataset_schema_not_found_returns_404() {
+    let app = TestApp::new().await;
+
+    let missing = uuid::Uuid::new_v4();
+    let response = app
+        .router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/datasets/{}/schema", missing))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}


### PR DESCRIPTION
## Summary

Partially addresses #68. Normalizes resource/distribution schema already present in harvested metadata and exposes it through:

```
GET /api/v1/datasets/{id}/schema
```

CKAN DataStore enrichment remains follow-up work in #68.

### What changed

- **ceres-core** — new `schema` module with `DatasetSchema::from_metadata`. It derives resources (name, format, media type, URL, description) and inline column-level fields from CKAN resources and DCAT distributions.
- **ceres-server** — schema DTOs, handler, route wiring, and OpenAPI registration.
- **SPARQL / EU Open Data Portal** — the data.europa.eu keyset harvester now treats `language` as a display preference rather than an eligibility filter. It retains datasets with non-English-only titles, selects stable BCP 47-aware fallbacks, and records bounded DCAT distribution metadata for the schema endpoint.
- **Resilience** — retains the branch's CKAN/data.gov and HTTP retry improvements, including correct CKAN action URLs for portals hosted below a path such as `/ckan`.

### Design notes

- Schema remains **derived on read**; no database migration is required.
- The EU keyset path issues a separate bounded distribution query per metadata batch to avoid multiplying multilingual dataset rows. Existing EU datasets should be re-harvested to populate distribution metadata.
- Field-level schema is returned only when the portal inlined it. CKAN DataStore enrichment (`datastore_info` per resource) remains out of scope for this PR and tracked by #68.

### Testing

- Unit coverage for CKAN resource shapes, inline DCAT distributions, non-English/BCP 47 title fallback, language-neutral keyset queries, SPARQL distribution metadata preservation, and path-based CKAN action endpoints.
- `cargo fmt --all -- --check`
- `cargo test -p ceres-client --lib`
- `cargo test -p ceres-core`
- `cargo clippy -p ceres-client -p ceres-core --all-targets -- -D warnings`
- Live data.europa.eu SPARQL probe for the distribution query.