### PR TITLE
feat(dcat): support static Project Open Data catalogs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3035,6 +3035,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -3056,12 +3057,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower 0.5.3",
  "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -4734,6 +4737,19 @@ dependencies = [
  "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio",
 pgvector = { version = "0.4", features = ["sqlx", "serde"] }
 
 # HTTP client
-reqwest = { version = "0.13.1", features = ["json"] }
+reqwest = { version = "0.13.1", features = ["json", "stream"] }
 
 # CLI
 clap = { version = "4.4", features = ["derive", "env"] }

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Today, the shipped portal clients cover:
 - `ckan`
 - `dcat` for udata-flavored DCAT-AP portals such as `data.public.lu` and `data.gouv.fr` (profile `udata_rest`, the default)
 - `dcat` with `--profile sparql` for SPARQL-backed DCAT catalogs such as `data.europa.eu`
+- `dcat` with `--profile static_json` for Project Open Data / DCAT-US `data.json` catalogs
 
 The codebase already models additional portal types such as `socrata`, but they are not yet implemented in the current client factory.
 
@@ -221,6 +222,9 @@ ceres harvest https://data.public.lu --type dcat
 
 # Ad-hoc SPARQL-backed DCAT harvest
 ceres harvest https://data.europa.eu --type dcat --profile sparql
+
+# Harvest a static Project Open Data catalog
+ceres harvest https://www.data.va.gov/data.json --type dcat --profile static_json --metadata-only
 
 # Named portal from config
 ceres harvest --portal milano --config examples/portals.toml

