### PR TITLE
feat(opendatasoft): add portal client for OpenDataSoft catalogs

### DIFF
--- a/.claude/skills/ceres/SKILL.md
+++ b/.claude/skills/ceres/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ceres
-description: Use when working with Ceres — a Rust harvest-first toolkit and public open data metadata index. Covers harvesting and synchronization, optional embedding and search, CKAN, DCAT udata, and SPARQL-backed DCAT portal support, Parquet snapshot manifests/reports/changelogs, Ollama or hosted providers, CLI commands, REST API endpoints, portal configuration, architecture, extending via traits, release workflow, and contributing to the Ceres codebase.
+description: Use when working with Ceres — a Rust harvest-first toolkit and public open data metadata index. Covers harvesting and synchronization, optional embedding and search, CKAN, DCAT udata, SPARQL-backed DCAT, Project Open Data data.json, Socrata Discovery, and OpenDataSoft Explore portal support, Parquet snapshot manifests/reports/changelogs, Ollama or hosted providers, CLI commands, REST API endpoints, portal configuration, architecture, extending via traits, release workflow, and contributing to the Ceres codebase.
 ---
 
 # Ceres — Harvest-First Toolkit for Open Data Portals
@@ -25,7 +25,7 @@ Harvesting and embedding are decoupled: `HarvestService` handles metadata, `Embe
 - Harvest first and keep metadata synchronized over time
 - Add embeddings later only if you want semantic retrieval
 - Prefer Ollama for local embedding, with Gemini and OpenAI still supported
-- Support CKAN, DCAT-AP udata REST, and SPARQL-backed DCAT portals in the current client factory
+- Support CKAN, DCAT-AP udata REST, SPARQL-backed DCAT, Project Open Data `data.json`, Socrata Discovery, and OpenDataSoft Explore portals in the current client factory
 - Publish reproducible Parquet snapshots for the public Open Data Index
 - Expose search, export, and API workflows over the same harvested catalog
 
@@ -163,10 +163,10 @@ ceres stats
 - **crates.io package:** `ceres-search`
 - Harvesting and embedding are decoupled: `--metadata-only` harvests without API key, `embed` command generates embeddings separately
 - Ollama is the preferred local embedding path; Gemini and OpenAI remain available
-- Current portal client factory supports CKAN and DCAT (`udata_rest` default profile plus `sparql` profile)
+- Current portal client factory supports CKAN, Socrata, OpenDataSoft, and DCAT (`udata_rest` default profile plus `sparql` and `static_json` profiles)
 - Stale dataset detection: datasets removed from portals are soft-marked (`is_stale`) during full syncs
 - Supports Ollama, Gemini, and OpenAI embeddings
 - Parquet export publishes a portable snapshot: `all.parquet` (canonical), per-portal subsets, `identity.parquet`, a versioned snapshot manifest (`metadata.json` with `snapshot_id`, provenance, alias-aware duplicate metadata, and SHA-256 checksums), coverage/quality reports (`reports.json`, `report.md`), and snapshot changelogs (`changelog.json`, `changelog.md` when `--previous` is supplied)
-- v0.6.0 milestone focus: portal coverage expansion in priority order — DCAT profile cleanup, Project Open Data `data.json`, Socrata, OpenDataSoft, ArcGIS Hub
+- v0.6.0 milestone focus: portal coverage expansion — DCAT profile cleanup, Project Open Data `data.json`, Socrata, and OpenDataSoft have shipped; ArcGIS Hub remains
 - v0.7.0 milestone focus: resource-level metadata depth tracked in issue #68
 - HuggingFace dataset: `AndreaBozzo/ceres-open-data-index`

--- a/.claude/skills/ceres/references/architecture.md
+++ b/.claude/skills/ceres/references/architecture.md
@@ -33,7 +33,7 @@ Key methods:
 
 The streaming pipeline processes datasets in batches without loading the entire portal into memory, supporting 100k+ dataset portals with a constant memory footprint. After a successful full sync with zero failures, stale detection marks removed datasets via `mark_stale_by_exclusion()`.
 
-Current client-factory support covers CKAN and DCAT profiles: `udata_rest` by default and `sparql` for SPARQL-backed catalogs such as `data.europa.eu`. The `PortalType` enum also models additional future portal families such as Socrata.
+Current client-factory support covers CKAN (`ckan`), Socrata Discovery (`socrata`), OpenDataSoft Explore v2.1 (`opendatasoft`), and DCAT (`dcat`) with profiles: `udata_rest` by default, `sparql` for SPARQL-backed catalogs such as `data.europa.eu`, and `static_json` for Project Open Data `data.json` catalogs.
 
 ### EmbeddingService
 

--- a/.claude/skills/ceres/references/cli-and-server.md
+++ b/.claude/skills/ceres/references/cli-and-server.md
@@ -20,7 +20,7 @@ ceres harvest --dry-run                     # Preview without DB writes or embed
 | Flag | Short | Description |
 |---|---|---|
 | `<URL>` | | Single portal URL (positional, backward compatible) |
-| `--type <TYPE>` | | Portal type for ad-hoc URL (`ckan`, `dcat`; `socrata` parses but is not implemented in the factory yet) |
+| `--type <TYPE>` | | Portal type for ad-hoc URL (`ckan`, `dcat`, `socrata`, `opendatasoft`) |
 | `--profile <PROFILE>` | | DCAT profile for ad-hoc DCAT URLs, currently `sparql` for SPARQL-backed catalogs |
 | `--portal <NAME>` | `-p` | Named portal from config file |
 | `--config <PATH>` | `-c` | Custom portals.toml path |
@@ -229,7 +229,7 @@ Fields:
 |---|---|---|---|
 | `name` | Yes | | Portal identifier (used with `--portal` flag) |
 | `url` | Yes | | Portal API base URL |
-| `type` | No | `ckan` | Portal type (`ckan`, `dcat`; `socrata` is modeled but not implemented yet) |
+| `type` | No | `ckan` | Portal type (`ckan`, `dcat`, `socrata`, `opendatasoft`) |
 | `profile` | No | | DCAT profile selector, e.g. `sparql`; omitted DCAT defaults to udata REST |
 | `sparql_endpoint` | No | | Override SPARQL endpoint for `profile = "sparql"` portals |
 | `enabled` | No | `true` | Include in batch harvests |

--- a/.claude/skills/ceres/references/extending.md
+++ b/.claude/skills/ceres/references/extending.md
@@ -81,7 +81,7 @@ Key design notes:
 - `search_modified_since` enables incremental sync. Return `Err` if the portal doesn't support it — Ceres will fall back to full sync.
 - `search_all_datasets` is an optimization for bulk fetch. Default returns an error, falling back to `list_dataset_ids()` + `get_dataset()`.
 
-**Built-in:** `CkanClient` and `DcatClient`.
+**Built-in:** `CkanClient`, `DcatClient`, `SparqlDcatClient`, `DataJsonClient`, `SocrataClient`, and `OpenDataSoftClient`.
 
 ### PortalClientFactory
 

--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,10 @@ RATE_LIMIT_BURST=30
 # Public read-only Socrata harvests also work without a token.
 # SOCRATA_APP_TOKEN=your-socrata-app-token
 
+# Optional OpenDataSoft API key for higher Explore API quotas.
+# Public read-only OpenDataSoft harvests also work without a key.
+# ODS_API_KEY=your-opendatasoft-api-key
+
 # Logging
 RUST_LOG=info
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Parquet snapshot exports are optional layers on top.
 ## Project map
 
 - `crates/ceres-core`: domain models, harvesting pipeline, configuration, and traits (`PortalClient`, `EmbeddingProvider`, `DatasetStore`).
-- `crates/ceres-client`: portal clients (CKAN, DCAT udata REST, SPARQL DCAT, Project Open Data `data.json`, Socrata Discovery) and embedding providers (Ollama, Gemini, OpenAI).
+- `crates/ceres-client`: portal clients (CKAN, DCAT udata REST, SPARQL DCAT, Project Open Data `data.json`, Socrata Discovery, OpenDataSoft Explore) and embedding providers (Ollama, Gemini, OpenAI).
 - `crates/ceres-db`: PostgreSQL/pgvector persistence.
 - `crates/ceres-server`: Axum HTTP API and OpenAPI definitions.
 - `crates/ceres-cli`: command-line entry point (`harvest`, `embed`, `search`, `export`, `stats`).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img src="website/src/assets/images/logo.png" alt="Ceres Logo" width="800" height="auto"/>
   <h1>Ceres</h1>
-  <p><strong>Harvest-first toolkit for open data portals — one synchronized catalog from 120+ portals and 2M+ datasets</strong></p>
+  <p><strong>Harvest-first toolkit for open data portals — one synchronized catalog from 150+ portals and 2M+ datasets</strong></p>
   <p>
     <a href="https://crates.io/crates/ceres-search"><img src="https://img.shields.io/crates/v/ceres-search.svg" alt="crates.io"></a>
     <a href="https://github.com/AndreaBozzo/Ceres/actions"><img src="https://github.com/AndreaBozzo/Ceres/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
@@ -28,7 +28,7 @@ Everything else is layered on top, and optional: local embeddings, semantic sear
 
 ## At a Glance
 
-- **120+ portals** harvested and kept in sync — national portals (data.gov, data.europa.eu, govdata.de, dados.gov.pt), cities (Milano, NYC), and agencies
+- **150+ portals** harvested and kept in sync — national portals (data.gov, data.europa.eu, govdata.de, dados.gov.pt), cities (Milano, NYC), and agencies
 - **2M+ datasets** in the live catalog; 1.85M+ curated in the latest published snapshot
 - **6 harvest paths** shipped: CKAN, DCAT udata REST, SPARQL-backed DCAT, Project Open Data `data.json`, Socrata Discovery, and OpenDataSoft Explore — with more clients landing on the [roadmap](#roadmap)
 - **Metadata-only by default** — no embedding provider, API key, or GPU required to build and maintain a catalog

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Everything else is layered on top, and optional: local embeddings, semantic sear
 
 - **120+ portals** harvested and kept in sync — national portals (data.gov, data.europa.eu, govdata.de, dados.gov.pt), cities (Milano, NYC), and agencies
 - **2M+ datasets** in the live catalog; 1.85M+ curated in the latest published snapshot
-- **5 harvest paths** shipped: CKAN, DCAT udata REST, SPARQL-backed DCAT, Project Open Data `data.json`, and Socrata Discovery — with more clients landing on the [roadmap](#roadmap)
+- **6 harvest paths** shipped: CKAN, DCAT udata REST, SPARQL-backed DCAT, Project Open Data `data.json`, Socrata Discovery, and OpenDataSoft Explore — with more clients landing on the [roadmap](#roadmap)
 - **Metadata-only by default** — no embedding provider, API key, or GPU required to build and maintain a catalog
 - **Local-first embeddings** via Ollama when you want semantic search; Gemini and OpenAI supported
 - **Reproducible exports** — Parquet snapshots with versioned manifests, SHA-256 checksums, coverage/quality reports, and changelogs
@@ -58,8 +58,9 @@ Ceres splits the system accordingly:
 | DCAT SPARQL | `--type dcat --profile sparql` | SPARQL-backed DCAT-AP catalogs | data.europa.eu |
 | Project Open Data | `--type dcat --profile static_json` | Static DCAT-US `data.json` catalogs | data.va.gov, census.gov, justice.gov |
 | Socrata | `--type socrata` | Socrata Discovery API catalogs | data.cityofnewyork.us, data.wa.gov |
+| OpenDataSoft | `--type opendatasoft` | OpenDataSoft Explore API v2.1 catalogs | opendata.paris.fr, data.economie.gouv.fr |
 
-All clients stream page-by-page, preserve the complete source metadata for downstream use, and share the same sync machinery (incremental sync, content-hash delta detection, stale marking). Next up: OpenDataSoft and ArcGIS Hub ([v0.6.0 milestone](https://github.com/AndreaBozzo/Ceres/milestones)).
+All clients stream page-by-page, preserve the complete source metadata for downstream use, and share the same sync machinery (incremental sync, content-hash delta detection, stale marking). Next up: ArcGIS Hub ([v0.6.0 milestone](https://github.com/AndreaBozzo/Ceres/milestones)).
 
 ## The Open Data Index
 
@@ -101,6 +102,9 @@ cargo run --bin ceres -- harvest https://data.public.lu --type dcat --metadata-o
 
 # Socrata portal (no app token required for public reads)
 cargo run --bin ceres -- harvest https://data.cityofnewyork.us --type socrata --metadata-only
+
+# OpenDataSoft portal (no API key required for public reads)
+cargo run --bin ceres -- harvest https://opendata.paris.fr --type opendatasoft --metadata-only
 
 # All enabled portals from config
 cargo run --bin ceres -- harvest --config examples/portals.toml --metadata-only
@@ -184,6 +188,10 @@ Socrata public catalogs can be harvested without credentials. For higher
 Discovery API rate limits, set `SOCRATA_APP_TOKEN`; Ceres sends it through the
 `X-App-Token` header and never stores it in portal configuration.
 
+OpenDataSoft public catalogs also work anonymously. For higher Explore API
+quotas, set `ODS_API_KEY`; Ceres sends it as an `Authorization: Apikey ...`
+header and never stores it in portal configuration.
+
 ### Harvest resilience / HTTP tuning
 
 Harvesting is hardened for slow or rate-limiting portals: the CKAN client grows
@@ -226,6 +234,7 @@ ceres harvest https://data.public.lu --type dcat
 ceres harvest https://data.europa.eu --type dcat --profile sparql
 ceres harvest https://www.data.va.gov/data.json --type dcat --profile static_json --metadata-only
 ceres harvest https://data.cityofnewyork.us --type socrata --metadata-only
+ceres harvest https://opendata.paris.fr --type opendatasoft --metadata-only
 
 # Named portal from config
 ceres harvest --portal milano --config examples/portals.toml
@@ -348,7 +357,7 @@ Ceres ships with agent support in-repo:
 ## Roadmap
 
 - **Now (v0.5.0)** — trustable published index: versioned snapshot manifests, integrity checksums, coverage/quality reports, alias-aware duplicate semantics, snapshot changelogs; Socrata Discovery and static `data.json` harvest paths
-- **Next (v0.6.0)** — portal coverage expansion: OpenDataSoft and ArcGIS Hub clients, job-based harvesting for every supported client, newly validated portals at scale
+- **Next (v0.6.0)** — portal coverage expansion: OpenDataSoft Explore (shipped) and ArcGIS Hub clients, job-based harvesting for every supported client, newly validated portals at scale
 - **Later (v0.7.0)** — resource-level metadata depth ([#68](https://github.com/AndreaBozzo/Ceres/issues/68))
 
 ## Related Projects

--- a/crates/ceres-cli/src/config.rs
+++ b/crates/ceres-cli/src/config.rs
@@ -79,6 +79,7 @@ pub enum Command {
   ceres harvest https://data.public.lu --type dcat    # Harvest DCAT portal by URL
   ceres harvest https://data.europa.eu --type dcat --profile sparql  # Harvest SPARQL DCAT endpoint
   ceres harvest https://www.data.va.gov/data.json --type dcat --profile static_json
+  ceres harvest https://opendata.paris.fr --type opendatasoft  # Harvest OpenDataSoft portal
   ceres harvest --portal milano                       # Harvest portal by name from config
   ceres harvest --config ~/custom.toml                # Use custom config file
   ceres harvest --full-sync                           # Force full sync even if incremental is available")]

--- a/crates/ceres-client/src/lib.rs
+++ b/crates/ceres-client/src/lib.rs
@@ -24,6 +24,7 @@
 //! | DCAT-AP (SPARQL) | Supported | SPARQL endpoint with DCAT vocabulary |
 //! | DCAT-US (`data.json`) | Supported | Project Open Data static catalog |
 //! | Socrata | Supported | [Discovery API](https://dev.socrata.com/docs/other/discovery) |
+//! | OpenDataSoft | Supported | Explore API v2.1 (`/api/explore/v2.1/catalog/datasets`) |
 //!
 //! # Embedding Providers
 //!
@@ -43,6 +44,7 @@ pub mod dcat;
 pub mod gemini;
 pub mod ollama;
 pub mod openai;
+pub mod opendatasoft;
 pub mod portal;
 pub mod provider;
 pub mod socrata;
@@ -55,6 +57,7 @@ pub use dcat::DcatClient;
 pub use gemini::GeminiClient;
 pub use ollama::OllamaClient;
 pub use openai::OpenAIClient;
+pub use opendatasoft::{OpenDataSoftClient, OpenDataSoftDataset};
 pub use portal::{PortalClientEnum, PortalClientFactoryEnum, PortalDataEnum};
 #[cfg(feature = "test-support")]
 pub use provider::MockEmbeddingClient;

--- a/crates/ceres-client/src/opendatasoft.rs
+++ b/crates/ceres-client/src/opendatasoft.rs
@@ -314,8 +314,9 @@ impl OpenDataSoftClient {
                         // Restart within the window from the oldest timestamp
                         // seen so far. If no new datasets arrived since the
                         // last restart the cursor cannot advance (more equal
-                        // timestamps than the window holds); stop instead of
-                        // looping forever.
+                        // timestamps than the window holds). Fail the stream
+                        // rather than truncate: a partial full sync would
+                        // otherwise mark every unfetched dataset stale.
                         let stalled =
                             state.cursor.is_some() && state.seen_ids.len() == state.seen_at_cursor;
                         match (oldest_modified.or(state.cursor), stalled) {
@@ -325,14 +326,14 @@ impl OpenDataSoftClient {
                                 state.offset = 0;
                             }
                             _ => {
-                                tracing::warn!(
-                                    portal = %state.client.base_url,
-                                    unique_ids = state.seen_ids.len(),
-                                    total_count = page.total_count,
-                                    "OpenDataSoft modified-cursor cannot advance; ending dated walk early"
-                                );
-                                state.phase = WalkPhase::Undated;
-                                state.offset = 0;
+                                state.phase = WalkPhase::Finished;
+                                let error = AppError::Generic(format!(
+                                    "OpenDataSoft modified-cursor cannot advance past {} of {} datasets on {}; aborting so the partial harvest is not treated as complete",
+                                    state.seen_ids.len(),
+                                    page.total_count,
+                                    state.client.base_url
+                                ));
+                                return Some((Err(error), state));
                             }
                         }
                     } else {
@@ -343,12 +344,14 @@ impl OpenDataSoftClient {
                     if query_exhausted {
                         state.phase = WalkPhase::Finished;
                     } else if next_offset + state.client.page_size > state.client.offset_window {
-                        tracing::warn!(
-                            portal = %state.client.base_url,
-                            total_count = page.total_count,
-                            "OpenDataSoft catalog has more undated datasets than the pagination window; truncating"
-                        );
+                        // Same reasoning as the dated stall: never let a
+                        // truncated walk look like a clean full sync.
                         state.phase = WalkPhase::Finished;
+                        let error = AppError::Generic(format!(
+                            "OpenDataSoft catalog on {} has more undated datasets ({}) than the pagination window can reach; aborting so the partial harvest is not treated as complete",
+                            state.client.base_url, page.total_count
+                        ));
+                        return Some((Err(error), state));
                     } else {
                         state.offset = next_offset;
                     }
@@ -464,7 +467,7 @@ impl OpenDataSoftClient {
                                 .get("retry-after")
                                 .and_then(|value| value.to_str().ok())
                                 .and_then(|value| value.parse::<u64>().ok())
-                                .map(Duration::from_secs)
+                                .map(|seconds| Duration::from_secs(seconds).min(MAX_RETRY_DELAY))
                                 .unwrap_or_else(|| retry_delay(self.retry_base_delay, attempt));
                             tracing::warn!(
                                 attempt,
@@ -927,7 +930,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stalled_cursor_ends_the_walk_instead_of_looping() {
+    async fn stalled_cursor_fails_the_walk_instead_of_looping() {
         #[derive(Clone)]
         struct SameTimestampCatalog;
 
@@ -971,9 +974,54 @@ mod tests {
         let mut client = test_client(&server.uri());
         client.page_size = 1;
         client.offset_window = 2;
-        let datasets = client.search_all_datasets().await.unwrap();
-        // Two window passes (ids ds-0, ds-1 twice, deduplicated), then stop.
-        assert_eq!(datasets.len(), 2);
+        // Two window passes (ids ds-0, ds-1 twice, deduplicated), then the
+        // walk must fail rather than report a truncated catalog as complete.
+        let error = client.search_all_datasets().await.unwrap_err();
+        assert!(error.to_string().contains("cannot advance"));
+    }
+
+    #[tokio::test]
+    async fn undated_overflow_fails_instead_of_truncating() {
+        #[derive(Clone)]
+        struct ManyUndated;
+
+        impl Respond for ManyUndated {
+            fn respond(&self, request: &Request) -> ResponseTemplate {
+                let query = |key: &str| {
+                    request
+                        .url
+                        .query_pairs()
+                        .find(|(name, _)| name == key)
+                        .map(|(_, value)| value.into_owned())
+                        .unwrap_or_default()
+                };
+                if query("where") != "modified is null" {
+                    return ResponseTemplate::new(200)
+                        .set_body_json(json!({"total_count": 0, "results": []}));
+                }
+                let offset: usize = query("offset").parse().unwrap();
+                ResponseTemplate::new(200).set_body_json(json!({
+                    "total_count": 10,
+                    "results": [{
+                        "dataset_id": format!("undated-{offset}"),
+                        "metas": {"default": {"title": "Undated"}}
+                    }]
+                }))
+            }
+        }
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/explore/v2.1/catalog/datasets"))
+            .respond_with(ManyUndated)
+            .mount(&server)
+            .await;
+
+        let mut client = test_client(&server.uri());
+        client.page_size = 1;
+        client.offset_window = 2;
+        let error = client.search_all_datasets().await.unwrap_err();
+        assert!(error.to_string().contains("undated"));
     }
 
     #[tokio::test]

--- a/crates/ceres-client/src/opendatasoft.rs
+++ b/crates/ceres-client/src/opendatasoft.rs
@@ -1,0 +1,1122 @@
+//! OpenDataSoft Explore API v2.1 client.
+//!
+//! OpenDataSoft portals expose their catalog at
+//! `/api/explore/v2.1/catalog/datasets` with `limit`/`offset` pagination.
+//! The API enforces two hard limits: `limit` is capped at 100 per page, and
+//! `limit + offset` must stay below 10,000. Small catalogs are walked with
+//! plain offset pagination; deeper catalogs (for example the
+//! `data.opendatasoft.com` federation hub) are walked with a keyset cursor on
+//! the `modified` timestamp (`order_by=modified desc` plus
+//! `where=modified <= date'...'`), since ODSQL rejects range comparisons on
+//! text fields such as `dataset_id`. Datasets without a `modified` timestamp
+//! are collected in a final `where=modified is null` sweep.
+//!
+//! The complete catalog entry (including the `fields` schema hints) is
+//! preserved in [`NewDataset::metadata`].
+
+use std::collections::HashSet;
+use std::time::Duration;
+
+use ceres_core::HttpConfig;
+use ceres_core::error::AppError;
+use ceres_core::models::NewDataset;
+use ceres_core::traits::PortalClient;
+use chrono::{DateTime, SecondsFormat, Utc};
+use futures::StreamExt;
+use futures::stream::{self, BoxStream};
+use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
+use reqwest::{Client, StatusCode, Url};
+use serde::Deserialize;
+use serde_json::Value;
+use tokio::time::sleep;
+
+/// Maximum page size accepted by the Explore API (`-1 <= limit <= 100`).
+const PAGE_SIZE: usize = 100;
+/// Highest offset we request. The API rejects `limit + offset >= 10_000`
+/// with an opaque HTTP 500, so stay well clear of the boundary.
+const OFFSET_WINDOW: usize = 9_000;
+const MAX_RETRY_DELAY: Duration = Duration::from_secs(30);
+
+/// A normalized OpenDataSoft dataset plus its complete catalog entry.
+#[derive(Debug, Clone)]
+pub struct OpenDataSoftDataset {
+    pub id: String,
+    pub title: String,
+    pub description: Option<String>,
+    pub landing_page: String,
+    pub modified: Option<DateTime<Utc>>,
+    pub themes: Vec<String>,
+    pub keywords: Vec<String>,
+    pub license: Option<String>,
+    pub publisher: Option<String>,
+    pub raw: Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct CatalogResponse {
+    #[serde(default)]
+    results: Vec<Value>,
+    #[serde(default)]
+    total_count: usize,
+}
+
+struct CatalogPage {
+    datasets: Vec<OpenDataSoftDataset>,
+    raw_count: usize,
+    total_count: usize,
+}
+
+/// Which slice of the catalog a full-sync walk is currently reading.
+#[derive(Clone, Copy, PartialEq)]
+enum WalkPhase {
+    /// Datasets with a `modified` timestamp, newest first.
+    Dated,
+    /// Datasets without a `modified` timestamp (rare; final sweep).
+    Undated,
+    Finished,
+}
+
+struct WalkState {
+    client: OpenDataSoftClient,
+    phase: WalkPhase,
+    offset: usize,
+    /// Upper bound for the next dated query (`modified <= cursor`).
+    cursor: Option<DateTime<Utc>>,
+    seen_ids: HashSet<String>,
+    /// Unique datasets collected when the current cursor was set; used to
+    /// detect a cursor that cannot advance.
+    seen_at_cursor: usize,
+}
+
+/// Client for one OpenDataSoft portal's Explore API v2.1 catalog.
+#[derive(Clone)]
+pub struct OpenDataSoftClient {
+    client: Client,
+    base_url: Url,
+    catalog_url: Url,
+    request_timeout: Duration,
+    max_retries: u32,
+    retry_base_delay: Duration,
+    page_size: usize,
+    offset_window: usize,
+}
+
+impl OpenDataSoftClient {
+    /// Creates a client and reads an optional API key from `ODS_API_KEY`.
+    pub fn new(base_url: &str) -> Result<Self, AppError> {
+        let api_key = std::env::var("ODS_API_KEY")
+            .ok()
+            .filter(|key| !key.trim().is_empty());
+        Self::new_with_api_key(base_url, api_key)
+    }
+
+    /// Creates a client with an explicitly supplied optional API key.
+    pub fn new_with_api_key(base_url: &str, api_key: Option<String>) -> Result<Self, AppError> {
+        Self::new_with_api_key_and_http_config(base_url, api_key, HttpConfig::from_env())
+    }
+
+    fn new_with_api_key_and_http_config(
+        base_url: &str,
+        api_key: Option<String>,
+        http_config: HttpConfig,
+    ) -> Result<Self, AppError> {
+        let mut base_url =
+            Url::parse(base_url).map_err(|_| AppError::InvalidPortalUrl(base_url.to_string()))?;
+        if base_url.host_str().is_none_or(str::is_empty) {
+            return Err(AppError::InvalidPortalUrl(base_url.to_string()));
+        }
+        base_url.set_query(None);
+        base_url.set_fragment(None);
+        let catalog_url = base_url
+            .join("/api/explore/v2.1/catalog/datasets")
+            .map_err(|error| AppError::InvalidPortalUrl(error.to_string()))?;
+
+        let mut headers = HeaderMap::new();
+        if let Some(key) = api_key.filter(|key| !key.trim().is_empty()) {
+            let value = HeaderValue::from_str(&format!("Apikey {}", key.trim())).map_err(|_| {
+                AppError::ConfigError(
+                    "ODS_API_KEY contains characters that are invalid in an HTTP header"
+                        .to_string(),
+                )
+            })?;
+            headers.insert(AUTHORIZATION, value);
+        }
+
+        let client = Client::builder()
+            .user_agent("Ceres/0.6 (open-data-harvester)")
+            .default_headers(headers)
+            .build()
+            .map_err(|error| AppError::ClientError(error.to_string()))?;
+
+        Ok(Self {
+            client,
+            base_url,
+            catalog_url,
+            request_timeout: http_config.timeout,
+            max_retries: http_config.max_retries,
+            retry_base_delay: http_config.retry_base_delay,
+            page_size: PAGE_SIZE,
+            offset_window: OFFSET_WINDOW,
+        })
+    }
+
+    pub fn portal_type(&self) -> &'static str {
+        "opendatasoft"
+    }
+
+    pub fn base_url(&self) -> &str {
+        self.base_url.as_str()
+    }
+
+    pub async fn list_dataset_ids(&self) -> Result<Vec<String>, AppError> {
+        Ok(self
+            .search_all_datasets()
+            .await?
+            .into_iter()
+            .map(|dataset| dataset.id)
+            .collect())
+    }
+
+    pub async fn get_dataset(&self, id: &str) -> Result<OpenDataSoftDataset, AppError> {
+        let url = Url::parse(&format!("{}/{id}", self.catalog_url))
+            .map_err(|error| AppError::ClientError(error.to_string()))?;
+        let response = match self.request_with_retry(&url).await {
+            Ok(response) => response,
+            Err(AppError::ClientError(message)) if message.starts_with("HTTP 404") => {
+                return Err(AppError::DatasetNotFound(id.to_string()));
+            }
+            Err(error) => return Err(error),
+        };
+        let body = response
+            .bytes()
+            .await
+            .map_err(|error| AppError::ClientError(error.to_string()))?;
+        let raw: Value = serde_json::from_slice(&body)?;
+        extract_dataset(raw, &self.base_url)
+            .ok_or_else(|| AppError::DatasetNotFound(id.to_string()))
+    }
+
+    pub async fn search_modified_since(
+        &self,
+        since: DateTime<Utc>,
+    ) -> Result<Vec<OpenDataSoftDataset>, AppError> {
+        let where_clause = format!("modified >= date'{}'", format_odsql_date(since));
+        let mut offset = 0;
+        let mut datasets = Vec::new();
+        let mut seen_ids = HashSet::new();
+
+        loop {
+            let page = self
+                .fetch_page(offset, Some("modified desc"), Some(&where_clause))
+                .await?;
+            if page.total_count > self.offset_window {
+                // More modified datasets than the offset window can reach;
+                // let the harvest service fall back to a full sync.
+                return Err(AppError::Generic(format!(
+                    "{} datasets modified since {since} exceed the OpenDataSoft pagination window",
+                    page.total_count
+                )));
+            }
+            let done = page.raw_count == 0 || offset + page.raw_count >= page.total_count;
+            offset += page.raw_count;
+            datasets.extend(
+                page.datasets
+                    .into_iter()
+                    .filter(|dataset| seen_ids.insert(dataset.id.clone())),
+            );
+            if done {
+                break;
+            }
+        }
+
+        Ok(datasets)
+    }
+
+    pub async fn search_all_datasets(&self) -> Result<Vec<OpenDataSoftDataset>, AppError> {
+        let mut stream = self.search_all_datasets_stream();
+        let mut datasets = Vec::new();
+        while let Some(page) = stream.next().await {
+            datasets.extend(page?);
+        }
+        Ok(datasets)
+    }
+
+    /// Streams the full catalog page-by-page.
+    ///
+    /// Dated datasets are walked newest-first; whenever the next request
+    /// would cross the offset window the walk restarts at offset 0 with
+    /// `where=modified <= date'<oldest seen>'` (inclusive, deduplicated by
+    /// dataset id). A final sweep collects datasets without a `modified`
+    /// timestamp.
+    pub fn search_all_datasets_stream(
+        &self,
+    ) -> BoxStream<'_, Result<Vec<OpenDataSoftDataset>, AppError>> {
+        let state = WalkState {
+            client: self.clone(),
+            phase: WalkPhase::Dated,
+            offset: 0,
+            cursor: None,
+            seen_ids: HashSet::new(),
+            seen_at_cursor: 0,
+        };
+        Box::pin(stream::unfold(state, |mut state| async move {
+            if state.phase == WalkPhase::Finished {
+                return None;
+            }
+
+            let (order_by, where_clause) = match state.phase {
+                WalkPhase::Dated => {
+                    let clause = match state.cursor {
+                        Some(cursor) => format!(
+                            "modified is not null and modified <= date'{}'",
+                            format_odsql_date(cursor)
+                        ),
+                        None => "modified is not null".to_string(),
+                    };
+                    (Some("modified desc"), clause)
+                }
+                WalkPhase::Undated => (None, "modified is null".to_string()),
+                WalkPhase::Finished => unreachable!(),
+            };
+
+            let page = match state
+                .client
+                .fetch_page(state.offset, order_by, Some(&where_clause))
+                .await
+            {
+                Ok(page) => page,
+                Err(error) => {
+                    state.phase = WalkPhase::Finished;
+                    return Some((Err(error), state));
+                }
+            };
+
+            let query_exhausted =
+                page.raw_count == 0 || state.offset + page.raw_count >= page.total_count;
+            let next_offset = state.offset + page.raw_count;
+            let oldest_modified = page
+                .datasets
+                .iter()
+                .filter_map(|dataset| dataset.modified)
+                .min();
+            let datasets: Vec<_> = page
+                .datasets
+                .into_iter()
+                .filter(|dataset| state.seen_ids.insert(dataset.id.clone()))
+                .collect();
+
+            match state.phase {
+                WalkPhase::Dated => {
+                    if query_exhausted {
+                        state.phase = WalkPhase::Undated;
+                        state.offset = 0;
+                    } else if next_offset + state.client.page_size > state.client.offset_window {
+                        // Restart within the window from the oldest timestamp
+                        // seen so far. If no new datasets arrived since the
+                        // last restart the cursor cannot advance (more equal
+                        // timestamps than the window holds); stop instead of
+                        // looping forever.
+                        let stalled =
+                            state.cursor.is_some() && state.seen_ids.len() == state.seen_at_cursor;
+                        match (oldest_modified.or(state.cursor), stalled) {
+                            (Some(cursor), false) => {
+                                state.cursor = Some(cursor);
+                                state.seen_at_cursor = state.seen_ids.len();
+                                state.offset = 0;
+                            }
+                            _ => {
+                                tracing::warn!(
+                                    portal = %state.client.base_url,
+                                    unique_ids = state.seen_ids.len(),
+                                    total_count = page.total_count,
+                                    "OpenDataSoft modified-cursor cannot advance; ending dated walk early"
+                                );
+                                state.phase = WalkPhase::Undated;
+                                state.offset = 0;
+                            }
+                        }
+                    } else {
+                        state.offset = next_offset;
+                    }
+                }
+                WalkPhase::Undated => {
+                    if query_exhausted {
+                        state.phase = WalkPhase::Finished;
+                    } else if next_offset + state.client.page_size > state.client.offset_window {
+                        tracing::warn!(
+                            portal = %state.client.base_url,
+                            total_count = page.total_count,
+                            "OpenDataSoft catalog has more undated datasets than the pagination window; truncating"
+                        );
+                        state.phase = WalkPhase::Finished;
+                    } else {
+                        state.offset = next_offset;
+                    }
+                }
+                WalkPhase::Finished => unreachable!(),
+            }
+
+            Some((Ok(datasets), state))
+        }))
+    }
+
+    pub async fn dataset_count(&self) -> Result<usize, AppError> {
+        let mut url = self.catalog_url.clone();
+        url.query_pairs_mut()
+            .append_pair("limit", "1")
+            .append_pair("offset", "0");
+        let response = self.request_with_retry(&url).await?;
+        let body = response
+            .bytes()
+            .await
+            .map_err(|error| AppError::ClientError(error.to_string()))?;
+        let response: CatalogResponse = serde_json::from_slice(&body)?;
+        Ok(response.total_count)
+    }
+
+    pub fn into_new_dataset(
+        data: OpenDataSoftDataset,
+        portal_url: &str,
+        _url_template: Option<&str>,
+        language: &str,
+    ) -> NewDataset {
+        let content_hash = NewDataset::compute_content_hash_with_language(
+            &data.title,
+            data.description.as_deref(),
+            language,
+        );
+        NewDataset {
+            original_id: data.id,
+            source_portal: portal_url.to_string(),
+            url: data.landing_page,
+            title: data.title,
+            description: data.description,
+            embedding: None,
+            metadata: data.raw,
+            content_hash,
+        }
+    }
+
+    async fn fetch_page(
+        &self,
+        offset: usize,
+        order_by: Option<&str>,
+        where_clause: Option<&str>,
+    ) -> Result<CatalogPage, AppError> {
+        let mut url = self.catalog_url.clone();
+        {
+            let mut query = url.query_pairs_mut();
+            query.append_pair("limit", &self.page_size.to_string());
+            query.append_pair("offset", &offset.to_string());
+            if let Some(order_by) = order_by {
+                query.append_pair("order_by", order_by);
+            }
+            if let Some(where_clause) = where_clause {
+                query.append_pair("where", where_clause);
+            }
+        }
+
+        let response = self.request_with_retry(&url).await?;
+        let body = response
+            .bytes()
+            .await
+            .map_err(|error| AppError::ClientError(error.to_string()))?;
+        let response: CatalogResponse = serde_json::from_slice(&body)?;
+        let raw_count = response.results.len();
+        let datasets = response
+            .results
+            .into_iter()
+            .filter_map(|result| match extract_dataset(result, &self.base_url) {
+                Some(dataset) => Some(dataset),
+                None => {
+                    tracing::warn!(portal = %self.base_url, "Skipping malformed OpenDataSoft catalog result");
+                    None
+                }
+            })
+            .collect();
+
+        Ok(CatalogPage {
+            datasets,
+            raw_count,
+            total_count: response.total_count,
+        })
+    }
+
+    async fn request_with_retry(&self, url: &Url) -> Result<reqwest::Response, AppError> {
+        let mut last_error = AppError::Generic("No OpenDataSoft request attempted".to_string());
+
+        for attempt in 1..=self.max_retries {
+            match self
+                .client
+                .get(url.clone())
+                .timeout(self.request_timeout)
+                .send()
+                .await
+            {
+                Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) => {
+                    let status = response.status();
+                    if status == StatusCode::TOO_MANY_REQUESTS {
+                        last_error = AppError::RateLimitExceeded;
+                        if attempt < self.max_retries {
+                            let delay = response
+                                .headers()
+                                .get("retry-after")
+                                .and_then(|value| value.to_str().ok())
+                                .and_then(|value| value.parse::<u64>().ok())
+                                .map(Duration::from_secs)
+                                .unwrap_or_else(|| retry_delay(self.retry_base_delay, attempt));
+                            tracing::warn!(
+                                attempt,
+                                delay_ms = delay.as_millis(),
+                                "OpenDataSoft rate limit; retrying request"
+                            );
+                            sleep(delay).await;
+                            continue;
+                        }
+                        return Err(last_error);
+                    }
+
+                    if status.is_server_error() {
+                        last_error = AppError::ClientError(format!(
+                            "OpenDataSoft server error: HTTP {}",
+                            status.as_u16()
+                        ));
+                        if attempt < self.max_retries {
+                            sleep(self.retry_base_delay.saturating_mul(attempt)).await;
+                            continue;
+                        }
+                        return Err(last_error);
+                    }
+
+                    return Err(AppError::ClientError(format!(
+                        "HTTP {} from {}",
+                        status.as_u16(),
+                        url
+                    )));
+                }
+                Err(error) => {
+                    last_error = if error.is_timeout() {
+                        AppError::Timeout(self.request_timeout.as_secs())
+                    } else if error.is_connect() {
+                        AppError::NetworkError(format!("Connection failed: {error}"))
+                    } else {
+                        AppError::ClientError(error.to_string())
+                    };
+                    if attempt < self.max_retries && (error.is_timeout() || error.is_connect()) {
+                        sleep(self.retry_base_delay.saturating_mul(attempt)).await;
+                        continue;
+                    }
+                }
+            }
+        }
+
+        Err(last_error)
+    }
+}
+
+impl PortalClient for OpenDataSoftClient {
+    type PortalData = OpenDataSoftDataset;
+
+    fn portal_type(&self) -> &'static str {
+        OpenDataSoftClient::portal_type(self)
+    }
+
+    fn base_url(&self) -> &str {
+        OpenDataSoftClient::base_url(self)
+    }
+
+    async fn list_dataset_ids(&self) -> Result<Vec<String>, AppError> {
+        OpenDataSoftClient::list_dataset_ids(self).await
+    }
+
+    async fn get_dataset(&self, id: &str) -> Result<Self::PortalData, AppError> {
+        OpenDataSoftClient::get_dataset(self, id).await
+    }
+
+    fn into_new_dataset(
+        data: Self::PortalData,
+        portal_url: &str,
+        url_template: Option<&str>,
+        language: &str,
+    ) -> NewDataset {
+        Self::into_new_dataset(data, portal_url, url_template, language)
+    }
+
+    async fn search_modified_since(
+        &self,
+        since: DateTime<Utc>,
+    ) -> Result<Vec<Self::PortalData>, AppError> {
+        OpenDataSoftClient::search_modified_since(self, since).await
+    }
+
+    async fn search_all_datasets(&self) -> Result<Vec<Self::PortalData>, AppError> {
+        OpenDataSoftClient::search_all_datasets(self).await
+    }
+
+    fn search_all_datasets_stream(&self) -> BoxStream<'_, Result<Vec<Self::PortalData>, AppError>> {
+        OpenDataSoftClient::search_all_datasets_stream(self)
+    }
+
+    async fn dataset_count(&self) -> Result<usize, AppError> {
+        OpenDataSoftClient::dataset_count(self).await
+    }
+}
+
+fn retry_delay(base_delay: Duration, attempt: u32) -> Duration {
+    let exponent = attempt.saturating_sub(1).min(u32::BITS - 1);
+    let multiplier = 1_u32.checked_shl(exponent).unwrap_or(u32::MAX);
+    base_delay.saturating_mul(multiplier).min(MAX_RETRY_DELAY)
+}
+
+/// Formats a timestamp as an ODSQL `date'...'` literal payload (second
+/// precision, UTC). Sub-second truncation is safe because the cursor
+/// comparison is inclusive and pages are deduplicated by dataset id.
+fn format_odsql_date(value: DateTime<Utc>) -> String {
+    value.to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+fn extract_dataset(raw: Value, base_url: &Url) -> Option<OpenDataSoftDataset> {
+    let id = non_empty_string(raw.get("dataset_id")?)?;
+    let default_metas = raw.pointer("/metas/default");
+    let title = default_metas
+        .and_then(|metas| metas.get("title"))
+        .and_then(non_empty_string)
+        .unwrap_or_else(|| id.clone());
+    let description = default_metas
+        .and_then(|metas| metas.get("description"))
+        .and_then(Value::as_str)
+        .map(html_to_text)
+        .filter(|value| !value.is_empty());
+    let modified = default_metas
+        .and_then(|metas| metas.get("modified"))
+        .and_then(Value::as_str)
+        .and_then(parse_datetime);
+    let mut themes = default_metas
+        .and_then(|metas| metas.get("theme"))
+        .and_then(string_list)
+        .unwrap_or_default();
+    deduplicate(&mut themes);
+    let mut keywords = default_metas
+        .and_then(|metas| metas.get("keyword"))
+        .and_then(string_list)
+        .unwrap_or_default();
+    deduplicate(&mut keywords);
+    let license = default_metas
+        .and_then(|metas| metas.get("license"))
+        .and_then(text_value);
+    let publisher = default_metas
+        .and_then(|metas| metas.get("publisher"))
+        .and_then(text_value)
+        .or_else(|| raw.pointer("/metas/dcat/creator").and_then(text_value))
+        .or_else(|| raw.pointer("/metas/dcat/publisher").and_then(text_value));
+    let landing_page = base_url
+        .join(&format!("/explore/dataset/{id}/"))
+        .map(|url| url.to_string())
+        .unwrap_or_else(|_| format!("{}explore/dataset/{id}/", base_url));
+
+    Some(OpenDataSoftDataset {
+        id,
+        title,
+        description,
+        landing_page,
+        modified,
+        themes,
+        keywords,
+        license,
+        publisher,
+        raw,
+    })
+}
+
+fn non_empty_string(value: &Value) -> Option<String> {
+    value
+        .as_str()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn parse_datetime(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|value| value.with_timezone(&Utc))
+}
+
+fn html_to_text(value: &str) -> String {
+    let rendered = html2text::config::plain_no_decorate()
+        .string_from_read(value.as_bytes(), usize::MAX)
+        .unwrap_or_else(|_| value.to_string());
+    rendered.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn text_value(value: &Value) -> Option<String> {
+    match value {
+        Value::String(value) => {
+            let value = value.trim();
+            (!value.is_empty()).then(|| value.to_string())
+        }
+        Value::Object(value) => value.get("name").and_then(text_value),
+        _ => None,
+    }
+}
+
+fn string_list(value: &Value) -> Option<Vec<String>> {
+    match value {
+        Value::Array(values) => Some(values.iter().filter_map(text_value).collect()),
+        Value::String(_) => text_value(value).map(|value| vec![value]),
+        _ => None,
+    }
+}
+
+fn deduplicate(values: &mut Vec<String>) {
+    let mut seen = HashSet::new();
+    values.retain(|value| seen.insert(value.to_lowercase()));
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use chrono::TimeZone;
+    use serde_json::json;
+    use wiremock::matchers::{header, method, path, query_param};
+    use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
+
+    use super::*;
+
+    const FIXTURE: &[u8] = include_bytes!("../tests/fixtures/opendatasoft_catalog.json");
+
+    fn test_http_config(max_retries: u32) -> HttpConfig {
+        HttpConfig {
+            timeout: Duration::from_secs(5),
+            max_retries,
+            retry_base_delay: Duration::ZERO,
+        }
+    }
+
+    fn test_client(uri: &str) -> OpenDataSoftClient {
+        OpenDataSoftClient::new_with_api_key_and_http_config(uri, None, test_http_config(1))
+            .unwrap()
+    }
+
+    #[test]
+    fn parses_and_normalizes_fixture_without_changing_raw_metadata() {
+        let response: CatalogResponse = serde_json::from_slice(FIXTURE).unwrap();
+        assert_eq!(response.total_count, 2);
+        let raw = response.results[0].clone();
+        let base_url = Url::parse("https://opendata.example.fr").unwrap();
+        let dataset = extract_dataset(raw.clone(), &base_url).unwrap();
+
+        assert_eq!(dataset.id, "arbres-remarquables");
+        assert_eq!(dataset.title, "Arbres remarquables");
+        assert_eq!(
+            dataset.description.as_deref(),
+            Some("Inventaire des arbres remarquables avec localisation & essences.")
+        );
+        assert_eq!(dataset.themes, ["Environnement"]);
+        assert_eq!(dataset.keywords, ["arbres", "nature"]);
+        assert_eq!(
+            dataset.license.as_deref(),
+            Some("Open Database License (ODbL)")
+        );
+        assert_eq!(dataset.publisher.as_deref(), Some("Ville Exemple"));
+        assert_eq!(
+            dataset.modified.unwrap(),
+            Utc.with_ymd_and_hms(2026, 3, 14, 9, 26, 53).unwrap()
+        );
+        assert_eq!(
+            dataset.landing_page,
+            "https://opendata.example.fr/explore/dataset/arbres-remarquables/"
+        );
+        assert_eq!(dataset.raw, raw);
+
+        let normalized = OpenDataSoftClient::into_new_dataset(
+            dataset,
+            "https://opendata.example.fr",
+            None,
+            "fr",
+        );
+        assert_eq!(normalized.metadata, raw);
+        assert_eq!(normalized.original_id, "arbres-remarquables");
+        assert_eq!(normalized.content_hash.len(), 64);
+    }
+
+    #[test]
+    fn applies_documented_fallbacks_for_sparse_entries() {
+        let response: CatalogResponse = serde_json::from_slice(FIXTURE).unwrap();
+        let base_url = Url::parse("https://opendata.example.fr").unwrap();
+        let dataset = extract_dataset(response.results[1].clone(), &base_url).unwrap();
+
+        // Title falls back to the dataset id; publisher falls back to the
+        // DCAT creator; missing modified/description/license stay None.
+        assert_eq!(dataset.id, "budget-2026");
+        assert_eq!(dataset.title, "budget-2026");
+        assert!(dataset.description.is_none());
+        assert!(dataset.modified.is_none());
+        assert!(dataset.license.is_none());
+        assert_eq!(dataset.publisher.as_deref(), Some("Direction des Finances"));
+        assert!(dataset.themes.is_empty());
+        assert!(dataset.keywords.is_empty());
+    }
+
+    #[test]
+    fn skips_entries_without_a_dataset_id() {
+        let base_url = Url::parse("https://opendata.example.fr").unwrap();
+        assert!(extract_dataset(json!({"metas": {}}), &base_url).is_none());
+        assert!(extract_dataset(json!({"dataset_id": "  "}), &base_url).is_none());
+    }
+
+    #[tokio::test]
+    async fn sends_paginated_catalog_request_with_api_key() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/explore/v2.1/catalog/datasets"))
+            .and(query_param("limit", "1"))
+            .and(query_param("offset", "0"))
+            .and(header("authorization", "Apikey secret-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "total_count": 42,
+                "results": []
+            })))
+            .mount(&server)
+            .await;
+
+        let client =
+            OpenDataSoftClient::new_with_api_key(&server.uri(), Some("secret-key".into())).unwrap();
+        assert_eq!(client.dataset_count().await.unwrap(), 42);
+    }
+
+    #[tokio::test]
+    async fn streams_dated_pages_then_sweeps_undated_datasets() {
+        #[derive(Clone)]
+        struct PhasedCatalog;
+
+        impl Respond for PhasedCatalog {
+            fn respond(&self, request: &Request) -> ResponseTemplate {
+                let query = |key: &str| {
+                    request
+                        .url
+                        .query_pairs()
+                        .find(|(name, _)| name == key)
+                        .map(|(_, value)| value.into_owned())
+                        .unwrap_or_default()
+                };
+                let where_clause = query("where");
+                let offset = query("offset");
+                if where_clause == "modified is null" {
+                    ResponseTemplate::new(200).set_body_json(json!({
+                        "total_count": 1,
+                        "results": [{"dataset_id": "undated", "metas": {"default": {"title": "Undated"}}}]
+                    }))
+                } else if offset == "0" {
+                    ResponseTemplate::new(200).set_body_json(json!({
+                        "total_count": 2,
+                        "results": [{
+                            "dataset_id": "newest",
+                            "metas": {"default": {"title": "Newest", "modified": "2026-07-11T10:00:00+00:00"}}
+                        }]
+                    }))
+                } else {
+                    ResponseTemplate::new(200).set_body_json(json!({
+                        "total_count": 2,
+                        "results": [{
+                            "dataset_id": "older",
+                            "metas": {"default": {"title": "Older", "modified": "2026-07-10T10:00:00+00:00"}}
+                        }]
+                    }))
+                }
+            }
+        }
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/explore/v2.1/catalog/datasets"))
+            .and(query_param("where", "modified is not null"))
+            .and(query_param("order_by", "modified desc"))
+            .respond_with(PhasedCatalog)
+            .expect(2)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api/explore/v2.1/catalog/datasets"))
+            .and(query_param("where", "modified is null"))
+            .respond_with(PhasedCatalog)
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut client = test_client(&server.uri());
+        client.page_size = 1;
+        let datasets = client.search_all_datasets().await.unwrap();
+        assert_eq!(
+            datasets
+                .iter()
+                .map(|dataset| dataset.id.as_str())
+                .collect::<Vec<_>>(),
+            ["newest", "older", "undated"]
+        );
+    }
+
+    #[tokio::test]
+    async fn resets_to_modified_cursor_at_the_offset_window() {
+        #[derive(Clone)]
+        struct DeepCatalog;
+
+        impl Respond for DeepCatalog {
+            fn respond(&self, request: &Request) -> ResponseTemplate {
+                let query = |key: &str| {
+                    request
+                        .url
+                        .query_pairs()
+                        .find(|(name, _)| name == key)
+                        .map(|(_, value)| value.into_owned())
+                        .unwrap_or_default()
+                };
+                let where_clause = query("where");
+                if where_clause == "modified is null" {
+                    return ResponseTemplate::new(200)
+                        .set_body_json(json!({"total_count": 0, "results": []}));
+                }
+                let offset: usize = query("offset").parse().unwrap();
+                let cursor_set = where_clause.contains("<=");
+                // Window of 2 with page size 1: the walk reads offsets 0 and 1,
+                // then must restart from the cursor.
+                let index = if cursor_set { 2 + offset } else { offset };
+                let day = 10 - index; // strictly decreasing timestamps
+                ResponseTemplate::new(200).set_body_json(json!({
+                    "total_count": if cursor_set { 2 } else { 4 },
+                    "results": [{
+                        "dataset_id": format!("ds-{index}"),
+                        "metas": {"default": {
+                            "title": format!("Dataset {index}"),
+                            "modified": format!("2026-06-{day:02}T00:00:00+00:00")
+                        }}
+                    }]
+                }))
+            }
+        }
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/explore/v2.1/catalog/datasets"))
+            .respond_with(DeepCatalog)
+            .mount(&server)
+            .await;
+
+        let mut client = test_client(&server.uri());
+        client.page_size = 1;
+        client.offset_window = 2;
+        let datasets = client.search_all_datasets().await.unwrap();
+        assert_eq!(
+            datasets
+                .iter()
+                .map(|dataset| dataset.id.as_str())
+                .collect::<Vec<_>>(),
+            ["ds-0", "ds-1", "ds-2", "ds-3"]
+        );
+
+        // The cursor query must carry the oldest timestamp seen (ds-1's).
+        let requests = server.received_requests().await.unwrap();
+        assert!(requests.iter().any(|request| {
+            request.url.query_pairs().any(|(key, value)| {
+                key == "where" && value.contains("modified <= date'2026-06-09T00:00:00Z'")
+            })
+        }));
+    }
+
+    #[tokio::test]
+    async fn stalled_cursor_ends_the_walk_instead_of_looping() {
+        #[derive(Clone)]
+        struct SameTimestampCatalog;
+
+        impl Respond for SameTimestampCatalog {
+            fn respond(&self, request: &Request) -> ResponseTemplate {
+                let query = |key: &str| {
+                    request
+                        .url
+                        .query_pairs()
+                        .find(|(name, _)| name == key)
+                        .map(|(_, value)| value.into_owned())
+                        .unwrap_or_default()
+                };
+                if query("where") == "modified is null" {
+                    return ResponseTemplate::new(200)
+                        .set_body_json(json!({"total_count": 0, "results": []}));
+                }
+                let offset: usize = query("offset").parse().unwrap();
+                // Every dataset shares one timestamp, so the cursor can never
+                // advance past it and re-reads the same two ids forever.
+                ResponseTemplate::new(200).set_body_json(json!({
+                    "total_count": 10,
+                    "results": [{
+                        "dataset_id": format!("ds-{offset}"),
+                        "metas": {"default": {
+                            "title": "Same instant",
+                            "modified": "2026-06-01T00:00:00+00:00"
+                        }}
+                    }]
+                }))
+            }
+        }
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/explore/v2.1/catalog/datasets"))
+            .respond_with(SameTimestampCatalog)
+            .mount(&server)
+            .await;
+
+        let mut client = test_client(&server.uri());
+        client.page_size = 1;
+        client.offset_window = 2;
+        let datasets = client.search_all_datasets().await.unwrap();
+        // Two window passes (ids ds-0, ds-1 twice, deduplicated), then stop.
+        assert_eq!(datasets.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn retries_rate_limit_on_the_same_page() {
+        #[derive(Clone)]
+        struct RateLimitOnce(Arc<AtomicUsize>);
+
+        impl Respond for RateLimitOnce {
+            fn respond(&self, _request: &Request) -> ResponseTemplate {
+                if self.0.fetch_add(1, Ordering::SeqCst) == 0 {
+                    ResponseTemplate::new(429).insert_header("retry-after", "0")
+                } else {
+                    ResponseTemplate::new(200).set_body_json(json!({
+                        "total_count": 0,
+                        "results": []
+                    }))
+                }
+            }
+        }
+
+        let server = MockServer::start().await;
+        let calls = Arc::new(AtomicUsize::new(0));
+        Mock::given(method("GET"))
+            .and(path("/api/explore/v2.1/catalog/datasets"))
+            .respond_with(RateLimitOnce(calls.clone()))
+            .mount(&server)
+            .await;
+
+        let client = OpenDataSoftClient::new_with_api_key_and_http_config(
+            &server.uri(),
+            None,
+            test_http_config(2),
+        )
+        .unwrap();
+        assert!(client.search_all_datasets().await.unwrap().is_empty());
+        assert_eq!(calls.load(Ordering::SeqCst), 3); // dated + retry + undated sweep
+    }
+
+    #[tokio::test]
+    async fn incremental_search_filters_server_side_and_paginates() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/explore/v2.1/catalog/datasets"))
+            .and(query_param(
+                "where",
+                "modified >= date'2026-07-10T00:00:00Z'",
+            ))
+            .and(query_param("order_by", "modified desc"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "total_count": 1,
+                "results": [{
+                    "dataset_id": "recent",
+                    "metas": {"default": {"title": "Recent", "modified": "2026-07-11T10:00:00+00:00"}}
+                }]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server.uri());
+        let since = Utc.with_ymd_and_hms(2026, 7, 10, 0, 0, 0).unwrap();
+        let datasets = client.search_modified_since(since).await.unwrap();
+        assert_eq!(datasets.len(), 1);
+        assert_eq!(datasets[0].id, "recent");
+    }
+
+    #[tokio::test]
+    async fn incremental_search_errors_when_results_exceed_the_window() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/explore/v2.1/catalog/datasets"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "total_count": 50_000,
+                "results": [{
+                    "dataset_id": "recent",
+                    "metas": {"default": {"title": "Recent", "modified": "2026-07-11T10:00:00+00:00"}}
+                }]
+            })))
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server.uri());
+        let since = Utc.with_ymd_and_hms(2026, 7, 10, 0, 0, 0).unwrap();
+        let error = client.search_modified_since(since).await.unwrap_err();
+        assert!(error.to_string().contains("pagination window"));
+    }
+
+    #[tokio::test]
+    async fn get_dataset_maps_missing_ids_to_dataset_not_found() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/explore/v2.1/catalog/datasets/missing"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+                "error_code": "ODSQLError",
+                "message": "Unknown dataset"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server.uri());
+        let error = client.get_dataset("missing").await.unwrap_err();
+        assert!(matches!(error, AppError::DatasetNotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn get_dataset_parses_a_single_catalog_entry() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/explore/v2.1/catalog/datasets/velib"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "dataset_id": "velib",
+                "metas": {"default": {"title": "Vélib en temps réel"}}
+            })))
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server.uri());
+        let dataset = client.get_dataset("velib").await.unwrap();
+        assert_eq!(dataset.id, "velib");
+        assert_eq!(dataset.title, "Vélib en temps réel");
+    }
+
+    #[test]
+    fn retry_backoff_starts_at_base_and_saturates_before_overflow() {
+        let base = Duration::from_millis(500);
+        assert_eq!(retry_delay(base, 1), base);
+        assert_eq!(retry_delay(base, 2), Duration::from_secs(1));
+        assert_eq!(retry_delay(base, u32::MAX), MAX_RETRY_DELAY);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network access to a public OpenDataSoft portal"]
+    async fn opendatasoft_smoke_catalog() {
+        // Opt-in smoke test: cargo test -p ceres-client opendatasoft_smoke -- --ignored
+        // Override the portal with CERES_ODS_SMOKE_URL.
+        let url = std::env::var("CERES_ODS_SMOKE_URL")
+            .unwrap_or_else(|_| "https://opendata.paris.fr".to_string());
+        let client = OpenDataSoftClient::new_with_api_key(&url, None).unwrap();
+        let count = client.dataset_count().await.unwrap();
+        assert!(count > 0, "{url} returned no datasets");
+        let mut stream = client.search_all_datasets_stream();
+        let first_page = stream.next().await.unwrap().unwrap();
+        assert!(!first_page.is_empty());
+        eprintln!("{url}: {count} datasets; first={}", first_page[0].id);
+    }
+}

--- a/crates/ceres-client/src/portal.rs
+++ b/crates/ceres-client/src/portal.rs
@@ -21,6 +21,7 @@ use futures::stream::BoxStream;
 use crate::ckan::{CkanClient, CkanDataset};
 use crate::datajson::{DataJsonClient, DataJsonDataset};
 use crate::dcat::{DcatClient, DcatDataset};
+use crate::opendatasoft::{OpenDataSoftClient, OpenDataSoftDataset};
 use crate::socrata::{SocrataClient, SocrataDataset};
 use crate::sparql::SparqlDcatClient;
 
@@ -35,6 +36,8 @@ pub enum PortalDataEnum {
     DataJson(DataJsonDataset),
     /// Data from a Socrata Discovery API catalog.
     Socrata(SocrataDataset),
+    /// Data from an OpenDataSoft Explore API catalog.
+    OpenDataSoft(OpenDataSoftDataset),
 }
 
 /// Unified portal client that wraps concrete portal implementations.
@@ -53,6 +56,8 @@ pub enum PortalClientEnum {
     DataJson(DataJsonClient),
     /// Socrata Discovery API client.
     Socrata(SocrataClient),
+    /// OpenDataSoft Explore API v2.1 client.
+    OpenDataSoft(OpenDataSoftClient),
 }
 
 impl PortalClient for PortalClientEnum {
@@ -65,6 +70,7 @@ impl PortalClient for PortalClientEnum {
             Self::SparqlDcat(c) => c.portal_type(),
             Self::DataJson(c) => c.portal_type(),
             Self::Socrata(c) => c.portal_type(),
+            Self::OpenDataSoft(c) => c.portal_type(),
         }
     }
 
@@ -75,6 +81,7 @@ impl PortalClient for PortalClientEnum {
             Self::SparqlDcat(c) => c.base_url(),
             Self::DataJson(c) => c.base_url(),
             Self::Socrata(c) => c.base_url(),
+            Self::OpenDataSoft(c) => c.base_url(),
         }
     }
 
@@ -85,6 +92,7 @@ impl PortalClient for PortalClientEnum {
             Self::SparqlDcat(c) => c.list_dataset_ids().await,
             Self::DataJson(c) => c.list_dataset_ids().await,
             Self::Socrata(c) => c.list_dataset_ids().await,
+            Self::OpenDataSoft(c) => c.list_dataset_ids().await,
         }
     }
 
@@ -95,6 +103,7 @@ impl PortalClient for PortalClientEnum {
             Self::SparqlDcat(c) => c.get_dataset(id).await.map(PortalDataEnum::Dcat),
             Self::DataJson(c) => c.get_dataset(id).await.map(PortalDataEnum::DataJson),
             Self::Socrata(c) => c.get_dataset(id).await.map(PortalDataEnum::Socrata),
+            Self::OpenDataSoft(c) => c.get_dataset(id).await.map(PortalDataEnum::OpenDataSoft),
         }
     }
 
@@ -116,6 +125,9 @@ impl PortalClient for PortalClientEnum {
             }
             PortalDataEnum::Socrata(data) => {
                 SocrataClient::into_new_dataset(data, portal_url, url_template, language)
+            }
+            PortalDataEnum::OpenDataSoft(data) => {
+                OpenDataSoftClient::into_new_dataset(data, portal_url, url_template, language)
             }
         }
     }
@@ -145,6 +157,12 @@ impl PortalClient for PortalClientEnum {
                 .search_modified_since(since)
                 .await
                 .map(|datasets| datasets.into_iter().map(PortalDataEnum::Socrata).collect()),
+            Self::OpenDataSoft(c) => c.search_modified_since(since).await.map(|datasets| {
+                datasets
+                    .into_iter()
+                    .map(PortalDataEnum::OpenDataSoft)
+                    .collect()
+            }),
         }
     }
 
@@ -170,6 +188,12 @@ impl PortalClient for PortalClientEnum {
                 .search_all_datasets()
                 .await
                 .map(|datasets| datasets.into_iter().map(PortalDataEnum::Socrata).collect()),
+            Self::OpenDataSoft(c) => c.search_all_datasets().await.map(|datasets| {
+                datasets
+                    .into_iter()
+                    .map(PortalDataEnum::OpenDataSoft)
+                    .collect()
+            }),
         }
     }
 
@@ -204,6 +228,17 @@ impl PortalClient for PortalClientEnum {
                     r.map(|datasets| datasets.into_iter().map(PortalDataEnum::Socrata).collect())
                 },
             )),
+            Self::OpenDataSoft(c) => Box::pin(StreamExt::map(
+                c.search_all_datasets_stream(),
+                |r: Result<Vec<OpenDataSoftDataset>, AppError>| {
+                    r.map(|datasets| {
+                        datasets
+                            .into_iter()
+                            .map(PortalDataEnum::OpenDataSoft)
+                            .collect()
+                    })
+                },
+            )),
         }
     }
 
@@ -219,6 +254,7 @@ impl PortalClient for PortalClientEnum {
                     .to_string(),
             )),
             Self::Socrata(c) => c.dataset_count().await,
+            Self::OpenDataSoft(c) => c.dataset_count().await,
         }
     }
 }
@@ -297,6 +333,9 @@ impl PortalClientFactory for PortalClientFactoryEnum {
         match portal_type {
             PortalType::Ckan => Ok(PortalClientEnum::Ckan(ckan_client_for(portal_url)?)),
             PortalType::Socrata => Ok(PortalClientEnum::Socrata(SocrataClient::new(portal_url)?)),
+            PortalType::OpenDataSoft => Ok(PortalClientEnum::OpenDataSoft(
+                OpenDataSoftClient::new(portal_url)?,
+            )),
             PortalType::Dcat => match profile.unwrap_or_default() {
                 DcatProfile::UdataRest => Ok(PortalClientEnum::Dcat(DcatClient::new(
                     portal_url, language,
@@ -445,6 +484,37 @@ mod tests {
             .err()
             .expect("expected endpoint-without-sparql error");
         assert!(err.to_string().contains("not 'sparql'"));
+    }
+
+    #[test]
+    fn test_factory_creates_opendatasoft_client() {
+        let factory = PortalClientFactoryEnum::new();
+        let client = factory
+            .create(
+                "https://opendata.paris.fr",
+                PortalType::OpenDataSoft,
+                "fr",
+                None,
+                None,
+            )
+            .unwrap();
+        assert!(matches!(client, PortalClientEnum::OpenDataSoft(_)));
+        assert_eq!(client.portal_type(), "opendatasoft");
+        assert_eq!(client.base_url(), "https://opendata.paris.fr/");
+    }
+
+    #[test]
+    fn test_factory_rejects_profile_on_opendatasoft_portal() {
+        let factory = PortalClientFactoryEnum::new();
+        let result = factory.create(
+            "https://opendata.paris.fr",
+            PortalType::OpenDataSoft,
+            "fr",
+            Some(DcatProfile::Sparql),
+            None,
+        );
+        let err = result.err().expect("expected profile-on-ods error");
+        assert!(err.to_string().contains("only valid for 'dcat'"));
     }
 
     #[test]

--- a/crates/ceres-client/tests/fixtures/opendatasoft_catalog.json
+++ b/crates/ceres-client/tests/fixtures/opendatasoft_catalog.json
@@ -1,0 +1,96 @@
+{
+  "total_count": 2,
+  "results": [
+    {
+      "visibility": "domain",
+      "dataset_id": "arbres-remarquables",
+      "dataset_uid": "da_abc123",
+      "has_records": true,
+      "features": ["analyze", "geo"],
+      "attachments": [],
+      "alternative_exports": [],
+      "data_visible": true,
+      "fields": [
+        {
+          "name": "essence",
+          "description": null,
+          "annotations": { "facet": true, "facetsort": "alphanum" },
+          "label": "Essence",
+          "type": "text"
+        },
+        {
+          "name": "geo_point",
+          "description": null,
+          "annotations": {},
+          "label": "Coordonnées géo",
+          "type": "geo_point_2d"
+        }
+      ],
+      "metas": {
+        "dcat": {
+          "created": "2019-05-02T00:00:00+00:00",
+          "issued": null,
+          "creator": "Direction des Espaces Verts",
+          "contributor": null,
+          "accrualperiodicity": "annual",
+          "spatial": null,
+          "temporal": null
+        },
+        "default": {
+          "title": "Arbres remarquables",
+          "description": "<p>Inventaire des <b>arbres remarquables</b> avec localisation &amp; essences.</p>",
+          "theme": ["Environnement", "environnement"],
+          "keyword": ["arbres", "nature", "Arbres"],
+          "license": "Open Database License (ODbL)",
+          "license_url": "http://opendatacommons.org/licenses/odbl/",
+          "language": "fr",
+          "metadata_languages": ["fr"],
+          "timezone": null,
+          "modified": "2026-03-14T09:26:53+00:00",
+          "modified_updates_on_metadata_change": false,
+          "modified_updates_on_data_change": true,
+          "data_processed": "2026-03-14T09:26:53+00:00",
+          "metadata_processed": "2026-03-15T02:11:07+00:00",
+          "geographic_reference": ["fr"],
+          "publisher": "Ville Exemple",
+          "records_count": 187,
+          "attributions": null,
+          "source_domain": null,
+          "source_dataset": null,
+          "shared_catalog": null,
+          "federated": false,
+          "parent_domain": null
+        }
+      }
+    },
+    {
+      "visibility": "domain",
+      "dataset_id": "budget-2026",
+      "dataset_uid": "da_def456",
+      "has_records": true,
+      "features": ["analyze"],
+      "attachments": [],
+      "alternative_exports": [],
+      "data_visible": true,
+      "fields": [],
+      "metas": {
+        "dcat": {
+          "created": null,
+          "issued": null,
+          "creator": "Direction des Finances"
+        },
+        "default": {
+          "title": "   ",
+          "description": null,
+          "theme": null,
+          "keyword": null,
+          "license": null,
+          "language": "fr",
+          "modified": null,
+          "publisher": null,
+          "records_count": 12
+        }
+      }
+    }
+  ]
+}

--- a/crates/ceres-core/src/config.rs
+++ b/crates/ceres-core/src/config.rs
@@ -389,6 +389,8 @@ pub enum PortalType {
     Socrata,
     /// DCAT-AP / SPARQL endpoint (EU portals, data.europa.eu).
     Dcat,
+    /// OpenDataSoft portal (Explore API v2.1; common in European and municipal portals).
+    OpenDataSoft,
 }
 
 impl fmt::Display for PortalType {
@@ -397,6 +399,7 @@ impl fmt::Display for PortalType {
             Self::Ckan => write!(f, "ckan"),
             Self::Socrata => write!(f, "socrata"),
             Self::Dcat => write!(f, "dcat"),
+            Self::OpenDataSoft => write!(f, "opendatasoft"),
         }
     }
 }
@@ -409,8 +412,9 @@ impl FromStr for PortalType {
             "ckan" => Ok(Self::Ckan),
             "socrata" => Ok(Self::Socrata),
             "dcat" => Ok(Self::Dcat),
+            "opendatasoft" => Ok(Self::OpenDataSoft),
             _ => Err(AppError::ConfigError(format!(
-                "Unknown portal type: '{}'. Valid options: ckan, socrata, dcat",
+                "Unknown portal type: '{}'. Valid options: ckan, socrata, dcat, opendatasoft",
                 s
             ))),
         }
@@ -1121,6 +1125,32 @@ type = "dcat"
         let err = "spqarql".parse::<DcatProfile>().unwrap_err();
         assert!(err.to_string().contains("spqarql"));
         assert!(err.to_string().contains("udata_rest"));
+    }
+
+    #[test]
+    fn test_portal_type_opendatasoft_parse_display_deserialize() {
+        assert_eq!(
+            "opendatasoft".parse::<PortalType>().unwrap(),
+            PortalType::OpenDataSoft
+        );
+        assert_eq!(
+            "OpenDataSoft".parse::<PortalType>().unwrap(),
+            PortalType::OpenDataSoft
+        );
+        assert_eq!(PortalType::OpenDataSoft.to_string(), "opendatasoft");
+
+        let toml = r#"
+[[portals]]
+name = "paris"
+url = "https://opendata.paris.fr"
+type = "opendatasoft"
+"#;
+        let config: PortalsConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.portals[0].portal_type, PortalType::OpenDataSoft);
+        assert!(config.portals[0].validate().is_ok());
+
+        let err = "odsx".parse::<PortalType>().unwrap_err();
+        assert!(err.to_string().contains("opendatasoft"));
     }
 
     #[test]

--- a/crates/ceres-server/src/dto/response.rs
+++ b/crates/ceres-server/src/dto/response.rs
@@ -115,7 +115,7 @@ pub struct PortalInfoResponse {
     pub name: String,
     /// Portal base URL
     pub url: String,
-    /// Portal type (ckan, socrata, dcat)
+    /// Portal type (ckan, socrata, dcat, opendatasoft)
     pub portal_type: String,
     /// DCAT profile (e.g., "sparql"), if applicable
     pub profile: Option<String>,

--- a/crates/ceres-server/src/openapi.rs
+++ b/crates/ceres-server/src/openapi.rs
@@ -18,7 +18,7 @@ use crate::handlers::{datasets, export, harvest, health, portals, search, stats}
         version = "1.0.0",
         description = "Semantic search engine for open data portals.
 
-Ceres indexes datasets from open data portals (CKAN, Socrata, DCAT) and provides
+Ceres indexes datasets from open data portals (CKAN, Socrata, DCAT, OpenDataSoft) and provides
 semantic search capabilities using vector embeddings.
 
 ## Features

--- a/examples/portals.toml
+++ b/examples/portals.toml
@@ -171,6 +171,79 @@ enabled = false
 description = "NYC Open Data Socrata catalog (~2,400 dataset assets)"
 
 # =============================================================================
+# OpenDataSoft Explore API v2.1 portals
+#
+# Public read-only harvests work without credentials. Set ODS_API_KEY in the
+# environment for higher API quotas; never put the key in this file.
+# =============================================================================
+
+[[portals]]
+name = "paris"
+url = "https://opendata.paris.fr"
+type = "opendatasoft"
+language = "fr"
+enabled = false
+description = "Ville de Paris open data (OpenDataSoft, ~490 datasets)"
+
+[[portals]]
+name = "france-economie"
+url = "https://data.economie.gouv.fr"
+type = "opendatasoft"
+language = "fr"
+enabled = false
+description = "French Ministry of the Economy open data (OpenDataSoft, ~600 datasets)"
+
+[[portals]]
+name = "toulouse"
+url = "https://data.toulouse-metropole.fr"
+type = "opendatasoft"
+language = "fr"
+enabled = false
+description = "Toulouse Métropole open data (OpenDataSoft, ~840 datasets)"
+
+[[portals]]
+name = "bordeaux"
+url = "https://opendata.bordeaux-metropole.fr"
+type = "opendatasoft"
+language = "fr"
+enabled = false
+description = "Bordeaux Métropole open data (OpenDataSoft, ~560 datasets)"
+
+[[portals]]
+name = "ile-de-france"
+url = "https://data.iledefrance.fr"
+type = "opendatasoft"
+language = "fr"
+enabled = false
+description = "Région Île-de-France open data (OpenDataSoft, ~1,030 datasets)"
+
+[[portals]]
+name = "rennes"
+url = "https://data.rennesmetropole.fr"
+type = "opendatasoft"
+language = "fr"
+enabled = false
+description = "Rennes Métropole open data (OpenDataSoft, ~680 datasets)"
+
+[[portals]]
+name = "sncf"
+url = "https://data.sncf.com"
+type = "opendatasoft"
+language = "fr"
+enabled = false
+description = "SNCF (French railways) open data (OpenDataSoft, ~170 datasets)"
+
+# The OpenDataSoft federation hub aggregates datasets from many ODS portals
+# (ids carry an @domain suffix). Very large; harvest deliberately.
+# [[portals]]
+# name = "ods-hub"
+# url = "https://data.opendatasoft.com"
+# type = "opendatasoft"
+# language = "en"
+# enabled = false
+# description = "OpenDataSoft federation hub (~94,000 datasets, very large)"
+
+# =============================================================================
 # DCAT-AP portals (udata REST flavor)
 #
 # type = "dcat" portals select a transport via `profile`:

--- a/examples/portals.toml
+++ b/examples/portals.toml
@@ -175,7 +175,9 @@ description = "Latvian Open Data Portal (~1,500 datasets)"
 
 [[portals]]
 name = "japan"
-url = "https://www.data.go.jp/data"
+# www.data.go.jp 301-redirects here; harvest the canonical host directly
+# (through the redirect, package_search ignores rows/start pagination).
+url = "https://data.e-gov.go.jp/data"
 type = "ckan"
 language = "ja"
 enabled = false
@@ -421,13 +423,55 @@ description = "Ville de Namur open data (OpenDataSoft, ~300 datasets)"
 
 # The OpenDataSoft federation hub aggregates datasets from many ODS portals
 # (ids carry an @domain suffix). Very large; harvest deliberately.
-# [[portals]]
-# name = "ods-hub"
-# url = "https://data.opendatasoft.com"
-# type = "opendatasoft"
-# language = "en"
-# enabled = false
-# description = "OpenDataSoft federation hub (~94,000 datasets, very large)"
+[[portals]]
+name = "ods-hub"
+url = "https://data.opendatasoft.com"
+type = "opendatasoft"
+language = "en"
+enabled = false
+description = "OpenDataSoft federation hub (~94,000 datasets, very large)"
+
+# US state and city Socrata portals (verified Jul 2026)
+
+[[portals]]
+name = "pennsylvania"
+url = "https://data.pa.gov"
+type = "socrata"
+language = "en"
+enabled = false
+description = "Pennsylvania open data (Socrata, ~370 dataset assets)"
+
+[[portals]]
+name = "vermont"
+url = "https://data.vermont.gov"
+type = "socrata"
+language = "en"
+enabled = false
+description = "Vermont open data (Socrata, ~170 dataset assets)"
+
+[[portals]]
+name = "providence"
+url = "https://data.providenceri.gov"
+type = "socrata"
+language = "en"
+enabled = false
+description = "City of Providence open data (Socrata, ~120 dataset assets)"
+
+[[portals]]
+name = "cambridge-ma"
+url = "https://data.cambridgema.gov"
+type = "socrata"
+language = "en"
+enabled = false
+description = "City of Cambridge, MA open data (Socrata, ~280 dataset assets)"
+
+[[portals]]
+name = "somerville-ma"
+url = "https://data.somervillema.gov"
+type = "socrata"
+language = "en"
+enabled = false
+description = "City of Somerville, MA open data (Socrata, ~30 dataset assets)"
 
 # =============================================================================
 # DCAT-AP portals (udata REST flavor)

--- a/examples/portals.toml
+++ b/examples/portals.toml
@@ -155,6 +155,56 @@ description = "Open Data NRW (Germany)"
 # type = "ckan"
 # description = "Australian Government Open Data (~109,000 datasets, English, very large)"
 
+# --- New verified portals (Jul 2026) --- #
+
+[[portals]]
+name = "greece"
+url = "https://data.gov.gr"
+type = "ckan"
+language = "el"
+enabled = false
+description = "Greek Government Open Data Portal (~22,600 datasets)"
+
+[[portals]]
+name = "latvia"
+url = "https://data.gov.lv"
+type = "ckan"
+language = "lv"
+enabled = false
+description = "Latvian Open Data Portal (~1,500 datasets)"
+
+[[portals]]
+name = "japan"
+url = "https://www.data.go.jp/data"
+type = "ckan"
+language = "ja"
+enabled = false
+description = "Japanese Government Open Data Portal (~18,200 datasets)"
+
+[[portals]]
+name = "denmark"
+url = "https://portal.opendata.dk"
+type = "ckan"
+language = "da"
+enabled = false
+description = "Danish Open Data Portal (~630 datasets)"
+
+[[portals]]
+name = "montreal"
+url = "https://donnees.montreal.ca"
+type = "ckan"
+language = "fr"
+enabled = false
+description = "Ville de Montréal open data (~400 datasets)"
+
+[[portals]]
+name = "boston"
+url = "https://data.boston.gov"
+type = "ckan"
+language = "en"
+enabled = false
+description = "City of Boston open data (~230 datasets)"
+
 # =============================================================================
 # Socrata Discovery API portals
 #
@@ -232,6 +282,142 @@ type = "opendatasoft"
 language = "fr"
 enabled = false
 description = "SNCF (French railways) open data (OpenDataSoft, ~170 datasets)"
+
+[[portals]]
+name = "nantes"
+url = "https://data.nantesmetropole.fr"
+type = "opendatasoft"
+language = "fr"
+enabled = false
+description = "Nantes Métropole open data (OpenDataSoft, ~590 datasets)"
+
+[[portals]]
+name = "strasbourg"
+url = "https://data.strasbourg.eu"
+type = "opendatasoft"
+language = "fr"
+enabled = false
+description = "Eurométropole de Strasbourg open data (OpenDataSoft, ~400 datasets)"
+
+[[portals]]
+name = "angers"
+url = "https://data.angers.fr"
+type = "opendatasoft"
+language = "fr"
+enabled = false
+description = "Angers Loire Métropole open data (OpenDataSoft, ~150 datasets)"
+
+[[portals]]
+name = "occitanie"
+url = "https://data.laregion.fr"
+type = "opendatasoft"
+language = "fr"
+enabled = false
+description = "Région Occitanie open data (OpenDataSoft, ~200 datasets)"
+
+[[portals]]
+name = "aix-marseille"
+url = "https://data.ampmetropole.fr"
+type = "opendatasoft"
+language = "fr"
+enabled = false
+description = "Métropole Aix-Marseille-Provence open data (OpenDataSoft, ~250 datasets)"
+
+[[portals]]
+name = "issy"
+url = "https://data.issy.com"
+type = "opendatasoft"
+language = "fr"
+enabled = false
+description = "Ville d'Issy-les-Moulineaux open data (OpenDataSoft, ~330 datasets)"
+
+[[portals]]
+name = "ratp"
+url = "https://data.ratp.fr"
+type = "opendatasoft"
+language = "fr"
+enabled = false
+description = "RATP (Paris transit) open data (OpenDataSoft, ~25 datasets)"
+
+[[portals]]
+name = "idf-mobilites"
+url = "https://data.iledefrance-mobilites.fr"
+type = "opendatasoft"
+language = "fr"
+enabled = false
+description = "Île-de-France Mobilités open data (OpenDataSoft, ~90 datasets)"
+
+[[portals]]
+name = "star-rennes"
+url = "https://data.explore.star.fr"
+type = "opendatasoft"
+language = "fr"
+enabled = false
+description = "STAR (Rennes transit) open data (OpenDataSoft, ~45 datasets)"
+
+[[portals]]
+name = "saemes"
+url = "https://opendata.saemes.fr"
+type = "opendatasoft"
+language = "fr"
+enabled = false
+description = "Saemes (Paris parking) open data (OpenDataSoft, ~20 datasets)"
+
+[[portals]]
+name = "odre"
+url = "https://odre.opendatasoft.com"
+type = "opendatasoft"
+language = "fr"
+enabled = false
+description = "Open Data Réseaux Énergies (OpenDataSoft, ~190 datasets)"
+
+[[portals]]
+name = "basel-stadt"
+url = "https://data.bs.ch"
+type = "opendatasoft"
+language = "de"
+enabled = false
+description = "Kanton Basel-Stadt open data (OpenDataSoft, ~350 datasets)"
+
+[[portals]]
+name = "thurgau"
+url = "https://data.tg.ch"
+type = "opendatasoft"
+language = "de"
+enabled = false
+description = "Kanton Thurgau open data (OpenDataSoft, ~450 datasets)"
+
+[[portals]]
+name = "sbb"
+url = "https://data.sbb.ch"
+type = "opendatasoft"
+language = "de"
+enabled = false
+description = "SBB (Swiss railways) open data (OpenDataSoft, ~65 datasets)"
+
+[[portals]]
+name = "rhein-kreis-neuss"
+url = "https://opendata.rhein-kreis-neuss.de"
+type = "opendatasoft"
+language = "de"
+enabled = false
+description = "Rhein-Kreis Neuss open data (OpenDataSoft, ~420 datasets)"
+
+[[portals]]
+name = "bruxelles"
+url = "https://opendata.bruxelles.be"
+type = "opendatasoft"
+language = "fr"
+enabled = false
+description = "Ville de Bruxelles open data (OpenDataSoft, ~210 datasets)"
+
+[[portals]]
+name = "namur"
+url = "https://data.namur.be"
+type = "opendatasoft"
+language = "fr"
+enabled = false
+description = "Ville de Namur open data (OpenDataSoft, ~300 datasets)"
 
 # The OpenDataSoft federation hub aggregates datasets from many ODS portals
 # (ids carry an @domain suffix). Very large; harvest deliberately.

--- a/website/src/content/docs/HARVESTING.md
+++ b/website/src/content/docs/HARVESTING.md
@@ -16,6 +16,7 @@ Today the shipping portal clients cover:
 - SPARQL-backed DCAT catalogs (via `--profile sparql`, e.g. `data.europa.eu`)
 - Static Project Open Data / DCAT-US catalogs (via `--profile static_json`)
 - Socrata catalogs through the Discovery API (via `--type socrata`)
+- OpenDataSoft catalogs through the Explore API v2.1 (via `--type opendatasoft`)
 
 See [Supported portals](/portals/) for per-portal configuration, examples, and
 current coverage numbers.
@@ -42,6 +43,40 @@ Run the ignored live smoke check against NYC or another public portal:
 ```bash
 CERES_SOCRATA_SMOKE_URL=https://data.cityofnewyork.us \
   cargo test -p ceres-client socrata_smoke_catalog -- --ignored --nocapture
