### PR TITLE
chore: Tighten pre-0.5 docs and infra

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,8 @@
 # =============================================================================
 
 # Database Configuration
-# Defaults match compose.yml. Override these in .env or compose.override.yml for local stacks.
+# POSTGRES_* values are read by docker compose. If you change them, keep
+# DATABASE_URL in sync because the CLI/server read DATABASE_URL directly.
 POSTGRES_USER=ceres_user
 POSTGRES_PASSWORD=password
 POSTGRES_DB=ceres_db

--- a/.env.example
+++ b/.env.example
@@ -3,9 +3,16 @@
 # =============================================================================
 
 # Database Configuration
-# Must match compose.yml: user=ceres_user, password=password, db=ceres_db
+# Defaults match compose.yml. Override these in .env or compose.override.yml for local stacks.
+POSTGRES_USER=ceres_user
+POSTGRES_PASSWORD=password
+POSTGRES_DB=ceres_db
 DATABASE_URL=postgresql://ceres_user:password@localhost:5432/ceres_db
 DB_MAX_CONNECTIONS=10
+
+# Optional pgAdmin service in compose.yml
+PGADMIN_DEFAULT_EMAIL=admin@ceres.local
+PGADMIN_DEFAULT_PASSWORD=change-me
 
 # Embedding Provider: "gemini" (default) or "openai"
 EMBEDDING_PROVIDER=gemini

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ Thumbs.db
 *.db
 *.sqlite
 *.sqlite3
+compose.override.yml
 
 # Logs
 *.log

--- a/README.md
+++ b/README.md
@@ -342,7 +342,11 @@ The website lives in `website/` and documents the same harvest-first model:
 
 ## Version
 
-Current version: `0.4.0`
+Current released version: `0.4.2`
+
+The `0.5.0` milestone is focused on the published index contract: versioned
+snapshot manifests, integrity checks, coverage and quality reports, explicit
+duplicate/source-alias semantics, and snapshot-to-snapshot changelogs.
 
 ## Contributing
 

--- a/compose.yml
+++ b/compose.yml
@@ -4,9 +4,9 @@ services:
     container_name: ceres_db
     restart: always
     environment:
-      POSTGRES_USER: ceres_user
-      POSTGRES_PASSWORD: password
-      POSTGRES_DB: ceres_db
+      POSTGRES_USER: ${POSTGRES_USER:-ceres_user}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-password}
+      POSTGRES_DB: ${POSTGRES_DB:-ceres_db}
     ports:
       - "5432:5432"
     # HNSW index builds need shared memory for parallel workers; the 64MB default
@@ -27,7 +27,7 @@ services:
     volumes:
       - ceres_pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ceres_user -d ceres_db"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-ceres_user} -d ${POSTGRES_DB:-ceres_db}"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -41,7 +41,7 @@ services:
 #      - path: .env
 #        required: false
 #    environment:
-#      DATABASE_URL: postgresql://ceres_user:password@db:5432/ceres_db
+#      DATABASE_URL: postgresql://${POSTGRES_USER:-ceres_user}:${POSTGRES_PASSWORD:-password}@db:5432/${POSTGRES_DB:-ceres_db}
 #    ports:
 #      - "3000:3000"
 #    depends_on:
@@ -52,10 +52,10 @@ services:
   pgadmin:
     image: dpage/pgadmin4
     container_name: ceres_pgadmin
-    restart: always
+    restart: unless-stopped
     environment:
-      PGADMIN_DEFAULT_EMAIL: admin@ceres.com
-      PGADMIN_DEFAULT_PASSWORD: admin
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:-admin@ceres.local}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-change-me}
     ports:
       - "5050:80"
     depends_on:

--- a/crates/ceres-server/src/main.rs
+++ b/crates/ceres-server/src/main.rs
@@ -13,7 +13,7 @@ use sqlx::postgres::PgPoolOptions;
 use tokio::net::TcpListener;
 use tokio::signal;
 use tokio_util::sync::CancellationToken;
-use tracing::{Level, info};
+use tracing::{Level, info, warn};
 use tracing_subscriber::FmtSubscriber;
 
 use ceres_client::{EmbeddingConfig, EmbeddingProviderEnum};