--- a/crates/ceres-cli/src/config.rs
+++ b/crates/ceres-cli/src/config.rs
@@ -78,6 +78,7 @@ pub enum Command {
   ceres harvest https://dati.comune.milano.it         # Harvest single CKAN URL (default type)
   ceres harvest https://data.public.lu --type dcat    # Harvest DCAT portal by URL
   ceres harvest https://data.europa.eu --type dcat --profile sparql  # Harvest SPARQL DCAT endpoint
+  ceres harvest https://www.data.va.gov/data.json --type dcat --profile static_json
   ceres harvest --portal milano                       # Harvest portal by name from config
   ceres harvest --config ~/custom.toml                # Use custom config file
   ceres harvest --full-sync                           # Force full sync even if incremental is available")]
@@ -96,7 +97,7 @@ pub enum Command {
         r#type: PortalType,
 
         /// DCAT profile when harvesting an ad-hoc DCAT URL.
-        /// Supported: "udata_rest" (alias "udata", default), "sparql"
+        /// Supported: "udata_rest" (alias "udata", default), "sparql", "static_json"
         #[arg(long, value_name = "PROFILE", requires = "portal_url")]
         profile: Option<String>,
 

--- a/crates/ceres-client/src/datajson.rs
+++ b/crates/ceres-client/src/datajson.rs
@@ -1,0 +1,364 @@
+//! Project Open Data / DCAT-US static `data.json` catalog client.
+//!
+//! A portal URL may point directly at a JSON document or at a site root, in
+//! which case `data.json` is appended. Static catalogs do not expose server-side
+//! pagination or incremental queries, so Ceres downloads one size-bounded
+//! document and applies `modified` filtering locally.
+
+use std::time::Duration;
+
+use ceres_core::error::AppError;
+use ceres_core::models::NewDataset;
+use chrono::{DateTime, NaiveDate, Utc};
+use futures::StreamExt;
+use reqwest::{Client, StatusCode, Url};
+use serde_json::Value;
+use tokio::time::sleep;
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+const DEFAULT_MAX_CATALOG_BYTES: u64 = 256 * 1024 * 1024;
+const MAX_RETRIES: u32 = 3;
+
+/// A normalized dataset plus its complete source object.
+#[derive(Debug, Clone)]
+pub struct DataJsonDataset {
+    pub identifier: String,
+    pub title: String,
+    pub description: Option<String>,
+    pub landing_page: String,
+    pub modified: Option<DateTime<Utc>>,
+    pub raw: Value,
+}
+
+/// Client for a static Project Open Data / DCAT-US catalog.
+#[derive(Clone)]
+pub struct DataJsonClient {
+    client: Client,
+    base_url: Url,
+    catalog_url: Url,
+    language: String,
+    max_catalog_bytes: u64,
+}
+
+impl DataJsonClient {
+    pub fn new(base_url_str: &str, language: &str) -> Result<Self, AppError> {
+        let base_url = Url::parse(base_url_str)
+            .map_err(|_| AppError::InvalidPortalUrl(base_url_str.to_string()))?;
+        let catalog_url = catalog_url(&base_url)?;
+        let max_catalog_bytes = std::env::var("CERES_STATIC_JSON_MAX_BYTES")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(DEFAULT_MAX_CATALOG_BYTES);
+        let client = Client::builder()
+            .user_agent("Ceres/0.6 (open-data-harvester)")
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .map_err(|error| AppError::ClientError(error.to_string()))?;
+
+        Ok(Self {
+            client,
+            base_url,
+            catalog_url,
+            language: language.to_string(),
+            max_catalog_bytes,
+        })
+    }
+
+    pub fn portal_type(&self) -> &'static str {
+        "dcat"
+    }
+
+    pub fn base_url(&self) -> &str {
+        self.base_url.as_str()
+    }
+
+    pub fn catalog_url(&self) -> &str {
+        self.catalog_url.as_str()
+    }
+
+    pub async fn list_dataset_ids(&self) -> Result<Vec<String>, AppError> {
+        Ok(self
+            .search_all_datasets()
+            .await?
+            .into_iter()
+            .map(|dataset| dataset.identifier)
+            .collect())
+    }
+
+    pub async fn get_dataset(&self, id: &str) -> Result<DataJsonDataset, AppError> {
+        self.search_all_datasets()
+            .await?
+            .into_iter()
+            .find(|dataset| dataset.identifier == id)
+            .ok_or_else(|| AppError::ClientError(format!("Dataset '{id}' was not found")))
+    }
+
+    pub async fn search_modified_since(
+        &self,
+        since: DateTime<Utc>,
+    ) -> Result<Vec<DataJsonDataset>, AppError> {
+        Ok(self
+            .search_all_datasets()
+            .await?
+            .into_iter()
+            .filter(|dataset| dataset.modified.is_none_or(|modified| modified >= since))
+            .collect())
+    }
+
+    pub async fn search_all_datasets(&self) -> Result<Vec<DataJsonDataset>, AppError> {
+        let body = self.fetch_catalog().await?;
+        parse_catalog(&body, self.base_url.as_str(), &self.language)
+    }
+
+    pub fn into_new_dataset(
+        data: DataJsonDataset,
+        portal_url: &str,
+        _url_template: Option<&str>,
+        language: &str,
+    ) -> NewDataset {
+        let content_hash = NewDataset::compute_content_hash_with_language(
+            &data.title,
+            data.description.as_deref(),
+            language,
+        );
+        NewDataset {
+            original_id: data.identifier,
+            source_portal: portal_url.to_string(),
+            url: data.landing_page,
+            title: data.title,
+            description: data.description,
+            embedding: None,
+            metadata: data.raw,
+            content_hash,
+        }
+    }
+
+    async fn fetch_catalog(&self) -> Result<Vec<u8>, AppError> {
+        let mut last_error = AppError::Generic("No catalog request attempted".to_string());
+        for attempt in 1..=MAX_RETRIES {
+            match self.client.get(self.catalog_url.clone()).send().await {
+                Ok(response) if response.status().is_success() => {
+                    if let Some(length) = response.content_length()
+                        && length > self.max_catalog_bytes
+                    {
+                        return Err(catalog_too_large(length, self.max_catalog_bytes));
+                    }
+                    let mut body = Vec::new();
+                    let mut stream = response.bytes_stream();
+                    while let Some(chunk) = stream.next().await {
+                        let chunk =
+                            chunk.map_err(|error| AppError::ClientError(error.to_string()))?;
+                        let next_len = body.len() as u64 + chunk.len() as u64;
+                        if next_len > self.max_catalog_bytes {
+                            return Err(catalog_too_large(next_len, self.max_catalog_bytes));
+                        }
+                        body.extend_from_slice(&chunk);
+                    }
+                    return Ok(body);
+                }
+                Ok(response) => {
+                    let status = response.status();
+                    last_error = if status == StatusCode::TOO_MANY_REQUESTS {
+                        AppError::RateLimitExceeded
+                    } else {
+                        AppError::ClientError(format!(
+                            "HTTP {} from {}",
+                            status.as_u16(),
+                            self.catalog_url
+                        ))
+                    };
+                    if !(status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error()) {
+                        return Err(last_error);
+                    }
+                }
+                Err(error) => {
+                    last_error = if error.is_timeout() {
+                        AppError::Timeout(REQUEST_TIMEOUT.as_secs())
+                    } else if error.is_connect() {
+                        AppError::NetworkError(format!("Connection failed: {error}"))
+                    } else {
+                        AppError::ClientError(error.to_string())
+                    };
+                }
+            }
+            if attempt < MAX_RETRIES {
+                sleep(Duration::from_millis(500 * u64::from(attempt))).await;
+            }
+        }
+        Err(last_error)
+    }
+}
+
+fn catalog_url(base_url: &Url) -> Result<Url, AppError> {
+    let path = base_url.path().trim_end_matches('/');
+    if path.ends_with(".json") {
+        Ok(base_url.clone())
+    } else {
+        base_url
+            .join("data.json")
+            .map_err(|error| AppError::InvalidPortalUrl(error.to_string()))
+    }
+}
+
+fn catalog_too_large(actual: u64, maximum: u64) -> AppError {
+    AppError::ClientError(format!(
+        "Static data.json catalog is too large ({actual} bytes; limit {maximum}). Set CERES_STATIC_JSON_MAX_BYTES to raise the bounded response limit."
+    ))
+}
+
+/// Parses a DCAT-US catalog. The standard shape is `{ "dataset": [...] }`;
+/// a top-level array is accepted for compatibility with local-government feeds.
+pub fn parse_catalog(
+    body: &[u8],
+    portal_url: &str,
+    language: &str,
+) -> Result<Vec<DataJsonDataset>, AppError> {
+    let root: Value = serde_json::from_slice(body).map_err(|error| {
+        AppError::ClientError(format!("Portal returned invalid data.json: {error}"))
+    })?;
+    let entries = match &root {
+        Value::Object(object) => object.get("dataset").and_then(Value::as_array),
+        Value::Array(array) => Some(array),
+        _ => None,
+    }
+    .ok_or_else(|| {
+        AppError::ClientError("data.json response is missing a dataset array".to_string())
+    })?;
+
+    Ok(entries
+        .iter()
+        .filter_map(|entry| extract_dataset(entry, portal_url, language))
+        .collect())
+}
+
+pub fn extract_dataset(value: &Value, portal_url: &str, language: &str) -> Option<DataJsonDataset> {
+    let object = value.as_object()?;
+    let identifier = text(object.get("identifier")?, language)?;
+    let title = text(object.get("title")?, language)?;
+    if identifier.trim().is_empty() || title.trim().is_empty() {
+        return None;
+    }
+    let description = object
+        .get("description")
+        .and_then(|value| text(value, language))
+        .filter(|value| !value.trim().is_empty());
+    let landing_page = object
+        .get("landingPage")
+        .or_else(|| object.get("landing_page"))
+        .and_then(|value| text(value, language))
+        .filter(|value| Url::parse(value).is_ok())
+        .or_else(|| Url::parse(&identifier).ok().map(|url| url.to_string()))
+        .unwrap_or_else(|| portal_url.to_string());
+    let modified = object
+        .get("modified")
+        .and_then(|value| text(value, language))
+        .and_then(|value| parse_datetime(&value));
+
+    Some(DataJsonDataset {
+        identifier,
+        title,
+        description,
+        landing_page,
+        modified,
+        raw: value.clone(),
+    })
+}
+
+fn text(value: &Value, language: &str) -> Option<String> {
+    match value {
+        Value::String(value) => Some(value.clone()),
+        Value::Object(values) => values
+            .get(language)
+            .or_else(|| values.get("en"))
+            .or_else(|| values.values().find(|value| value.is_string()))
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        Value::Array(values) => values.iter().find_map(|value| text(value, language)),
+        _ => None,
+    }
+}
+
+fn parse_datetime(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|date| date.with_timezone(&Utc))
+        .ok()
+        .or_else(|| {
+            NaiveDate::parse_from_str(value, "%Y-%m-%d")
+                .ok()?
+                .and_hms_opt(0, 0, 0)
+                .map(|date| date.and_utc())
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FIXTURE: &[u8] = include_bytes!("../tests/fixtures/project_open_data.json");
+
+    #[test]
+    fn parses_fixture_and_preserves_source_metadata() {
+        let datasets = parse_catalog(FIXTURE, "https://agency.gov/", "en").unwrap();
+        assert_eq!(datasets.len(), 3);
+        assert_eq!(datasets[0].identifier, "dataset-1");
+        assert_eq!(datasets[0].title, "Air quality observations");
+        assert_eq!(
+            datasets[0].landing_page,
+            "https://agency.gov/datasets/air-quality"
+        );
+        assert_eq!(datasets[0].raw["distribution"][0]["format"], "CSV");
+        assert!(datasets[1].description.is_none());
+        assert_eq!(datasets[2].title, "English title");
+        let french = parse_catalog(FIXTURE, "https://agency.gov/", "fr").unwrap();
+        assert_eq!(french[2].title, "Titre français");
+    }
+
+    #[test]
+    fn direct_json_url_is_not_modified() {
+        let client = DataJsonClient::new("https://agency.gov/catalog/data.json", "en").unwrap();
+        assert_eq!(client.catalog_url(), "https://agency.gov/catalog/data.json");
+    }
+
+    #[test]
+    fn site_root_gets_data_json_path() {
+        let client = DataJsonClient::new("https://agency.gov/open-data/", "en").unwrap();
+        assert_eq!(
+            client.catalog_url(),
+            "https://agency.gov/open-data/data.json"
+        );
+    }
+
+    #[test]
+    fn normalizes_dataset_and_hashes_selected_language() {
+        let raw = serde_json::json!({
+            "identifier": "one",
+            "title": "Title",
+            "description": "Description",
+            "keyword": ["one"],
+            "publisher": {"name": "Agency"}
+        });
+        let data = extract_dataset(&raw, "https://agency.gov/", "en").unwrap();
+        let normalized = DataJsonClient::into_new_dataset(data, "https://agency.gov/", None, "en");
+        assert_eq!(normalized.original_id, "one");
+        assert_eq!(normalized.metadata["publisher"]["name"], "Agency");
+        assert_eq!(normalized.content_hash.len(), 64);
+    }
+
+    #[test]
+    fn rejects_non_catalog_json() {
+        let error =
+            parse_catalog(br#"{"title":"not a catalog"}"#, "https://agency.gov", "en").unwrap_err();
+        assert!(error.to_string().contains("dataset array"));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network access to a Project Open Data catalog"]
+    async fn data_json_smoke_catalog() {
+        let url = std::env::var("CERES_DATAJSON_SMOKE_URL")
+            .unwrap_or_else(|_| "https://www.data.va.gov/data.json".to_string());
+        let client = DataJsonClient::new(&url, "en").unwrap();
+        let datasets = client.search_all_datasets().await.unwrap();
+        assert!(!datasets.is_empty(), "{url} returned no usable datasets");
+        eprintln!("{url}: {} datasets", datasets.len());
+    }
+}

--- a/crates/ceres-client/src/datajson.rs
+++ b/crates/ceres-client/src/datajson.rs
@@ -5,6 +5,7 @@
 //! pagination or incremental queries, so Ceres downloads one size-bounded
 //! document and applies `modified` filtering locally.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use ceres_core::error::AppError;
@@ -13,6 +14,7 @@ use chrono::{DateTime, NaiveDate, Utc};
 use futures::StreamExt;
 use reqwest::{Client, StatusCode, Url};
 use serde_json::Value;
+use tokio::sync::OnceCell;
 use tokio::time::sleep;
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
@@ -38,6 +40,10 @@ pub struct DataJsonClient {
     catalog_url: Url,
     language: String,
     max_catalog_bytes: u64,
+    /// Parsed catalog shared by all clones of this client. Static catalogs have
+    /// no per-dataset endpoint, so caching prevents list-then-get callers from
+    /// downloading the same document once per dataset.
+    datasets: Arc<OnceCell<Vec<DataJsonDataset>>>,
 }
 
 impl DataJsonClient {
@@ -61,6 +67,7 @@ impl DataJsonClient {
             catalog_url,
             language: language.to_string(),
             max_catalog_bytes,
+            datasets: Arc::new(OnceCell::new()),
         })
     }
 
@@ -78,18 +85,19 @@ impl DataJsonClient {
 
     pub async fn list_dataset_ids(&self) -> Result<Vec<String>, AppError> {
         Ok(self
-            .search_all_datasets()
+            .datasets()
             .await?
-            .into_iter()
-            .map(|dataset| dataset.identifier)
+            .iter()
+            .map(|dataset| dataset.identifier.clone())
             .collect())
     }
 
     pub async fn get_dataset(&self, id: &str) -> Result<DataJsonDataset, AppError> {
-        self.search_all_datasets()
+        self.datasets()
             .await?
-            .into_iter()
+            .iter()
             .find(|dataset| dataset.identifier == id)
+            .cloned()
             .ok_or_else(|| AppError::ClientError(format!("Dataset '{id}' was not found")))
     }
 
@@ -98,16 +106,16 @@ impl DataJsonClient {
         since: DateTime<Utc>,
     ) -> Result<Vec<DataJsonDataset>, AppError> {
         Ok(self
-            .search_all_datasets()
+            .datasets()
             .await?
-            .into_iter()
+            .iter()
             .filter(|dataset| dataset.modified.is_none_or(|modified| modified >= since))
+            .cloned()
             .collect())
     }
 
     pub async fn search_all_datasets(&self) -> Result<Vec<DataJsonDataset>, AppError> {
-        let body = self.fetch_catalog().await?;
-        parse_catalog(&body, self.base_url.as_str(), &self.language)
+        Ok(self.datasets().await?.clone())
     }
 
     pub fn into_new_dataset(
@@ -187,6 +195,15 @@ impl DataJsonClient {
         }
         Err(last_error)
     }
+
+    async fn datasets(&self) -> Result<&Vec<DataJsonDataset>, AppError> {
+        self.datasets
+            .get_or_try_init(|| async {
+                let body = self.fetch_catalog().await?;
+                parse_catalog(&body, self.base_url.as_str(), &self.language)
+            })
+            .await
+    }
 }
 
 fn catalog_url(base_url: &Url) -> Result<Url, AppError> {
@@ -194,7 +211,11 @@ fn catalog_url(base_url: &Url) -> Result<Url, AppError> {
     if path.ends_with(".json") {
         Ok(base_url.clone())
     } else {
-        base_url
+        let mut directory_url = base_url.clone();
+        if !directory_url.path().ends_with('/') {
+            directory_url.set_path(&format!("{}/", directory_url.path()));
+        }
+        directory_url
             .join("data.json")
             .map_err(|error| AppError::InvalidPortalUrl(error.to_string()))
     }
@@ -326,6 +347,22 @@ mod tests {
             client.catalog_url(),
             "https://agency.gov/open-data/data.json"
         );
+    }
+
+    #[test]
+    fn site_path_without_trailing_slash_gets_data_json_path() {
+        let client = DataJsonClient::new("https://agency.gov/open-data", "en").unwrap();
+        assert_eq!(
+            client.catalog_url(),
+            "https://agency.gov/open-data/data.json"
+        );
+    }
+
+    #[test]
+    fn client_clones_share_the_catalog_cache() {
+        let client = DataJsonClient::new("https://agency.gov/", "en").unwrap();
+        let clone = client.clone();
+        assert!(Arc::ptr_eq(&client.datasets, &clone.datasets));
     }
 
     #[test]

--- a/crates/ceres-client/src/lib.rs
+++ b/crates/ceres-client/src/lib.rs
@@ -22,6 +22,7 @@
 //! | CKAN | Supported | [CKAN API](https://docs.ckan.org/en/2.9/api/) |
 //! | DCAT-AP (udata REST) | Supported | [DCAT-AP](https://joinup.ec.europa.eu/collection/semantic-interoperability-community-semic/solution/dcat-application-profile-data-portals-europe) |
 //! | DCAT-AP (SPARQL) | Supported | SPARQL endpoint with DCAT vocabulary |
+//! | DCAT-US (`data.json`) | Supported | Project Open Data static catalog |
 //! | Socrata | Planned | [Socrata API](https://dev.socrata.com/) |
 //!
 //! # Embedding Providers
@@ -37,6 +38,7 @@
 //! | Ollama | mxbai-embed-large | 1024 |
 
 pub mod ckan;
+pub mod datajson;
 pub mod dcat;
 pub mod gemini;
 pub mod ollama;
@@ -47,6 +49,7 @@ pub mod sparql;
 
 // Re-export main client types
 pub use ckan::{CkanClient, CkanClientFactory};
+pub use datajson::{DataJsonClient, DataJsonDataset};
 pub use dcat::DcatClient;
 pub use gemini::GeminiClient;
 pub use ollama::OllamaClient;

--- a/crates/ceres-client/src/portal.rs
+++ b/crates/ceres-client/src/portal.rs
@@ -19,6 +19,7 @@ use futures::StreamExt;
 use futures::stream::BoxStream;
 
 use crate::ckan::{CkanClient, CkanDataset};
+use crate::datajson::{DataJsonClient, DataJsonDataset};
 use crate::dcat::{DcatClient, DcatDataset};
 use crate::sparql::SparqlDcatClient;
 
@@ -29,6 +30,8 @@ pub enum PortalDataEnum {
     Ckan(CkanDataset),
     /// Data from a DCAT-AP portal.
     Dcat(DcatDataset),
+    /// Data from a static Project Open Data / DCAT-US catalog.
+    DataJson(DataJsonDataset),
 }
 
 /// Unified portal client that wraps concrete portal implementations.
@@ -43,6 +46,8 @@ pub enum PortalClientEnum {
     Dcat(DcatClient),
     /// DCAT-AP SPARQL endpoint client.
     SparqlDcat(SparqlDcatClient),
+    /// Static Project Open Data / DCAT-US `data.json` client.
+    DataJson(DataJsonClient),
 }
 
 impl PortalClient for PortalClientEnum {
@@ -53,6 +58,7 @@ impl PortalClient for PortalClientEnum {
             Self::Ckan(c) => c.portal_type(),
             Self::Dcat(c) => c.portal_type(),
             Self::SparqlDcat(c) => c.portal_type(),
+            Self::DataJson(c) => c.portal_type(),
         }
     }
 
@@ -61,6 +67,7 @@ impl PortalClient for PortalClientEnum {
             Self::Ckan(c) => c.base_url(),
             Self::Dcat(c) => c.base_url(),
             Self::SparqlDcat(c) => c.base_url(),
+            Self::DataJson(c) => c.base_url(),
         }
     }
 
@@ -69,6 +76,7 @@ impl PortalClient for PortalClientEnum {
             Self::Ckan(c) => c.list_dataset_ids().await,
             Self::Dcat(c) => c.list_dataset_ids().await,
             Self::SparqlDcat(c) => c.list_dataset_ids().await,
+            Self::DataJson(c) => c.list_dataset_ids().await,
         }
     }
 
@@ -77,6 +85,7 @@ impl PortalClient for PortalClientEnum {
             Self::Ckan(c) => c.get_dataset(id).await.map(PortalDataEnum::Ckan),
             Self::Dcat(c) => c.get_dataset(id).await.map(PortalDataEnum::Dcat),
             Self::SparqlDcat(c) => c.get_dataset(id).await.map(PortalDataEnum::Dcat),
+            Self::DataJson(c) => c.get_dataset(id).await.map(PortalDataEnum::DataJson),
         }
     }
 
@@ -92,6 +101,9 @@ impl PortalClient for PortalClientEnum {
             }
             PortalDataEnum::Dcat(dcat_data) => {
                 DcatClient::into_new_dataset(dcat_data, portal_url, url_template, language)
+            }
+            PortalDataEnum::DataJson(data) => {
+                DataJsonClient::into_new_dataset(data, portal_url, url_template, language)
             }
         }
     }