+```
+
+## OpenDataSoft Explore API
+
+OpenDataSoft portals are harvested from their paginated
+`/api/explore/v2.1/catalog/datasets` endpoint. Ceres streams one page at a
+time (100 datasets per page, the API maximum) and preserves each complete
+catalog entry — including the `fields` schema hints — in `metadata`. Titles,
+descriptions, themes, keywords, license, publisher, and the `modified`
+timestamp are normalized from `metas.default`; HTML descriptions are converted
+to plain text for search and embedding while the original HTML remains in the
+raw metadata.
+
+The Explore API rejects requests where `limit + offset` reaches 10,000. Small
+catalogs are walked with plain offset pagination; deeper catalogs (such as the
+`data.opendatasoft.com` federation hub, ~94k datasets) are walked newest-first
+with a keyset cursor on the `modified` timestamp, followed by a final sweep
+for datasets without one. Incremental sync filters server-side with
+`where=modified >= date'...'` and falls back to a full sync when more datasets
+changed than the pagination window can reach.
+
+Public read-only harvests require no credentials. Set `ODS_API_KEY` to send an
+`Authorization: Apikey ...` header and receive higher quotas:
+
+```bash
+ODS_API_KEY=... ceres harvest https://opendata.paris.fr \
+  --type opendatasoft --metadata-only
+```
+
+Run the ignored live smoke check against Paris or another public portal:
+
+```bash
+CERES_ODS_SMOKE_URL=https://opendata.paris.fr \
+  cargo test -p ceres-client opendatasoft_smoke_catalog -- --ignored --nocapture
 ```
 
 ## DCAT profiles

--- a/website/src/content/docs/PORTALS.md
+++ b/website/src/content/docs/PORTALS.md
@@ -18,6 +18,7 @@ detection, streaming page-by-page processing, and stale dataset marking.
 | DCAT SPARQL | `--type dcat --profile sparql` | SPARQL-backed DCAT-AP catalogs | data.europa.eu |
 | Project Open Data | `--type dcat --profile static_json` | Static DCAT-US `data.json` catalogs | data.va.gov, census.gov, justice.gov |
 | Socrata | `--type socrata` | Socrata Discovery API catalogs | data.cityofnewyork.us, data.wa.gov |
+| OpenDataSoft | `--type opendatasoft` | OpenDataSoft Explore API v2.1 catalogs | opendata.paris.fr, data.economie.gouv.fr |
 
 Every client preserves the complete source metadata payload, so downstream
 features like resource-schema extraction keep working no matter which portal a
@@ -40,6 +41,9 @@ ceres harvest https://www.data.va.gov/data.json --type dcat --profile static_jso
 
 # Socrata Discovery API
 ceres harvest https://data.cityofnewyork.us --type socrata --metadata-only
+
+# OpenDataSoft Explore API
+ceres harvest https://opendata.paris.fr --type opendatasoft --metadata-only
 ```
 
 Or configure them once in `portals.toml` and harvest in batch:
