### PR TITLE
enable portal-aware harvest jobs

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,8 @@
+[advisories]
+ignore = [
+    # rsa is retained in Cargo.lock through SQLx's optional MySQL package
+    # metadata, but it is not reachable from the resolved Ceres workspace
+    # graph (`cargo tree --target all -i rsa` is empty). RustSec currently
+    # lists no patched version.
+    "RUSTSEC-2023-0071",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"
@@ -610,6 +610,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bon"
+version = "3.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,38 +651,6 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
-name = "camino"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
 
 [[package]]
 name = "cc"
@@ -745,8 +738,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
- "vergen",
- "vergen-git2",
+ "vergen-gitcl",
 ]
 
 [[package]]
@@ -1020,25 +1012,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,36 +1044,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1118,22 +1067,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn",
 ]
@@ -1168,7 +1106,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -1180,37 +1117,6 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
-dependencies = [
- "derive_builder_core",
  "syn",
 ]
 
@@ -1245,6 +1151,16 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
 ]
 
 [[package]]
@@ -1612,19 +1528,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "git2"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
-dependencies = [
- "bitflags",
- "libc",
- "libgit2-sys",
- "log",
- "url",
-]
-
-[[package]]
 name = "governor"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1639,7 +1542,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "spinning_top",
 ]