@@ -113,6 +125,10 @@ impl PortalClient for PortalClientEnum {
                 .search_modified_since(since)
                 .await
                 .map(|datasets| datasets.into_iter().map(PortalDataEnum::Dcat).collect()),
+            Self::DataJson(c) => c
+                .search_modified_since(since)
+                .await
+                .map(|datasets| datasets.into_iter().map(PortalDataEnum::DataJson).collect()),
         }
     }
 
@@ -130,6 +146,10 @@ impl PortalClient for PortalClientEnum {
                 .search_all_datasets()
                 .await
                 .map(|datasets| datasets.into_iter().map(PortalDataEnum::Dcat).collect()),
+            Self::DataJson(c) => c
+                .search_all_datasets()
+                .await
+                .map(|datasets| datasets.into_iter().map(PortalDataEnum::DataJson).collect()),
         }
     }
 
@@ -153,6 +173,11 @@ impl PortalClient for PortalClientEnum {
                     r.map(|datasets| datasets.into_iter().map(PortalDataEnum::Dcat).collect())
                 },
             )),
+            Self::DataJson(c) => Box::pin(futures::stream::once(async move {
+                c.search_all_datasets()
+                    .await
+                    .map(|datasets| datasets.into_iter().map(PortalDataEnum::DataJson).collect())
+            })),
         }
     }
 