@@ -100,6 +104,14 @@ for a larger, curated configuration set.
 - Uses `updatedAt` ordering for incremental synchronization
 - HTML descriptions are converted to plain text for search and embedding; the original HTML stays in the raw metadata
 - No credentials required for public reads; set `SOCRATA_APP_TOKEN` for higher rate limits
+
+### OpenDataSoft Explore API
+
+- Harvests the paginated `/api/explore/v2.1/catalog/datasets` endpoint (100 datasets per page, the API maximum)
+- Normalizes title, description, themes, keywords, license, publisher, and `modified` from `metas.default`; the complete catalog entry, including `fields` schema hints, stays in the raw metadata
+- Catalogs deeper than the API's 10,000-row pagination window (e.g. the `data.opendatasoft.com` federation hub) are walked with a keyset cursor on `modified`
+- Incremental sync filters server-side with an ODSQL `where=modified >= date'...'` clause
+- No credentials required for public reads; set `ODS_API_KEY` for higher quotas
 
 ## The published index
 

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Ceres
-description: Harvest-first toolkit for open data portals — one synchronized catalog from 120+ portals and 2M+ datasets
+description: Harvest-first toolkit for open data portals — one synchronized catalog from 150+ portals and 2M+ datasets
 template: splash
 hero:
-  tagline: One synchronized catalog from 120+ open data portals. Harvest first — embed, search, and publish when you're ready.
+  tagline: One synchronized catalog from 150+ open data portals. Harvest first — embed, search, and publish when you're ready.
   image:
     file: ../../assets/images/logo-icon.png
     alt: Ceres circuit-sickle logo
