### PR TITLE
feat(parquet): add versioned snapshot manifest and integrity metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,21 @@ ceres export --format csv > datasets.csv
 ceres export --format parquet --output ./ceres-export
 ```
 
+### Published snapshot contract
+
+A Parquet export produces one portable snapshot directory:
+
+- `all.parquet` is the **canonical complete index**.
+- `data/<portal>.parquet` files are convenience subsets and intentionally repeat
+  rows from `all.parquet`; do not add their row counts to the canonical total.
+- `metadata.json` is a versioned manifest with the snapshot ID, UTC generation
+  time, Ceres version and commit, portal-config checksum, curation counts,
+  per-portal inclusion status, and SHA-256 checksums for every Parquet file.
+
+Verify the checksums in `metadata.json` before consuming a copied or mirrored
+snapshot. A library caller that does not supply build metadata records the Git
+commit as `unknown`; the `ceres` CLI populates it automatically.
+
 ### Stats
 
 ```bash

--- a/crates/ceres-cli/src/main.rs
+++ b/crates/ceres-cli/src/main.rs
@@ -147,7 +147,8 @@ async fn main() -> anyhow::Result<()> {
                 let parquet_service = ParquetExportService::new(
                     repo.clone(),
                     portals_config,
-                    ParquetExportConfig::default(),
+                    ParquetExportConfig::default()
+                        .with_git_commit(option_env!("VERGEN_GIT_SHA").unwrap_or("unknown")),
                 );
                 let result = parquet_service.export_to_directory(&output_dir).await?;
                 print_parquet_export_summary(&result);
@@ -440,6 +441,8 @@ fn print_parquet_export_summary(result: &ParquetExportResult) {
     eprintln!("  PARQUET EXPORT COMPLETE");
     eprintln!("═══════════════════════════════════════════════════════");
     eprintln!("  Output:              {}", result.output_dir.display());
+    eprintln!("  Snapshot ID:         {}", result.snapshot_id);
+    eprintln!("  Generated at:        {}", result.generated_at);
     eprintln!("  Snapshot date:       {}", result.snapshot_date);
     eprintln!("  Total exported:      {}", result.total_exported);
     eprintln!("  Filtered (noise):    {}", result.total_filtered);

--- a/crates/ceres-core/src/lib.rs
+++ b/crates/ceres-core/src/lib.rs
@@ -94,7 +94,11 @@ pub use traits::{DatasetStore, EmbeddingProvider, PortalClient, PortalClientFact
 pub use embedding::{EmbeddingService, EmbeddingStats};
 pub use export::{ExportFormat, ExportService};
 pub use harvest::{HarvestService, SyncOptions};
-pub use parquet_export::{ParquetExportConfig, ParquetExportResult, ParquetExportService};
+pub use parquet_export::{
+    CeresBuildInfo, ParquetExportConfig, ParquetExportResult, ParquetExportService,
+    PortalConfigProvenance, PortalExportStats, SNAPSHOT_MANIFEST_SCHEMA_VERSION, SnapshotFile,
+    SnapshotManifest, SnapshotPortal, SnapshotRowCounts,
+};
 pub use pipeline::HarvestPipeline;
 pub use search::SearchService;
 

--- a/crates/ceres-core/src/parquet_export.rs
+++ b/crates/ceres-core/src/parquet_export.rs
@@ -296,6 +296,7 @@ impl<S: DatasetStore> ParquetExportService<S> {
             "all.parquet",
             "canonical",
             result.total_exported,
+            Some(&canonical_checksum),
         )?];
 
         let mut portals = Vec::with_capacity(result.portals.len());
@@ -307,6 +308,7 @@ impl<S: DatasetStore> ParquetExportService<S> {
                 &relative_path,
                 "portal_subset",
                 portal.count,
+                None,
             )?);
             portals.push(SnapshotPortal {
                 name: portal.name.clone(),
@@ -758,6 +760,7 @@ fn snapshot_file(
     relative_path: &str,
     kind: &str,
     row_count: u64,
+    checksum: Option<&str>,
 ) -> Result<SnapshotFile, AppError> {
     let size_bytes = fs::metadata(path)
         .map_err(|e| {
@@ -770,7 +773,10 @@ fn snapshot_file(
         kind: kind.to_string(),
         row_count,
         size_bytes,
-        sha256: sha256_file(path)?,
+        sha256: match checksum {
+            Some(checksum) => checksum.to_string(),
+            None => sha256_file(path)?,
+        },
     })
 }
 

--- a/crates/ceres-core/src/parquet_export.rs
+++ b/crates/ceres-core/src/parquet_export.rs
@@ -6,6 +6,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::fs;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -18,6 +19,7 @@ use parquet::arrow::ArrowWriter;
 use parquet::basic::{Compression, ZstdLevel};
 use parquet::file::properties::WriterProperties;
 use serde::Serialize;
+use sha2::{Digest, Sha256};
 use tracing::info;
 
 use crate::config::PortalsConfig;
@@ -25,7 +27,10 @@ use crate::error::AppError;
 use crate::models::Dataset;
 use crate::traits::DatasetStore;
 
-/// Configuration for Parquet export curation.
+/// Schema version for the snapshot manifest written beside every Parquet export.
+pub const SNAPSHOT_MANIFEST_SCHEMA_VERSION: &str = "1.0.0";
+
+/// Configuration for Parquet export curation and provenance.
 pub struct ParquetExportConfig {
     /// Minimum title length — titles shorter are filtered as noise.
     pub min_title_length: usize,
@@ -33,6 +38,9 @@ pub struct ParquetExportConfig {
     pub noise_patterns: Vec<String>,
     /// Number of rows per Arrow RecordBatch / row group.
     pub batch_size: usize,
+    /// Git commit that produced the exporting binary. `unknown` is retained for
+    /// library callers that do not provide build metadata.
+    pub git_commit: String,
 }
 
 impl Default for ParquetExportConfig {
@@ -41,7 +49,18 @@ impl Default for ParquetExportConfig {
             min_title_length: 5,
             noise_patterns: vec!["test".into(), "prova".into(), "esempio".into()],
             batch_size: 10_000,
+            git_commit: option_env!("VERGEN_GIT_SHA")
+                .unwrap_or("unknown")
+                .to_string(),
         }
+    }
+}
+
+impl ParquetExportConfig {
+    /// Records the commit that produced the binary writing a snapshot manifest.
+    pub fn with_git_commit(mut self, git_commit: impl Into<String>) -> Self {
+        self.git_commit = git_commit.into();
+        self
     }
 }
 
@@ -53,6 +72,9 @@ pub struct ParquetExportResult {
     pub total_duplicates: u64,
     pub portals: Vec<PortalExportStats>,
     pub snapshot_date: String,
+    pub snapshot_id: String,
+    pub generated_at: String,
+    pub manifest_schema_version: String,
     pub output_dir: PathBuf,
 }
 
@@ -62,6 +84,72 @@ pub struct PortalExportStats {
     pub name: String,
     pub url: String,
     pub count: u64,
+    pub portal_type: String,
+    pub profile: Option<String>,
+}
+
+/// A versioned, portable description of a published index snapshot.
+///
+/// This is written as `metadata.json`. It deliberately excludes the local
+/// output directory so the file is portable and suitable for publication.
+#[derive(Debug, Serialize)]
+pub struct SnapshotManifest {
+    pub schema_version: String,
+    pub snapshot_id: String,
+    pub generated_at: String,
+    pub snapshot_date: String,
+    pub ceres: CeresBuildInfo,
+    pub portal_config: PortalConfigProvenance,
+    pub row_counts: SnapshotRowCounts,
+    pub canonical_file: String,
+    pub files: Vec<SnapshotFile>,
+    pub portals: Vec<SnapshotPortal>,
+    pub warnings: Vec<String>,
+}
+
+/// Ceres build metadata embedded in a snapshot manifest.
+#[derive(Debug, Serialize)]
+pub struct CeresBuildInfo {
+    pub version: String,
+    pub git_commit: String,
+}
+
+/// Provenance for the portal configuration used while exporting a snapshot.
+#[derive(Debug, Serialize)]
+pub struct PortalConfigProvenance {
+    /// SHA-256 of the serialized portal configuration, when one was supplied.
+    pub sha256: Option<String>,
+}
+
+/// Counts showing how curation changed the database rows considered for export.
+#[derive(Debug, Serialize)]
+pub struct SnapshotRowCounts {
+    pub raw: u64,
+    pub exported: u64,
+    pub filtered: u64,
+    pub duplicate_flagged: u64,
+}
+
+/// Integrity metadata for a published data file.
+#[derive(Debug, Serialize)]
+pub struct SnapshotFile {
+    pub path: String,
+    pub kind: String,
+    pub row_count: u64,
+    pub size_bytes: u64,
+    pub sha256: String,
+}
+
+/// Per-portal inclusion status for a snapshot.
+#[derive(Debug, Serialize)]
+pub struct SnapshotPortal {
+    pub name: String,
+    pub source_url: String,
+    pub portal_type: String,
+    pub profile: Option<String>,
+    pub status: String,
+    pub row_count: u64,
+    pub file: String,
 }
 
 /// Intermediate flattened record between Database `Dataset` and Arrow `RecordBatch`.
@@ -88,6 +176,9 @@ pub struct ParquetExportService<S: DatasetStore> {
     config: ParquetExportConfig,
     portal_names: HashMap<String, String>,
     portal_languages: HashMap<String, String>,
+    portal_types: HashMap<String, String>,
+    portal_profiles: HashMap<String, Option<String>>,
+    portal_config_sha256: Option<String>,
 }
 
 impl<S: DatasetStore> ParquetExportService<S> {
@@ -102,12 +193,18 @@ impl<S: DatasetStore> ParquetExportService<S> {
     ) -> Self {
         let mut portal_names = HashMap::new();
         let mut portal_languages = HashMap::new();
+        let mut portal_types = HashMap::new();
+        let mut portal_profiles = HashMap::new();
+        let portal_config_sha256 = portals_config.as_ref().map(hash_portals_config);
 
         if let Some(pc) = &portals_config {
             for entry in &pc.portals {
                 let url = normalize_portal_url(&entry.url);
                 portal_names.insert(url.clone(), entry.name.clone());
                 portal_languages.insert(url, entry.language().to_string());
+                let url = normalize_portal_url(&entry.url);
+                portal_types.insert(url.clone(), entry.portal_type.to_string());
+                portal_profiles.insert(url, entry.profile().map(str::to_string));
             }
         }
 
@@ -116,6 +213,9 @@ impl<S: DatasetStore> ParquetExportService<S> {
             config,
             portal_names,
             portal_languages,
+            portal_types,
+            portal_profiles,
+            portal_config_sha256,
         }
     }
 
@@ -124,7 +224,7 @@ impl<S: DatasetStore> ParquetExportService<S> {
     /// Creates:
     /// - `all.parquet` — complete curated dataset
     /// - `data/<portal-name>.parquet` — per-portal subsets
-    /// - `metadata.json` — snapshot metadata with counts
+    /// - `metadata.json` — versioned snapshot manifest and integrity metadata
     pub async fn export_to_directory(
         &self,
         output_dir: &Path,
@@ -150,20 +250,28 @@ impl<S: DatasetStore> ParquetExportService<S> {
         let (exported, filtered, duplicates, portal_stats) =
             self.stream_and_write(output_dir, &duplicate_titles).await?;
 
-        let snapshot_date = Utc::now().format("%Y-%m-%d").to_string();
+        let generated_at = Utc::now();
+        let snapshot_date = generated_at.format("%Y-%m-%d").to_string();
+        let generated_at = generated_at.to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
 
-        let result = ParquetExportResult {
+        let mut result = ParquetExportResult {
             total_exported: exported,
             total_filtered: filtered,
             total_duplicates: duplicates,
             portals: portal_stats,
-            snapshot_date: snapshot_date.clone(),
+            snapshot_date,
+            snapshot_id: String::new(),
+            generated_at,
+            manifest_schema_version: SNAPSHOT_MANIFEST_SCHEMA_VERSION.to_string(),
             output_dir: output_dir.to_path_buf(),
         };
 
-        // Write metadata.json
+        let manifest = self.build_manifest(output_dir, &result)?;
+        result.snapshot_id = manifest.snapshot_id.clone();
+
+        // Write the portable snapshot manifest, never the local output path.
         let metadata_path = output_dir.join("metadata.json");
-        let metadata_json = serde_json::to_string_pretty(&result)
+        let metadata_json = serde_json::to_string_pretty(&manifest)
             .map_err(|e| AppError::ExportError(format!("Failed to serialize metadata: {}", e)))?;
         fs::write(&metadata_path, metadata_json).map_err(|e| {
             AppError::IoError(format!(
@@ -174,6 +282,78 @@ impl<S: DatasetStore> ParquetExportService<S> {
         })?;
 
         Ok(result)
+    }
+
+    fn build_manifest(
+        &self,
+        output_dir: &Path,
+        result: &ParquetExportResult,
+    ) -> Result<SnapshotManifest, AppError> {
+        let canonical_path = output_dir.join("all.parquet");
+        let canonical_checksum = sha256_file(&canonical_path)?;
+        let mut files = vec![snapshot_file(
+            &canonical_path,
+            "all.parquet",
+            "canonical",
+            result.total_exported,
+        )?];
+
+        let mut portals = Vec::with_capacity(result.portals.len());
+        for portal in &result.portals {
+            let relative_path = format!("data/{}.parquet", portal_file_name(&portal.name));
+            let file_path = output_dir.join(&relative_path);
+            files.push(snapshot_file(
+                &file_path,
+                &relative_path,
+                "portal_subset",
+                portal.count,
+            )?);
+            portals.push(SnapshotPortal {
+                name: portal.name.clone(),
+                source_url: portal.url.clone(),
+                portal_type: portal.portal_type.clone(),
+                profile: portal.profile.clone(),
+                status: "included".to_string(),
+                row_count: portal.count,
+                file: relative_path,
+            });
+        }
+
+        let mut warnings = Vec::new();
+        if self.portal_config_sha256.is_none() {
+            warnings.push(
+                "No portals configuration was supplied; portal type/profile provenance may be unknown."
+                    .to_string(),
+            );
+        }
+
+        Ok(SnapshotManifest {
+            schema_version: SNAPSHOT_MANIFEST_SCHEMA_VERSION.to_string(),
+            snapshot_id: format!(
+                "ceres-{}-{}",
+                result.snapshot_date.replace('-', ""),
+                &canonical_checksum[..12]
+            ),
+            generated_at: result.generated_at.clone(),
+            snapshot_date: result.snapshot_date.clone(),
+            ceres: CeresBuildInfo {
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                git_commit: self.config.git_commit.clone(),
+            },
+            portal_config: PortalConfigProvenance {
+                sha256: self.portal_config_sha256.clone(),
+            },
+            row_counts: SnapshotRowCounts {
+                raw: result.total_exported + result.total_filtered,
+                exported: result.total_exported,
+                filtered: result.total_filtered,
+                duplicate_flagged: result.total_duplicates,
+            },
+            canonical_file: "all.parquet".to_string(),
+            files,
+            portals,
+            warnings,
+        })
     }
 
     /// Streams all datasets, applies curation, and writes Parquet files.
@@ -340,10 +520,18 @@ impl<S: DatasetStore> ParquetExportService<S> {
             .into_iter()
             .map(|(portal_key, count)| {
                 let (ref name, _) = portal_info[&portal_key];
+                let portal_type = self
+                    .portal_types
+                    .get(&portal_key)
+                    .cloned()
+                    .unwrap_or_else(|| "unknown".to_string());
+                let profile = self.portal_profiles.get(&portal_key).cloned().flatten();
                 PortalExportStats {
                     name: name.clone(),
                     url: portal_key,
                     count,
+                    portal_type,
+                    profile,
                 }
             })
             .collect();
@@ -548,6 +736,70 @@ fn get_or_create_portal_writer<'a>(
     Ok(writers
         .get_mut(portal_key)
         .expect("writer just inserted above"))
+}
+
+// =============================================================================
+// Snapshot Manifest Helpers
+// =============================================================================
+
+/// Hashes the logical portal configuration used to resolve export provenance.
+///
+/// The serialized representation is deterministic for these struct fields and
+/// avoids leaking a local configuration path into a published manifest.
+fn hash_portals_config(config: &PortalsConfig) -> String {
+    let serialized =
+        serde_json::to_vec(config).expect("PortalsConfig contains only serializable values");
+    sha256_bytes(&serialized)
+}
+
+/// Builds integrity metadata after a Parquet writer has been closed.
+fn snapshot_file(
+    path: &Path,
+    relative_path: &str,
+    kind: &str,
+    row_count: u64,
+) -> Result<SnapshotFile, AppError> {
+    let size_bytes = fs::metadata(path)
+        .map_err(|e| {
+            AppError::IoError(format!("Failed to read {} metadata: {}", path.display(), e))
+        })?
+        .len();
+
+    Ok(SnapshotFile {
+        path: relative_path.to_string(),
+        kind: kind.to_string(),
+        row_count,
+        size_bytes,
+        sha256: sha256_file(path)?,
+    })
+}
+
+/// Returns the SHA-256 digest of a file without loading it into memory.
+fn sha256_file(path: &Path) -> Result<String, AppError> {
+    let mut file = fs::File::open(path)
+        .map_err(|e| AppError::IoError(format!("Failed to open {}: {}", path.display(), e)))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+
+    loop {
+        let read = file.read(&mut buffer).map_err(|e| {
+            AppError::IoError(format!(
+                "Failed to read {} for checksum: {}",
+                path.display(),
+                e
+            ))
+        })?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn sha256_bytes(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
 }
 
 // =============================================================================

--- a/crates/ceres-core/tests/integration/export_tests.rs
+++ b/crates/ceres-core/tests/integration/export_tests.rs
@@ -6,6 +6,10 @@ use crate::integration::common::{MockDatasetStore, MockPortalData};
 use ceres_core::export::{ExportFormat, ExportService};
 use ceres_core::models::NewDataset;
 use ceres_core::traits::DatasetStore;
+use ceres_core::{
+    ParquetExportConfig, ParquetExportService, PortalEntry, PortalType, PortalsConfig,
+};
+use sha2::{Digest, Sha256};
 
 const TEST_PORTAL_URL: &str = "https://test-portal.example.com";
 
@@ -201,6 +205,90 @@ async fn test_export_csv_empty_store() {
 
     // Should have only header
     assert_eq!(lines.len(), 1, "CSV should have only header line");
+}
+
+// =============================================================================
+// Parquet Snapshot Manifest Tests
+// =============================================================================
+
+#[tokio::test]
+async fn test_parquet_export_writes_versioned_snapshot_manifest() {
+    let store = MockDatasetStore::new();
+    let dataset = NewDataset {
+        original_id: "transport-routes".to_string(),
+        source_portal: TEST_PORTAL_URL.to_string(),
+        url: format!("{TEST_PORTAL_URL}/dataset/transport-routes"),
+        title: "Public transport routes".to_string(),
+        description: Some("Route and stop information for public transport.".to_string()),
+        embedding: None,
+        metadata: serde_json::json!({"tags": [{"name": "transport"}]}),
+        content_hash: NewDataset::compute_content_hash(
+            "Public transport routes",
+            Some("Route and stop information for public transport."),
+        ),
+    };
+    store.upsert(&dataset).await.unwrap();
+
+    let portals = PortalsConfig {
+        portals: vec![PortalEntry {
+            name: "test-portal".to_string(),
+            url: TEST_PORTAL_URL.to_string(),
+            portal_type: PortalType::Ckan,
+            enabled: true,
+            description: None,
+            url_template: None,
+            language: None,
+            profile: None,
+            sparql_endpoint: None,
+        }],
+    };
+    let service = ParquetExportService::new(
+        store,
+        Some(portals),
+        ParquetExportConfig::default().with_git_commit("abc123def"),
+    );
+    let output = tempfile::tempdir().unwrap();
+
+    let result = service.export_to_directory(output.path()).await.unwrap();
+    let manifest: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(output.path().join("metadata.json")).unwrap())
+            .unwrap();
+
+    assert_eq!(manifest["schema_version"], "1.0.0");
+    assert_eq!(manifest["snapshot_id"], result.snapshot_id);
+    assert_eq!(manifest["ceres"]["git_commit"], "abc123def");
+    assert_eq!(manifest["canonical_file"], "all.parquet");
+    assert_eq!(manifest["row_counts"]["raw"], 1);
+    assert_eq!(manifest["row_counts"]["exported"], 1);
+    assert!(manifest["portal_config"]["sha256"].as_str().is_some());
+    assert!(manifest.get("output_dir").is_none());
+
+    let files = manifest["files"].as_array().unwrap();
+    assert_eq!(files.len(), 2);
+    assert!(
+        files
+            .iter()
+            .all(|file| file["sha256"].as_str().unwrap().len() == 64)
+    );
+    assert!(
+        files
+            .iter()
+            .all(|file| file["size_bytes"].as_u64().unwrap() > 0)
+    );
+    let canonical = files
+        .iter()
+        .find(|file| file["path"] == "all.parquet")
+        .unwrap();
+    let canonical_bytes = std::fs::read(output.path().join("all.parquet")).unwrap();
+    assert_eq!(
+        canonical["sha256"],
+        format!("{:x}", Sha256::digest(canonical_bytes))
+    );
+
+    let portal = &manifest["portals"][0];
+    assert_eq!(portal["status"], "included");
+    assert_eq!(portal["portal_type"], "ckan");
+    assert_eq!(portal["file"], "data/test-portal.parquet");
 }
 
 #[tokio::test]

--- a/crates/ceres-core/tests/integration/export_tests.rs
+++ b/crates/ceres-core/tests/integration/export_tests.rs
@@ -280,9 +280,10 @@ async fn test_parquet_export_writes_versioned_snapshot_manifest() {
         .find(|file| file["path"] == "all.parquet")
         .unwrap();
     let canonical_bytes = std::fs::read(output.path().join("all.parquet")).unwrap();
+    let expected_checksum = format!("{:x}", Sha256::digest(canonical_bytes));
     assert_eq!(
-        canonical["sha256"],
-        format!("{:x}", Sha256::digest(canonical_bytes))
+        canonical["sha256"].as_str(),
+        Some(expected_checksum.as_str())
     );
 
     let portal = &manifest["portals"][0];


### PR DESCRIPTION
## Summary

introduces the versioned Parquet snapshot manifest

- writes a portable `metadata.json` manifest with provenance, row counts, per-portal inclusion data, and SHA-256 checksums
- records the CLI build commit and prints snapshot identity
- documents `all.parquet` as the canonical file and clarifies per-portal duplication
- adds an offline integrity test that recomputes the canonical file checksum

## Validation

- `cargo test -p ceres-client -p ceres-core`
- `cargo check -p ceres-search`
- `cargo clippy -p ceres-core -p ceres-search --all-targets -- -D warnings`

The full-workspace formatter still reports existing mixed-newline diagnostics in unrelated files; the touched files pass targeted `rustfmt --check`.