@@ -163,6 +188,10 @@ impl PortalClient for PortalClientEnum {
                 "dataset_count not supported for DCAT udata REST portals".to_string(),
             )),
             Self::SparqlDcat(c) => c.dataset_count().await,
+            Self::DataJson(_) => Err(AppError::Generic(
+                "dataset_count is not available without downloading the static data.json catalog"
+                    .to_string(),
+            )),
         }
     }
 }
@@ -248,6 +277,9 @@ impl PortalClientFactory for PortalClientFactoryEnum {
                     portal_url,
                     language,
                     sparql_endpoint,
+                )?)),
+                DcatProfile::StaticJson => Ok(PortalClientEnum::DataJson(DataJsonClient::new(
+                    portal_url, language,
                 )?)),
             },
             other => Err(AppError::ConfigError(format!(
@@ -344,6 +376,21 @@ mod tests {
             )
             .unwrap();
         assert!(matches!(client, PortalClientEnum::Dcat(_)));
+    }
+
+    #[test]
+    fn test_factory_creates_static_json_client() {
+        let factory = PortalClientFactoryEnum::new();
+        let client = factory
+            .create(
+                "https://www.data.va.gov/data.json",
+                PortalType::Dcat,
+                "en",
+                Some(DcatProfile::StaticJson),
+                None,
+            )
+            .unwrap();
+        assert!(matches!(client, PortalClientEnum::DataJson(_)));
     }
 
     #[test]

--- a/crates/ceres-client/tests/fixtures/project_open_data.json
+++ b/crates/ceres-client/tests/fixtures/project_open_data.json
@@ -1,0 +1,36 @@
+{
+  "@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+  "@id": "https://agency.gov/data.json",
+  "conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
+  "describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
+  "dataset": [
+    {
+      "identifier": "dataset-1",
+      "title": "Air quality observations",
+      "description": "Hourly sensor observations.",
+      "keyword": ["air", "environment"],
+      "modified": "2026-06-01T10:30:00Z",
+      "publisher": {"name": "Example Agency"},
+      "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+      "landingPage": "https://agency.gov/datasets/air-quality",
+      "distribution": [
+        {
+          "title": "CSV download",
+          "format": "CSV",
+          "downloadURL": "https://agency.gov/files/air-quality.csv"
+        }
+      ]
+    },
+    {
+      "identifier": "https://agency.gov/datasets/budget",
+      "title": "Budget",
+      "modified": "2026-05-01",
+      "distribution": [{"accessURL": "https://api.agency.gov/budget"}]
+    },
+    {
+      "identifier": "dataset-3",
+      "title": {"fr": "Titre français", "en": "English title"},
+      "description": ["Description en français"]
+    }
+  ]
+}

--- a/crates/ceres-core/src/config.rs
+++ b/crates/ceres-core/src/config.rs
@@ -435,6 +435,8 @@ pub enum DcatProfile {
     UdataRest,
     /// SPARQL endpoint returning DCAT-AP metadata.
     Sparql,
+    /// Static Project Open Data / DCAT-US `data.json` catalog.
+    StaticJson,
 }
 
 impl<'de> Deserialize<'de> for DcatProfile {
@@ -449,7 +451,8 @@ impl<'de> Deserialize<'de> for DcatProfile {
 
 impl DcatProfile {
     /// Human-readable list of accepted profile names, for error messages.
-    pub const SUPPORTED: &'static str = "'udata_rest' (alias: 'udata'), 'sparql'";
+    pub const SUPPORTED: &'static str =
+        "'udata_rest' (alias: 'udata'), 'sparql', 'static_json' (alias: 'data_json')";
 
     /// Returns the canonical string representation (used in config files,
     /// the harvest job table, and API responses).
@@ -457,6 +460,7 @@ impl DcatProfile {
         match self {
             Self::UdataRest => "udata_rest",
             Self::Sparql => "sparql",
+            Self::StaticJson => "static_json",
         }
     }
 }
@@ -474,6 +478,7 @@ impl FromStr for DcatProfile {
         match s.to_lowercase().as_str() {
             "udata_rest" | "udata" => Ok(Self::UdataRest),
             "sparql" => Ok(Self::Sparql),
+            "static_json" | "data_json" => Ok(Self::StaticJson),
             _ => Err(AppError::ConfigError(format!(
                 "Unknown DCAT profile: '{}'. Supported profiles: {}",
                 s,
@@ -1104,6 +1109,14 @@ type = "dcat"
             "SPARQL".parse::<DcatProfile>().unwrap(),
             DcatProfile::Sparql
         );
+        assert_eq!(
+            "static_json".parse::<DcatProfile>().unwrap(),
+            DcatProfile::StaticJson
+        );
+        assert_eq!(
+            "data_json".parse::<DcatProfile>().unwrap(),
+            DcatProfile::StaticJson
+        );
 
         let err = "spqarql".parse::<DcatProfile>().unwrap_err();
         assert!(err.to_string().contains("spqarql"));
@@ -1112,7 +1125,11 @@ type = "dcat"
 
     #[test]
     fn test_dcat_profile_canonical_roundtrip() {
-        for profile in [DcatProfile::UdataRest, DcatProfile::Sparql] {
+        for profile in [
+            DcatProfile::UdataRest,
+            DcatProfile::Sparql,
+            DcatProfile::StaticJson,
+        ] {
             assert_eq!(profile.as_str().parse::<DcatProfile>().unwrap(), profile);
         }
         assert_eq!(DcatProfile::default(), DcatProfile::UdataRest);
@@ -1169,6 +1186,10 @@ profile = "SPARQL"
         assert_eq!(
             serde_json::to_string(&DcatProfile::Sparql).unwrap(),
             "\"sparql\""
+        );
+        assert_eq!(
+            serde_json::to_string(&DcatProfile::StaticJson).unwrap(),
+            "\"static_json\""
         );
     }
 

--- a/examples/portals.toml
+++ b/examples/portals.toml
@@ -162,6 +162,8 @@ description = "Open Data NRW (Germany)"
 #   profile = "udata_rest"  (alias "udata"; default when omitted)
 #   profile = "sparql"      (SPARQL endpoint; defaults to {url}/sparql,
 #                            override with sparql_endpoint = "...")
+#   profile = "static_json" (Project Open Data / DCAT-US data.json; the URL
+#                            may be a site root or point directly to data.json)
 # `profile` is only valid on dcat portals, and `sparql_endpoint` only with
 # profile = "sparql" — anything else fails config validation.
 # =============================================================================
@@ -182,6 +184,46 @@ description = "Luxembourg Open Data Portal (DCAT-AP / udata)"
 # language = "fr"
 # enabled = false
 # description = "data.gouv.fr — French Government Open Data Portal (~50,000+ datasets)"
+
+# =============================================================================
+# DCAT-US / Project Open Data static data.json catalogs
+# =============================================================================
+
+[[portals]]
+name = "us-veterans-affairs"
+url = "https://www.data.va.gov/data.json"
+type = "dcat"
+profile = "static_json"
+language = "en"
+enabled = false
+description = "US Department of Veterans Affairs Project Open Data catalog (~1,965 datasets)"
+
+[[portals]]
+name = "us-energy"
+url = "https://www.energy.gov/data.json"
+type = "dcat"
+profile = "static_json"
+language = "en"
+enabled = false
+description = "US Department of Energy Project Open Data catalog (~483 datasets)"
+
+[[portals]]
+name = "us-census"
+url = "https://www.census.gov/data.json"
+type = "dcat"
+profile = "static_json"
+language = "en"
+enabled = false
+description = "US Census Bureau Project Open Data catalog (~1,790 datasets)"
+
+[[portals]]
+name = "us-justice"
+url = "https://www.justice.gov/data.json"
+type = "dcat"
+profile = "static_json"
+language = "en"
+enabled = false
+description = "US Department of Justice Project Open Data catalog (~3,273 datasets)"
 
 # =============================================================================
 # DCAT-AP portals (SPARQL endpoint)

--- a/website/src/content/docs/HARVESTING.md
+++ b/website/src/content/docs/HARVESTING.md
@@ -14,6 +14,7 @@ Today the shipping portal clients cover:
 - CKAN portals
 - DCAT-AP portals that expose the udata REST JSON-LD catalog
 - SPARQL-backed DCAT catalogs (via `--profile sparql`, e.g. `data.europa.eu`)
+- Static Project Open Data / DCAT-US catalogs (via `--profile static_json`)
 
 ## DCAT profiles
 
@@ -26,6 +27,7 @@ a profile can be specified: `portals.toml` (`profile = "..."`), the CLI
 |---|---|---|---|
 | `udata_rest` | `udata` | udata REST JSON-LD catalog | Default when omitted |
 | `sparql` | — | SPARQL endpoint (DCAT-AP) | Endpoint defaults to `{url}/sparql`; override with `sparql_endpoint` |
+| `static_json` | `data_json` | Project Open Data / DCAT-US `data.json` | URL may be the site root or the JSON document |
 
 Every profile preserves full source metadata. Validation is enforced at config
 load and at client creation:
@@ -33,6 +35,33 @@ load and at client creation:
 - `profile` is only valid on `type = "dcat"` portals
 - `sparql_endpoint` is only valid with `profile = "sparql"`
 - unknown profile names are rejected with the list of supported values
+
+Static catalogs are downloaded with a hard 256 MiB response limit because the
+format is normally one JSON document without server-side pagination. Override
+the ceiling with `CERES_STATIC_JSON_MAX_BYTES` when a trusted catalog is larger.
+The complete source dataset object, including distributions, is preserved in
+`metadata`; incremental runs filter the catalog locally using `modified`.
+
+```bash
+ceres harvest https://www.data.va.gov/data.json \
+  --type dcat --profile static_json --metadata-only
+```
+
+Verified public catalogs (live smoke-tested 2026-07-10):
+
+| Portal | URL | Usable datasets observed |
+|---|---|---:|
+| US Department of Veterans Affairs | `https://www.data.va.gov/data.json` | 1,965 |
+| US Department of Energy | `https://www.energy.gov/data.json` | 483 |
+| US Census Bureau | `https://www.census.gov/data.json` | 1,790 |
+| US Department of Justice | `https://www.justice.gov/data.json` | 3,273 |
+
+Run the opt-in parser/network smoke check against any candidate URL:
+
+```bash
+CERES_DATAJSON_SMOKE_URL=https://www.energy.gov/data.json \
+  cargo test -p ceres-client data_json_smoke_catalog -- --ignored --nocapture
+```
 
 ## Core pipeline
 
@@ -204,4 +233,5 @@ This converges faster than halving and handles portals with resource-heavy datas
 - CKAN client: [`crates/ceres-client/src/ckan.rs`](../crates/ceres-client/src/ckan.rs) (`search_modified_since`, adaptive page size)
 - DCAT client: [`crates/ceres-client/src/dcat.rs`](../crates/ceres-client/src/dcat.rs)
 - SPARQL DCAT client: [`crates/ceres-client/src/sparql.rs`](../crates/ceres-client/src/sparql.rs)
+- Project Open Data client: [`crates/ceres-client/src/datajson.rs`](../crates/ceres-client/src/datajson.rs)
 - DB schema: [`migrations/`](../migrations/)


### PR DESCRIPTION
## Summary

Adds the `static_json` DCAT profile for Project Open Data / DCAT-US `data.json` catalogs.

- adds a dedicated static catalog client with bounded response handling and local `modified` filtering
- preserves complete dataset metadata, including distributions
- wires typed profile parsing, factory dispatch, CLI help, examples, and documentation
- documents four verified public catalog endpoints and adds fixture plus opt-in live smoke coverage

## Why

Project Open Data catalogs are a major portal family whose static top-level `dataset` array does not fit udata REST or SPARQL transport paths. This provides explicit, reproducible support without automatic type guessing.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- live parser smoke checks for VA, Energy, Census, and Justice catalogs
- CLI metadata-only full-sync dry run against Energy: 483 datasets processed, no writes