@@ -33,7 +33,7 @@ Open data is scattered across thousands of portals speaking different APIs. Cere
 </div>
 
 <div class="stat-band animate-fade-in-up animate-delay-1">
-  <div class="stat"><span class="stat-value">120+</span><span class="stat-label">portals in sync</span></div>
+  <div class="stat"><span class="stat-value">150+</span><span class="stat-label">portals in sync</span></div>
   <div class="stat"><span class="stat-value">2M+</span><span class="stat-label">datasets harvested</span></div>
   <div class="stat"><span class="stat-value">5</span><span class="stat-label">portal API families</span></div>
   <div class="stat"><span class="stat-value">1.85M+</span><span class="stat-label">datasets in the published index</span></div>

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -27,7 +27,7 @@ import Terminal from '../../components/Terminal.astro';
 import FeatureGrid from '../../components/FeatureGrid.astro';
 
 <div class="animate-fade-in-up">
-Open data is scattered across thousands of portals speaking different APIs. Ceres harvests CKAN, DCAT, SPARQL, `data.json`, and Socrata sources into one synchronized PostgreSQL catalog — then layers embeddings, semantic search, exports, and a public index on top, only when you want them.
+Open data is scattered across thousands of portals speaking different APIs. Ceres harvests CKAN, DCAT, SPARQL, `data.json`, Socrata, and OpenDataSoft sources into one synchronized PostgreSQL catalog — then layers embeddings, semantic search, exports, and a public index on top, only when you want them.
 
 > *Named after the Roman goddess of harvest and agriculture.*
 </div>