@@ -1916,7 +1819,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -2251,18 +2154,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
-name = "libgit2-sys"
-version = "0.17.0+1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "pkg-config",
-]
-
-[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2286,18 +2177,6 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
-dependencies = [
- "cc",
- "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -2471,7 +2350,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -2487,9 +2366,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2539,6 +2418,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2871,9 +2807,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -2928,9 +2864,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3009,26 +2945,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "rayon"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -3410,10 +3326,6 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
-dependencies = [
- "serde",
- "serde_core",
-]
 
 [[package]]
 name = "seq-macro"
@@ -3532,7 +3444,7 @@ version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn",
@@ -3779,7 +3691,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "sha1",
@@ -3819,7 +3731,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",
@@ -3943,15 +3855,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.31.4"
+version = "0.39.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355dbe4f8799b304b05e1b0f05fc59b2a18d36645cf169607da45bde2f69a1be"
+checksum = "2c8bd2130a9b60bee2581bf82cfe89ee836424d1f37dcfa4ce21509611684673"
 dependencies = [
- "core-foundation-sys",
  "libc",
  "memchr",
  "ntapi",
- "rayon",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "objc2-open-directory",
  "windows",
 ]
 
@@ -4082,12 +3995,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
@@ -4099,15 +4011,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4650,14 +4562,12 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "9.0.1"
+version = "10.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349ed9e45296a581f455bc18039878f409992999bc1d5da12a6800eb18c8752f"
+checksum = "b5574dd2f922b1a46a06a4b1dc11193a4012108fd54cf725e1816cb8183d8778"
 dependencies = [
  "anyhow",
- "cargo_metadata",
- "derive_builder",
- "regex",
+ "bon",
  "rustc_version",
  "rustversion",
  "sysinfo",
@@ -4666,14 +4576,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "vergen-git2"
-version = "1.0.1"
+name = "vergen-gitcl"
+version = "10.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e771aff771c0d7c2f42e434e2766d304d917e29b40f0424e8faaaa936bbc3f29"
+checksum = "23d9fead6d7c515ac3a658e1a65d36925525d5cfdea414e27eb99b99ffd92bfa"
 dependencies = [
  "anyhow",
- "derive_builder",
- "git2",
+ "bon",
  "rustversion",
  "time",
  "vergen",
@@ -4682,12 +4591,12 @@ dependencies = [
 
 [[package]]
 name = "vergen-lib"
-version = "0.1.6"
+version = "10.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b07e6010c0f3e59fcb164e0163834597da68d1f864e2b8ca49f74de01e9c166"
+checksum = "8cd42fd155c2c2971f6d00face12ec245fbb604fce011ccaf2306d014c2e97ca"
 dependencies = [
  "anyhow",
- "derive_builder",
+ "bon",
  "rustversion",
 ]
 
@@ -4918,7 +4827,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4929,24 +4838,23 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.57.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-core 0.57.0",
- "windows-targets 0.52.6",
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.57.0"
+name = "windows-collections"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
+ "windows-core",
 ]
 
 [[package]]
@@ -4955,22 +4863,22 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-strings",
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.57.0"
+name = "windows-future"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -4978,17 +4886,6 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5013,23 +4910,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
 name = "windows-registry"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-strings",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5156,6 +5054,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.5.0"
 edition = "2024"
 authors = ["Andrea Bozzo"]
 license = "Apache-2.0"
-rust-version = "1.88"
+rust-version = "1.95.0"
 repository = "https://github.com/AndreaBozzo/Ceres"
 
 [profile.release]
@@ -37,7 +37,7 @@ anyhow = "1.0"
 thiserror = "2.0"
 
 # Database
-sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres", "uuid", "chrono", "json"] }
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "tls-rustls", "postgres", "uuid", "chrono", "json", "macros"] }
 pgvector = { version = "0.4", features = ["sqlx", "serde"] }
 
 # HTTP client

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Builder
-FROM rust:1.88-slim-bookworm AS builder
+FROM rust:1.95-slim-bookworm AS builder
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -327,6 +327,11 @@ Available endpoints:
 
 Set `CERES_ADMIN_TOKEN` to enable protected write endpoints.
 
+Server-triggered harvest jobs use the matching `portals.toml` entry for both
+`POST /api/v1/portals/{name}/harvest` and `POST /api/v1/harvest`: portal
+`type`, DCAT `profile`, language, URL template, and optional
+`sparql_endpoint` are copied onto each durable job before the worker runs it.
+
 ## Website Docs
 
 The website lives in `website/` and documents the same harvest-first model:

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The codebase already models additional portal types such as `socrata`, but they 
 
 ### Prerequisites
 
-- Rust 1.88+
+- Rust 1.95+
 - Docker and Docker Compose
 - PostgreSQL 16+ with `pgvector` when running outside Docker
 - Optional for embeddings: [Ollama](https://ollama.com) locally, or Gemini/OpenAI credentials

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,3 @@
 # Clippy configuration for stricter linting
-msrv = "1.88"
+msrv = "1.95.0"
 cognitive-complexity-threshold = 30

--- a/crates/ceres-cli/Cargo.toml
+++ b/crates/ceres-cli/Cargo.toml
@@ -47,5 +47,4 @@ anyhow.workspace = true
 dirs.workspace = true
 
 [build-dependencies]
-vergen = "=9.0.1"
-vergen-git2 = { version = "1.0", features = ["build", "cargo", "rustc", "si"] }
+vergen-gitcl = { version = "10.0.1", features = ["build", "cargo", "rustc", "si"] }

--- a/crates/ceres-cli/build.rs
+++ b/crates/ceres-cli/build.rs
@@ -1,17 +1,17 @@
-use vergen_git2::{BuildBuilder, CargoBuilder, Emitter, Git2Builder, RustcBuilder};
+use vergen_gitcl::{Build, Cargo, Emitter, Gitcl, Rustc};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Build instructions
-    let git2 = Git2Builder::default().sha(true).build()?;
-    let build = BuildBuilder::default().build_date(true).build()?;
-    let cargo = CargoBuilder::default().target_triple(true).build()?;
-    let rustc = RustcBuilder::default().semver(true).build()?;
+    let git = Gitcl::builder().sha(true).build();
+    let build = Build::builder().build_date(true).build();
+    let cargo = Cargo::builder().target_triple(true).build();
+    let rustc = Rustc::builder().semver(true).build();
 
     // Emit env variables for cargo
     Emitter::default()
         .add_instructions(&build)?
         .add_instructions(&cargo)?
-        .add_instructions(&git2)?
+        .add_instructions(&git)?
         .add_instructions(&rustc)?
         .emit()?;
 

--- a/crates/ceres-server/src/handlers/harvest.rs
+++ b/crates/ceres-server/src/handlers/harvest.rs
@@ -2,10 +2,11 @@
 
 use axum::{Json, extract::State, http::StatusCode};
 
-use ceres_core::{CreateJobRequest, JobQueue, JobStatus, PortalType};
+use ceres_core::{JobQueue, JobStatus};
 
 use crate::dto::{HarvestJobResponse, HarvestStatusResponse, TriggerHarvestRequest};
 use crate::error::ApiError;
+use crate::handlers::build_harvest_job_request;
 use crate::state::AppState;
 
 /// Trigger harvest for all enabled portals.
@@ -43,29 +44,7 @@ pub async fn trigger_harvest_all(
     let mut jobs = Vec::new();
 
     for portal in enabled_portals {
-        // Only CKAN portals are supported for job-based harvesting for now
-        if portal.portal_type != PortalType::Ckan {
-            tracing::warn!(
-                portal = %portal.name,
-                portal_type = %portal.portal_type,
-                "Skipping portal: only 'ckan' is supported for job-based harvesting"
-            );
-            continue;
-        }
-
-        let mut job_request = CreateJobRequest::new(&portal.url).with_name(&portal.name);
-
-        if let Some(ref tmpl) = portal.url_template {
-            job_request = job_request.with_url_template(tmpl);
-        }
-
-        if let Some(ref lang) = portal.language {
-            job_request = job_request.with_language(lang);
-        }
-
-        if request.force_full_sync {
-            job_request = job_request.with_full_sync();
-        }
+        let job_request = build_harvest_job_request(portal, request.force_full_sync);
 
         let job = state
             .job_repo

--- a/crates/ceres-server/src/handlers/mod.rs
+++ b/crates/ceres-server/src/handlers/mod.rs
@@ -1,5 +1,7 @@
 //! HTTP request handlers for API endpoints.
 
+use ceres_core::{CreateJobRequest, PortalEntry};
+
 pub mod datasets;
 pub mod export;
 pub mod harvest;
@@ -7,3 +9,34 @@ pub mod health;
 pub mod portals;
 pub mod search;
 pub mod stats;
+
+pub(crate) fn build_harvest_job_request(
+    portal: &PortalEntry,
+    force_full_sync: bool,
+) -> CreateJobRequest {
+    let mut request = CreateJobRequest::new(portal.url.as_str())
+        .with_name(portal.name.as_str())
+        .with_portal_type(portal.portal_type);
+
+    if let Some(ref template) = portal.url_template {
+        request = request.with_url_template(template.as_str());
+    }
+
+    if let Some(ref language) = portal.language {
+        request = request.with_language(language.as_str());
+    }
+
+    if let Some(ref profile) = portal.profile {
+        request = request.with_profile(profile.as_str());
+    }
+
+    if let Some(ref sparql_endpoint) = portal.sparql_endpoint {
+        request = request.with_sparql_endpoint(sparql_endpoint.as_str());
+    }
+
+    if force_full_sync {
+        request = request.with_full_sync();
+    }
+
+    request
+}

--- a/crates/ceres-server/src/handlers/portals.rs
+++ b/crates/ceres-server/src/handlers/portals.rs
@@ -6,12 +6,13 @@ use axum::{
     http::StatusCode,
 };
 
-use ceres_core::{CreateJobRequest, JobQueue};
+use ceres_core::JobQueue;
 
 use crate::dto::{
     HarvestJobResponse, PortalInfoResponse, PortalStatsResponse, TriggerHarvestRequest,
 };
 use crate::error::ApiError;
+use crate::handlers::build_harvest_job_request;
 use crate::state::AppState;
 
 /// List all configured portals with sync status.
@@ -148,27 +149,7 @@ pub async fn trigger_portal_harvest(
         .find_by_name(&name)
         .ok_or_else(|| ApiError::NotFound(format!("Portal not found: {}", name)))?;
 
-    let mut job_request = CreateJobRequest::new(&portal.url)
-        .with_name(&portal.name)
-        .with_portal_type(portal.portal_type);
-
-    if let Some(ref tmpl) = portal.url_template {
-        job_request = job_request.with_url_template(tmpl);
-    }
-
-    if let Some(ref lang) = portal.language {
-        job_request = job_request.with_language(lang);
-    }
-
-    if let Some(ref profile) = portal.profile {
-        job_request = job_request.with_profile(profile);
-    }
-    if let Some(ref sparql_endpoint) = portal.sparql_endpoint {
-        job_request = job_request.with_sparql_endpoint(sparql_endpoint);
-    }
-    if request.force_full_sync {
-        job_request = job_request.with_full_sync();
-    }
+    let job_request = build_harvest_job_request(portal, request.force_full_sync);
 
     let job = state
         .job_repo

--- a/crates/ceres-server/tests/integration/common.rs
+++ b/crates/ceres-server/tests/integration/common.rs
@@ -68,6 +68,10 @@ const MIGRATIONS: &[&str] = &[
         force_full_sync BOOLEAN NOT NULL DEFAULT FALSE,
         url_template TEXT,
         language TEXT,
+        portal_type TEXT NOT NULL DEFAULT 'ckan'
+            CHECK (portal_type IN ('ckan', 'dcat', 'socrata')),
+        profile TEXT,
+        sparql_endpoint TEXT,
         CONSTRAINT chk_harvest_jobs_status CHECK (
             status IN ('pending', 'running', 'completed', 'failed', 'cancelled')
         )
@@ -104,6 +108,14 @@ impl TestApp {
     /// Create a test app with an admin token configured.
     pub async fn with_admin_token(token: &str) -> Self {
         Self::build(None, Some(token.to_string())).await
+    }
+
+    /// Create a test app with a portals config and admin token configured.
+    pub async fn with_portals_config_and_admin_token(
+        portals_config: ceres_core::PortalsConfig,
+        token: &str,
+    ) -> Self {
+        Self::build(Some(portals_config), Some(token.to_string())).await
     }
 
     async fn build(

--- a/crates/ceres-server/tests/integration/handler_tests.rs
+++ b/crates/ceres-server/tests/integration/handler_tests.rs
@@ -3,8 +3,11 @@
 //! Tests the HTTP API endpoints via the actual Axum router with a real
 //! PostgreSQL database and mock embedding provider.
 
+use std::collections::HashMap;
+
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
+use ceres_core::{PortalEntry, PortalType, PortalsConfig};
 use http_body_util::BodyExt;
 use tower::ServiceExt;
 
@@ -20,6 +23,18 @@ async fn body_json(body: Body) -> serde_json::Value {
             String::from_utf8_lossy(&bytes)
         )
     })
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct HarvestJobConfigRow {
+    portal_name: Option<String>,
+    portal_url: String,
+    force_full_sync: bool,
+    url_template: Option<String>,
+    language: Option<String>,
+    portal_type: String,
+    profile: Option<String>,
+    sparql_endpoint: Option<String>,
 }
 
 // =============================================================================
@@ -151,6 +166,144 @@ async fn test_protected_endpoint_disabled_returns_403() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn test_harvest_all_creates_jobs_for_supported_portal_configs() {
+    let portals_config = PortalsConfig {
+        portals: vec![
+            PortalEntry {
+                name: "ckan-city".to_string(),
+                url: "https://ckan.example.org".to_string(),
+                portal_type: PortalType::Ckan,
+                enabled: true,
+                description: None,
+                url_template: Some("https://ckan.example.org/dataset/{name}".to_string()),
+                language: Some("it".to_string()),
+                profile: None,
+                sparql_endpoint: None,
+                aliases: vec![],
+            },
+            PortalEntry {
+                name: "dcat-udata".to_string(),
+                url: "https://data.public.example".to_string(),
+                portal_type: PortalType::Dcat,
+                enabled: true,
+                description: None,
+                url_template: None,
+                language: Some("fr".to_string()),
+                profile: None,
+                sparql_endpoint: None,
+                aliases: vec![],
+            },
+            PortalEntry {
+                name: "dcat-sparql".to_string(),
+                url: "https://data.eu.example".to_string(),
+                portal_type: PortalType::Dcat,
+                enabled: true,
+                description: None,
+                url_template: None,
+                language: Some("en".to_string()),
+                profile: Some("sparql".to_string()),
+                sparql_endpoint: Some("https://sparql.example.org/query".to_string()),
+                aliases: vec![],
+            },
+            PortalEntry {
+                name: "disabled-dcat".to_string(),
+                url: "https://disabled.example.org".to_string(),
+                portal_type: PortalType::Dcat,
+                enabled: false,
+                description: None,
+                url_template: None,
+                language: Some("en".to_string()),
+                profile: Some("sparql".to_string()),
+                sparql_endpoint: Some("https://disabled.example.org/sparql".to_string()),
+                aliases: vec![],
+            },
+        ],
+    };
+    let app = TestApp::with_portals_config_and_admin_token(portals_config, "test-secret").await;
+
+    let response = app
+        .router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/harvest")
+                .header("content-type", "application/json")
+                .header("authorization", "Bearer test-secret")
+                .body(Body::from(r#"{"force_full_sync": true}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = response.status();
+    let json = body_json(response.into_body()).await;
+    assert_eq!(status, StatusCode::ACCEPTED, "Response: {:?}", json);
+
+    let response_jobs = json.as_array().expect("harvest response array");
+    assert_eq!(response_jobs.len(), 3);
+    assert!(
+        response_jobs
+            .iter()
+            .all(|job| job["status"].as_str() == Some("pending"))
+    );
+
+    let rows: Vec<HarvestJobConfigRow> = sqlx::query_as(
+        "SELECT portal_name, portal_url, force_full_sync, url_template, language, portal_type, profile, sparql_endpoint \
+         FROM harvest_jobs ORDER BY portal_name",
+    )
+    .fetch_all(&app.pool)
+    .await
+    .expect("failed to load harvest jobs");
+
+    assert_eq!(rows.len(), 3);
+    let by_name: HashMap<String, HarvestJobConfigRow> = rows
+        .into_iter()
+        .map(|row| {
+            (
+                row.portal_name
+                    .clone()
+                    .expect("test jobs should preserve portal_name"),
+                row,
+            )
+        })
+        .collect();
+
+    let ckan = by_name.get("ckan-city").expect("ckan job");
+    assert_eq!(ckan.portal_url, "https://ckan.example.org");
+    assert_eq!(ckan.portal_type, "ckan");
+    assert_eq!(ckan.language.as_deref(), Some("it"));
+    assert_eq!(
+        ckan.url_template.as_deref(),
+        Some("https://ckan.example.org/dataset/{name}")
+    );
+    assert!(ckan.force_full_sync);
+    assert!(ckan.profile.is_none());
+    assert!(ckan.sparql_endpoint.is_none());
+
+    let dcat = by_name.get("dcat-udata").expect("dcat udata job");
+    assert_eq!(dcat.portal_url, "https://data.public.example");
+    assert_eq!(dcat.portal_type, "dcat");
+    assert_eq!(dcat.language.as_deref(), Some("fr"));
+    assert!(dcat.force_full_sync);
+    assert!(dcat.profile.is_none());
+    assert!(dcat.sparql_endpoint.is_none());
+
+    let sparql = by_name.get("dcat-sparql").expect("sparql dcat job");
+    assert_eq!(sparql.portal_url, "https://data.eu.example");
+    assert_eq!(sparql.portal_type, "dcat");
+    assert_eq!(sparql.language.as_deref(), Some("en"));
+    assert_eq!(sparql.profile.as_deref(), Some("sparql"));
+    assert_eq!(
+        sparql.sparql_endpoint.as_deref(),
+        Some("https://sparql.example.org/query")
+    );
+    assert!(sparql.force_full_sync);
+
+    assert!(!by_name.contains_key("disabled-dcat"));
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Remove the CKAN-only skip from batch API harvest job creation.
- Share harvest job request construction between batch and named portal endpoints so portal type, DCAT profile, language, URL template, and SPARQL endpoint are preserved consistently.
- Add server integration coverage for mixed CKAN, DCAT udata, and SPARQL DCAT portal configs, plus a README note for API-triggered harvest jobs.

## Why

The database job schema and worker path already support portal type/profile metadata, but `POST /api/v1/harvest` was still silently skipping non-CKAN portals. This unblocks durable jobs for currently supported DCAT clients and keeps unsupported-profile failures in the worker/factory path instead of hiding configured portals at request time.

Closes #153.

## Validation

- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