@@ -91,6 +91,16 @@ async fn main() -> anyhow::Result<()> {
         info!("Admin authentication: enabled");
     } else {
         info!("Admin authentication: disabled (set CERES_ADMIN_TOKEN to enable)");
+    }
+
+    if config
+        .cors_origins
+        .split(',')
+        .any(|origin| origin.trim() == "*")
+    {
+        warn!(
+            "CORS_ALLOWED_ORIGINS includes '*'. This is convenient for local development, but production deployments should set explicit origins."
+        );
     }
 
     // Create application state

--- a/crates/ceres-server/src/main.rs
+++ b/crates/ceres-server/src/main.rs
@@ -93,13 +93,9 @@ async fn main() -> anyhow::Result<()> {
         info!("Admin authentication: disabled (set CERES_ADMIN_TOKEN to enable)");
     }
 
-    if config
-        .cors_origins
-        .split(',')
-        .any(|origin| origin.trim() == "*")
-    {
+    if config.cors_origins.trim() == "*" {
         warn!(
-            "CORS_ALLOWED_ORIGINS includes '*'. This is convenient for local development, but production deployments should set explicit origins."
+            "CORS_ALLOWED_ORIGINS is set to '*'. This is convenient for local development, but production deployments should set explicit origins."
         );
     }
 

--- a/website/src/content/docs/SECURITY.md
+++ b/website/src/content/docs/SECURITY.md
@@ -33,6 +33,7 @@ When using Ceres:
 
 - **API Keys**: Never commit API keys or database credentials to version control
 - **Admin Endpoints**: Protect harvest and admin API endpoints with a strong `CERES_ADMIN_TOKEN` (Bearer token auth)
+- **CORS**: Keep `CORS_ALLOWED_ORIGINS=*` for local development only; production deployments should list explicit trusted origins
 - **Database**: Use strong passwords for PostgreSQL and restrict network access
 - **Input Validation**: Be cautious when harvesting from untrusted data portals
 - **Dependencies**: Keep Rust dependencies updated with `cargo update`; run `cargo deny check` for audits

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -110,11 +110,15 @@ Ceres is designed around that order of work: harvest first, embed later if usefu
 
 <FeatureGrid>
   <div class="ceres-card animate-fade-in-up">
-    <h3>Now (v0.4.0)</h3>
-    <p>Performance at scale and ecosystem consolidation: tuned HNSW vector index, dynamic <code>ef_search</code>, SPARQL-backed DCAT harvesting (e.g. data.europa.eu), more resilient batch embedding under provider failures, and internal refactors for maintainability.</p>
+    <h3>Now (v0.4.2)</h3>
+    <p>Harvest-first operations across CKAN, DCAT udata, and SPARQL-backed DCAT portals, with resource-schema inspection in the API and a curated Parquet export path for the public Open Data Index.</p>
   </div>
   <div class="ceres-card animate-fade-in-up">
     <h3>Next (v0.5.0)</h3>
-    <p>Broader portal coverage (Socrata), multi-tenant operations, webhooks, and a Parquet export endpoint on the REST API.</p>
+    <p>Trust the Index: versioned snapshot manifests, integrity checks, coverage and quality reports, explicit duplicate/source-alias semantics, and snapshot-to-snapshot changelogs.</p>
+  </div>
+  <div class="ceres-card animate-fade-in-up">
+    <h3>After (v0.6.0)</h3>
+    <p>Coverage foundations: static <code>data.json</code> DCAT catalogs, job-based harvesting for every supported portal client, and a small documented set of newly validated portals.</p>
   </div>
 </FeatureGrid>


### PR DESCRIPTION
## Summary

- warn when the server starts with wildcard CORS enabled
- make compose DB and pgAdmin defaults env-driven, with safer pgAdmin restart behavior
- realign README and website roadmap around the completed 0.5.0 trust-the-index milestone

## Validation

- `rustfmt --check crates\ceres-server\src\main.rs`
- `cargo check -p ceres-server --bin ceres-server`
- `cargo test -p ceres-server --lib`
- `docker compose --env-file .env.example config -q`
- `npm ci && npm run build`