@@ -47,7 +47,7 @@ Open data is scattered across thousands of portals speaking different APIs. Cere
     Open data work usually breaks on synchronization, portal quirks, and stale records before search even starts.
   </Card>
   <Card title="Portals Are Fragmented" icon="error">
-    CKAN, DCAT, SPARQL, static data.json, and Socrata portals expose different capabilities, languages, and reliability profiles. Ceres speaks all of them.
+    CKAN, DCAT, SPARQL, static data.json, Socrata, and OpenDataSoft portals expose different capabilities, languages, and reliability profiles. Ceres speaks all of them.
   </Card>
   <Card title="Embedding Should Be Optional" icon="magnifier">
     Many teams need a trustworthy harvested catalog first, then decide later whether to add local or hosted embeddings.
@@ -74,7 +74,7 @@ Ceres is designed around that order of work: harvest first, embed later if usefu
 <FeatureGrid>
   <div class="ceres-card animate-fade-in-up animate-delay-2">
     <h3>Harvest First</h3>
-    <p>Stream metadata from CKAN, DCAT (udata REST, SPARQL, static <code>data.json</code>), and Socrata portals into PostgreSQL, track sync history, detect stale datasets, and keep the catalog current even when embeddings are disabled.</p>
+    <p>Stream metadata from CKAN, DCAT (udata REST, SPARQL, static <code>data.json</code>), Socrata, and OpenDataSoft portals into PostgreSQL, track sync history, detect stale datasets, and keep the catalog current even when embeddings are disabled.</p>
   </div>
   <div class="ceres-card animate-fade-in-up animate-delay-3">
     <h3>Decoupled Pipeline</h3>
@@ -127,7 +127,7 @@ Ceres is designed around that order of work: harvest first, embed later if usefu
   </div>
   <div class="ceres-card animate-fade-in-up">
     <h3>Next (v0.6.0)</h3>
-    <p>Coverage expansion: OpenDataSoft and ArcGIS Hub clients, job-based harvesting for every supported portal client, and a significant jump in indexed portals and datasets.</p>
+    <p>Coverage expansion: OpenDataSoft Explore (shipped) and ArcGIS Hub clients, job-based harvesting for every supported portal client, and a significant jump in indexed portals and datasets.</p>
   </div>
   <div class="ceres-card animate-fade-in-up">
     <h3>Later (v0.7.0)</h3>

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -35,7 +35,7 @@ Open data is scattered across thousands of portals speaking different APIs. Cere
 <div class="stat-band animate-fade-in-up animate-delay-1">
   <div class="stat"><span class="stat-value">150+</span><span class="stat-label">portals in sync</span></div>
   <div class="stat"><span class="stat-value">2M+</span><span class="stat-label">datasets harvested</span></div>
-  <div class="stat"><span class="stat-value">5</span><span class="stat-label">portal API families</span></div>
+  <div class="stat"><span class="stat-value">6</span><span class="stat-label">portal API families</span></div>
   <div class="stat"><span class="stat-value">1.85M+</span><span class="stat-label">datasets in the published index</span></div>
 </div>
 


### PR DESCRIPTION
Closes #167

## What

Adds OpenDataSoft support behind the existing portal-client abstraction, expanding European and municipal portal coverage.

## API research

The client targets the **Explore API v2.1** (`/api/explore/v2.1/catalog/datasets`), verified against live portals (opendata.paris.fr, data.economie.gouv.fr, data.opendatasoft.com hub):

- `limit` is capped at 100 per page; `limit + offset` must stay below 10,000 (the API returns an opaque HTTP 500 near the boundary)
- ODSQL rejects range comparisons on text fields (`dataset_id > '...'` fails with `IncompatibleTypesInComparisonFilter`), but date keysets work: `order_by=modified desc` + `where=modified <= date'...'`
- Datasets lacking `modified` are excluded from `modified` ordering and need a separate `where=modified is null` sweep
- Normalization source: `dataset_id`, `metas.default.{title, description, theme, keyword, license, publisher, modified}`, with `metas.dcat.creator/publisher` fallbacks

## Implementation

- `PortalType::OpenDataSoft`, serialized as `opendatasoft`, with parse/display/deserialize tests
- `OpenDataSoftClient` streams page-by-page with bounded memory; deep catalogs (federation hub, ~94k datasets) use the modified-timestamp keyset cursor with a stall guard against non-advancing cursors
- Incremental sync filters server-side with `where=modified >= date'...'`; if more datasets changed than the pagination window can reach it errors so the harvest service falls back to full sync
- Full source metadata (including `fields` schema hints for the v0.7 resource-metadata work) preserved in `NewDataset.metadata`; HTML descriptions converted to text for search, raw HTML retained
- Optional `ODS_API_KEY` sent as `Authorization: Apikey ...`
- Wired through `PortalClientEnum`/`PortalDataEnum`/`PortalClientFactoryEnum`; profile validation rejects DCAT profiles on `opendatasoft` portals

## Tests

- Offline fixture + wiremock coverage: parsing/normalization with raw-metadata preservation, documented fallbacks, malformed-entry skipping, pagination phases, cursor reset at the offset window, stalled-cursor termination, 429 retry with `retry-after`, incremental filtering and window overflow, 404 mapping, API-key header
- Opt-in live smoke test: `CERES_ODS_SMOKE_URL=... cargo test -p ceres-client opendatasoft_smoke_catalog -- --ignored` (verified against opendata.paris.fr: 489 datasets)
- `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -D warnings`, and `cargo test -p ceres-client -p ceres-core` all clean

## Docs

README, website (HARVESTING.md, PORTALS.md, index.mdx), AGENTS.md, in-repo skill references, `.env.example`, CLI help examples, and seven verified example portals in `examples/portals.toml` (Paris, Économie, Toulouse, Bordeaux, Île-de-France, Rennes, SNCF, plus the federation hub commented out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)