### PR TITLE
feat: add CatalogRecordKind enum and integrate into dataset models

### DIFF
--- a/.claude/skills/ceres/SKILL.md
+++ b/.claude/skills/ceres/SKILL.md
@@ -63,7 +63,7 @@ pub trait PortalClient: Send + Sync + Clone {
 
 pub trait PortalClientFactory: Send + Sync + Clone {
     type Client: PortalClient;
-    fn create(&self, portal_url: &str, portal_type: PortalType, language: &str, profile: Option<DcatProfile>, sparql_endpoint: Option<&str>) -> Result<Self::Client, AppError>;
+    fn create(&self, portal_url: &str, portal_type: PortalType, language: &str, profile: Option<DcatProfile>, sparql_endpoint: Option<&str>, ogc_endpoint: Option<&str>) -> Result<Self::Client, AppError>;
 }
 // DcatProfile (ceres_core::config): typed DCAT profile enum — UdataRest (canonical
 // "udata_rest", alias "udata", default) and Sparql ("sparql"). Since PR #171 it is
@@ -103,7 +103,7 @@ pub trait DatasetStore: Send + Sync + Clone {
 | `SyncStats` | `ceres_core::sync` | created, updated, unchanged, failed, skipped counts |
 | `SyncOutcome` | `ceres_core::sync` | Per-dataset outcome: Created, Updated, Unchanged, Failed, Skipped |
 | `BatchHarvestSummary` | `ceres_core::sync` | Aggregated results from batch harvesting multiple portals |
-| `PortalEntry` | `ceres_core::config` | Portal config: name, url, type, enabled, url_template, language, profile, sparql_endpoint |
+| `PortalEntry` | `ceres_core::config` | Portal config: name, url, type, enabled, url_template, language, profile, sparql_endpoint, ogc_endpoint |
 | `AppError` | `ceres_core::error` | Error enum with `is_retryable()` and `should_trip_circuit()` |
 | `EmbeddingStats` | `ceres_core::embedding` | embedded, failed, skipped, total counts from an embedding run |
 | `HarvestPipeline` | `ceres_core::pipeline` | Composes HarvestService + EmbeddingService for combined harvest-then-embed |

--- a/.claude/skills/ceres/SKILL.md
+++ b/.claude/skills/ceres/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ceres
-description: Use when working with Ceres — a Rust harvest-first toolkit and public open data metadata index. Covers harvesting and synchronization, optional embedding and search, CKAN, DCAT udata, SPARQL-backed DCAT, Project Open Data data.json, Socrata Discovery, OpenDataSoft Explore, and ArcGIS Hub portal support, Parquet snapshot manifests/reports/changelogs, Ollama or hosted providers, CLI commands, REST API endpoints, portal configuration, architecture, extending via traits, release workflow, and contributing to the Ceres codebase.
+description: Use when working with Ceres — a Rust harvest-first toolkit and public open data metadata index. Covers harvesting and synchronization, optional embedding and search, CKAN, DCAT udata, SPARQL-backed DCAT, Project Open Data data.json, Socrata Discovery, OpenDataSoft Explore, ArcGIS Hub, and OGC CSW portal support, Parquet snapshot manifests/reports/changelogs, Ollama or hosted providers, CLI commands, REST API endpoints, portal configuration, architecture, extending via traits, release workflow, and contributing to the Ceres codebase.
 ---
 
 # Ceres — Harvest-First Toolkit for Open Data Portals

--- a/.claude/skills/ceres/references/cli-and-server.md
+++ b/.claude/skills/ceres/references/cli-and-server.md
@@ -229,9 +229,10 @@ Fields:
 |---|---|---|---|
 | `name` | Yes | | Portal identifier (used with `--portal` flag) |
 | `url` | Yes | | Portal API base URL |
-| `type` | No | `ckan` | Portal type (`ckan`, `dcat`, `socrata`, `opendatasoft`) |
+| `type` | No | `ckan` | Portal type (`ckan`, `dcat`, `socrata`, `opendatasoft`, `arcgis`, `ogc_records`) |
 | `profile` | No | | DCAT profile selector, e.g. `sparql`; omitted DCAT defaults to udata REST |
 | `sparql_endpoint` | No | | Override SPARQL endpoint for `profile = "sparql"` portals |
+| `ogc_endpoint` | No | | CSW service URL for `type = "ogc_records"` portals when it differs from `url` |
 | `enabled` | No | `true` | Include in batch harvests |
 | `language` | No | `en` | Preferred language for multilingual fields |
 | `url_template` | No | | Custom URL template with `{id}` and `{name}` placeholders |

--- a/.claude/skills/ceres/references/extending.md
+++ b/.claude/skills/ceres/references/extending.md
@@ -81,7 +81,7 @@ Key design notes:
 - `search_modified_since` enables incremental sync. Return `Err` if the portal doesn't support it — Ceres will fall back to full sync.
 - `search_all_datasets` is an optimization for bulk fetch. Default returns an error, falling back to `list_dataset_ids()` + `get_dataset()`.
 
-**Built-in:** `CkanClient`, `DcatClient`, `SparqlDcatClient`, `DataJsonClient`, `SocrataClient`, and `OpenDataSoftClient`.
+**Built-in:** `CkanClient`, `DcatClient`, `SparqlDcatClient`, `DataJsonClient`, `SocrataClient`, `OpenDataSoftClient`, `ArcGisClient`, and `OgcRecordsClient`.
 
 ### PortalClientFactory
 
@@ -90,7 +90,7 @@ Separate factory trait for creating portal clients:
 ```rust
 pub trait PortalClientFactory: Send + Sync + Clone {
     type Client: PortalClient;
-    fn create(&self, portal_url: &str, portal_type: PortalType, language: &str) -> Result<Self::Client, AppError>;
+    fn create(&self, portal_url: &str, portal_type: PortalType, language: &str, profile: Option<DcatProfile>, sparql_endpoint: Option<&str>, ogc_endpoint: Option<&str>) -> Result<Self::Client, AppError>;
 }
 ```
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,6 +684,7 @@ dependencies = [
  "futures",
  "html2text",
  "reqwest",
+ "roxmltree",
  "serde",
  "serde_json",
  "tokio",
@@ -3211,6 +3212,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rsa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ tokio = { version = "1.49.0", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.148"
 html2text = "0.17.1"
+roxmltree = "0.20"
 
 # Error handling
 anyhow = "1.0"

--- a/crates/ceres-cli/src/config.rs
+++ b/crates/ceres-cli/src/config.rs
@@ -81,6 +81,7 @@ pub enum Command {
   ceres harvest https://www.data.va.gov/data.json --type dcat --profile static_json
   ceres harvest https://opendata.paris.fr --type opendatasoft  # Harvest OpenDataSoft portal
   ceres harvest https://opendata.dc.gov --type arcgis  # Harvest ArcGIS Hub portal
+  ceres harvest https://emodnet.ec.europa.eu/geonetwork/emodnet/eng/csw --type ogc_records
   ceres harvest --portal milano                       # Harvest portal by name from config
   ceres harvest --config ~/custom.toml                # Use custom config file
   ceres harvest --full-sync                           # Force full sync even if incremental is available")]

--- a/crates/ceres-cli/src/main.rs
+++ b/crates/ceres-cli/src/main.rs
@@ -209,6 +209,7 @@ async fn handle_harvest(
                     ad_hoc_portal_type,
                     ad_hoc_profile,
                     None,
+                    None,
                 )
                 .await?;
             print_single_portal_summary(&url, &stats);
@@ -246,7 +247,8 @@ async fn handle_harvest(
                     &reporter,
                     portal.portal_type,
                     portal.profile(),
-                    portal.sparql_endpoint().or(portal.ogc_endpoint()),
+                    portal.sparql_endpoint(),
+                    portal.ogc_endpoint(),
                 )
                 .await?;
             print_single_portal_summary(&portal.url, &stats);

--- a/crates/ceres-cli/src/main.rs
+++ b/crates/ceres-cli/src/main.rs
@@ -246,7 +246,7 @@ async fn handle_harvest(
                     &reporter,
                     portal.portal_type,
                     portal.profile(),
-                    portal.sparql_endpoint(),
+                    portal.sparql_endpoint().or(portal.ogc_endpoint()),
                 )
                 .await?;
             print_single_portal_summary(&portal.url, &stats);

--- a/crates/ceres-client/Cargo.toml
+++ b/crates/ceres-client/Cargo.toml
@@ -27,6 +27,7 @@ reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 html2text.workspace = true
+roxmltree.workspace = true
 
 # Domain types
 url.workspace = true

--- a/crates/ceres-client/README.md
+++ b/crates/ceres-client/README.md
@@ -4,8 +4,12 @@
 
 This crate handles connections to external systems used by Ceres: portal APIs for harvesting and embedding providers for optional vector generation.
 
+OGC catalogue records are harvested through CSW 2.0.2 with
+`type = "ogc_records"`; use `ogc_endpoint` when the CSW service URL differs
+from the logical portal URL.
+
 ### What it provides
-* **Portal Clients**: CKAN harvesting plus current DCAT udata support.
+* **Portal Clients**: CKAN, DCAT profiles, Socrata, OpenDataSoft, ArcGIS Hub, and OGC CSW 2.0.2.
 * **Embedding Providers**: Ollama, Gemini, and OpenAI via the `EmbeddingProvider` trait.
 * **HTTP Handling**: Robust request handling with retries.
 

--- a/crates/ceres-client/src/arcgis.rs
+++ b/crates/ceres-client/src/arcgis.rs
@@ -385,6 +385,7 @@ impl ArcGisClient {
             language,
         );
         NewDataset {
+            record_kind: ceres_core::CatalogRecordKind::Dataset,
             original_id: data.id,
             source_portal: portal_url.to_string(),
             url: data.landing_page,

--- a/crates/ceres-client/src/ckan.rs
+++ b/crates/ceres-client/src/ckan.rs
@@ -862,6 +862,7 @@ impl CkanClient {
         );
 
         NewDataset {
+            record_kind: ceres_core::CatalogRecordKind::Dataset,
             original_id: dataset.id,
             source_portal: portal_url.to_string(),
             url: landing_page,

--- a/crates/ceres-client/src/ckan.rs
+++ b/crates/ceres-client/src/ckan.rs
@@ -1306,6 +1306,7 @@ impl ceres_core::traits::PortalClientFactory for CkanClientFactory {
         _language: &str,
         _profile: Option<ceres_core::config::DcatProfile>,
         _sparql_endpoint: Option<&str>,
+        _ogc_endpoint: Option<&str>,
     ) -> Result<Self::Client, AppError> {
         match portal_type {
             ceres_core::config::PortalType::Ckan => CkanClient::new(portal_url),

--- a/crates/ceres-client/src/datajson.rs
+++ b/crates/ceres-client/src/datajson.rs
@@ -130,6 +130,7 @@ impl DataJsonClient {
             language,
         );
         NewDataset {
+            record_kind: ceres_core::CatalogRecordKind::Dataset,
             original_id: data.identifier,
             source_portal: portal_url.to_string(),
             url: data.landing_page,

--- a/crates/ceres-client/src/dcat.rs
+++ b/crates/ceres-client/src/dcat.rs
@@ -168,6 +168,7 @@ impl DcatClient {
         );
 
         NewDataset {
+            record_kind: ceres_core::CatalogRecordKind::Dataset,
             original_id: data.identifier,
             source_portal: portal_url.to_string(),
             url: data.id_uri,

--- a/crates/ceres-client/src/lib.rs
+++ b/crates/ceres-client/src/lib.rs
@@ -26,6 +26,7 @@
 //! | Socrata | Supported | [Discovery API](https://dev.socrata.com/docs/other/discovery) |
 //! | OpenDataSoft | Supported | Explore API v2.1 (`/api/explore/v2.1/catalog/datasets`) |
 //! | ArcGIS Hub | Supported | Hub Search API (`/api/search/v1/collections/dataset/items`) |
+//! | OGC Records | Supported | CSW 2.0.2 catalog service |
 //!
 //! # Embedding Providers
 //!
@@ -44,6 +45,7 @@ pub mod ckan;
 pub mod datajson;
 pub mod dcat;
 pub mod gemini;
+pub mod ogc_records;
 pub mod ollama;
 pub mod openai;
 pub mod opendatasoft;
@@ -58,6 +60,7 @@ pub use ckan::{CkanClient, CkanClientFactory};
 pub use datajson::{DataJsonClient, DataJsonDataset};
 pub use dcat::DcatClient;
 pub use gemini::GeminiClient;
+pub use ogc_records::{OgcRecord, OgcRecordsClient};
 pub use ollama::OllamaClient;
 pub use openai::OpenAIClient;
 pub use opendatasoft::{OpenDataSoftClient, OpenDataSoftDataset};

--- a/crates/ceres-client/src/ogc_records.rs
+++ b/crates/ceres-client/src/ogc_records.rs
@@ -386,13 +386,40 @@ fn parse_record(
         })
         .unwrap_or_default();
     let record_kind = classify_kind(&scope);
-    let online_resources: Vec<Value> = node.descendants().filter(|n| local(*n) == "CI_OnlineResource").map(|n| {
-        let url = n.descendants().find(|x| local(*x) == "URL").and_then(node_value);
-        let protocol = n.descendants().find(|x| local(*x) == "protocol").and_then(node_value);
-        let function = n.descendants().find(|x| local(*x) == "CI_OnLineFunctionCode").and_then(|x| x.attribute("codeListValue").map(str::to_owned).or_else(|| node_value(x)));
-        let downloadable = protocol.as_deref().is_some_and(|p| { let p=p.to_ascii_lowercase(); p.contains("download") || p.contains("wfs") || p.contains("file") }) || function.as_deref().is_some_and(|f| f.eq_ignore_ascii_case("download"));
-        json!({"url": url, "protocol": protocol, "function": function, "downloadable": downloadable})
-    }).collect();
+    let online_resources: Vec<Value> = node
+        .descendants()
+        .filter(|n| local(*n) == "CI_OnlineResource")
+        .map(|n| {
+            let url = n
+                .descendants()
+                .find(|x| local(*x) == "URL")
+                .and_then(node_value);
+            let protocol = n
+                .descendants()
+                .find(|x| local(*x) == "protocol")
+                .and_then(node_value);
+            let function = n
+                .descendants()
+                .find(|x| local(*x) == "CI_OnLineFunctionCode")
+                .and_then(|x| {
+                    x.attribute("codeListValue")
+                        .map(str::to_owned)
+                        .or_else(|| node_value(x))
+                });
+            let downloadable = protocol.as_deref().is_some_and(|p| {
+                let p = p.to_ascii_lowercase();
+                p.contains("download") || p.contains("wfs") || p.contains("file")
+            }) || function
+                .as_deref()
+                .is_some_and(|f| f.eq_ignore_ascii_case("download"));
+            json!({
+                "url": url,
+                "protocol": protocol,
+                "function": function,
+                "downloadable": downloadable,
+            })
+        })
+        .collect();
     let landing_page = online_resources
         .iter()
         .find_map(|r| r.get("url").and_then(Value::as_str))
@@ -407,10 +434,15 @@ fn parse_record(
         modified,
         record_kind,
         metadata: json!({
-            "catalog_record_kind": record_kind, "source_format": "application/xml", "source_xml": raw_xml,
-            "scope": scope, "keywords": values(&["keyword", "subject"]), "publisher": first(&["organisationName", "publisher"]),
-            "license": first(&["useLimitation", "accessConstraints", "license"]), "modified": modified_text,
-            "online_resources": online_resources
+            "catalog_record_kind": record_kind,
+            "source_format": "application/xml",
+            "source_xml": raw_xml,
+            "scope": scope,
+            "keywords": values(&["keyword", "subject"]),
+            "publisher": first(&["organisationName", "publisher"]),
+            "license": first(&["useLimitation", "accessConstraints", "license"]),
+            "modified": modified_text,
+            "online_resources": online_resources,
         }),
     })
 }
@@ -462,6 +494,76 @@ fn csw_exception(doc: &Document<'_>) -> AppError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const FIXTURE: &str = include_str!("../tests/fixtures/csw_get_records.xml");
+
+    #[test]
+    fn parses_get_records_fixture_page() {
+        let page = parse_get_records(FIXTURE, "https://catalog.example.test", "en").unwrap();
+        assert_eq!(page.matched, 3);
+        assert_eq!(page.next_record, 0);
+
+        let kinds: Vec<CatalogRecordKind> = page.records.iter().map(|r| r.record_kind).collect();
+        assert_eq!(
+            kinds,
+            [
+                CatalogRecordKind::Dataset,
+                CatalogRecordKind::Series,
+                CatalogRecordKind::Service,
+            ]
+        );
+
+        let dataset = &page.records[0];
+        assert_eq!(
+            dataset.identifier,
+            "b1a7e9c2-0d43-4f6a-9a21-demo-dataset-001"
+        );
+        assert_eq!(dataset.title, "Mean sea surface temperature 2000-2025");
+        assert!(
+            dataset
+                .description
+                .as_deref()
+                .unwrap()
+                .contains("sea surface temperature")
+        );
+        // Landing page comes from the first online resource.
+        assert_eq!(
+            dataset.landing_page,
+            "https://catalog.example.test/download/sst-2000-2025.nc"
+        );
+        assert_eq!(
+            dataset.modified.unwrap().date_naive().to_string(),
+            "2026-05-14"
+        );
+
+        // Records without online resources fall back to the portal URL.
+        assert_eq!(page.records[1].landing_page, "https://catalog.example.test");
+    }
+
+    #[test]
+    fn fixture_dataset_metadata_preserves_source_details() {
+        let page = parse_get_records(FIXTURE, "https://catalog.example.test", "en").unwrap();
+        let metadata = &page.records[0].metadata;
+
+        assert_eq!(metadata["publisher"], "European Marine Observation Network");
+        assert_eq!(metadata["license"], "CC-BY 4.0");
+        assert_eq!(metadata["keywords"], json!(["oceanography", "temperature"]));
+        assert_eq!(metadata["scope"], "dataset");
+        assert_eq!(metadata["source_format"], "application/xml");
+        assert!(
+            metadata["source_xml"]
+                .as_str()
+                .unwrap()
+                .contains("MD_Metadata")
+        );
+
+        let resources = metadata["online_resources"].as_array().unwrap();
+        assert_eq!(resources.len(), 2);
+        assert_eq!(resources[0]["downloadable"], true);
+        assert_eq!(resources[0]["protocol"], "WWW:DOWNLOAD-1.0-http--download");
+        assert_eq!(resources[1]["downloadable"], false);
+    }
+
     #[test]
     fn parses_iso_record_and_preserves_xml() {
         let xml = r#"<csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco"><csw:SearchResults numberOfRecordsMatched="1" numberOfRecordsReturned="1" nextRecord="0"><gmd:MD_Metadata><gmd:fileIdentifier><gco:CharacterString>abc</gco:CharacterString></gmd:fileIdentifier><gmd:hierarchyLevel><gmd:MD_ScopeCode codeListValue="service"/></gmd:hierarchyLevel><gmd:title><gco:CharacterString>Marine service</gco:CharacterString></gmd:title><gmd:abstract><gco:CharacterString>Description</gco:CharacterString></gmd:abstract></gmd:MD_Metadata></csw:SearchResults></csw:GetRecordsResponse>"#;

--- a/crates/ceres-client/src/ogc_records.rs
+++ b/crates/ceres-client/src/ogc_records.rs
@@ -1,0 +1,519 @@
+//! OGC catalogue records client using the CSW 2.0.2 discovery protocol.
+
+use std::{collections::HashSet, sync::Arc, time::Duration};
+
+use ceres_core::{AppError, CatalogRecordKind, NewDataset, traits::PortalClient};
+use chrono::{DateTime, Utc};
+use futures::{StreamExt, stream::BoxStream};
+use reqwest::{Client, Url};
+use roxmltree::{Document, Node};
+use serde_json::{Value, json};
+use tokio::sync::OnceCell;
+
+const PAGE_SIZE: usize = 100;
+const MAX_PAGES: usize = 100_000;
+const MAX_RESPONSE_BYTES: usize = 32 * 1024 * 1024;
+
+#[derive(Debug, Clone)]
+struct CswBindings {
+    get_records: Url,
+    get_record_by_id: Url,
+}
+
+#[derive(Debug, Clone)]
+pub struct OgcRecord {
+    pub identifier: String,
+    pub title: String,
+    pub description: Option<String>,
+    pub landing_page: String,
+    pub modified: Option<DateTime<Utc>>,
+    pub record_kind: CatalogRecordKind,
+    pub metadata: Value,
+}
+
+#[derive(Debug)]
+struct Page {
+    records: Vec<OgcRecord>,
+    next_record: usize,
+    matched: usize,
+}
+
+#[derive(Clone)]
+pub struct OgcRecordsClient {
+    client: Client,
+    base_url: Url,
+    endpoint: Url,
+    language: String,
+    bindings: Arc<OnceCell<CswBindings>>,
+}
+
+impl OgcRecordsClient {
+    pub fn new(base_url: &str, language: &str, endpoint: Option<&str>) -> Result<Self, AppError> {
+        let base_url =
+            Url::parse(base_url).map_err(|_| AppError::InvalidPortalUrl(base_url.to_string()))?;
+        let endpoint = Url::parse(endpoint.unwrap_or(base_url.as_str())).map_err(|_| {
+            AppError::InvalidPortalUrl(endpoint.unwrap_or(base_url.as_str()).to_string())
+        })?;
+        let client = Client::builder()
+            .user_agent("Ceres/0.6 (open-data-harvester)")
+            .timeout(Duration::from_secs(120))
+            .build()
+            .map_err(|error| AppError::ClientError(error.to_string()))?;
+        Ok(Self {
+            client,
+            base_url,
+            endpoint,
+            language: language.to_string(),
+            bindings: Arc::new(OnceCell::new()),
+        })
+    }
+
+    async fn bounded_get(
+        &self,
+        mut url: Url,
+        params: &[(&str, String)],
+    ) -> Result<String, AppError> {
+        url.query_pairs_mut()
+            .extend_pairs(params.iter().map(|(k, v)| (*k, v.as_str())));
+        let response = self
+            .client
+            .get(url.clone())
+            .send()
+            .await
+            .map_err(|error| AppError::ClientError(error.to_string()))?;
+        if !response.status().is_success() {
+            return Err(AppError::ClientError(format!(
+                "HTTP {} from {url}",
+                response.status()
+            )));
+        }
+        if response
+            .content_length()
+            .is_some_and(|n| n > MAX_RESPONSE_BYTES as u64)
+        {
+            return Err(AppError::ClientError(format!(
+                "CSW response exceeds {MAX_RESPONSE_BYTES} bytes"
+            )));
+        }
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|error| AppError::ClientError(error.to_string()))?;
+        if bytes.len() > MAX_RESPONSE_BYTES {
+            return Err(AppError::ClientError(format!(
+                "CSW response exceeds {MAX_RESPONSE_BYTES} bytes"
+            )));
+        }
+        String::from_utf8(bytes.to_vec())
+            .map_err(|error| AppError::ClientError(format!("CSW returned non-UTF-8 XML: {error}")))
+    }
+
+    async fn bindings(&self) -> Result<&CswBindings, AppError> {
+        self.bindings
+            .get_or_try_init(|| async {
+                let xml = self
+                    .bounded_get(
+                        self.endpoint.clone(),
+                        &[
+                            ("service", "CSW".into()),
+                            ("version", "2.0.2".into()),
+                            ("request", "GetCapabilities".into()),
+                        ],
+                    )
+                    .await?;
+                parse_capabilities(&xml, &self.endpoint)
+            })
+            .await
+    }
+
+    async fn page(&self, start: usize) -> Result<Page, AppError> {
+        let endpoint = self.bindings().await?.get_records.clone();
+        let xml = self
+            .bounded_get(
+                endpoint,
+                &[
+                    ("service", "CSW".into()),
+                    ("version", "2.0.2".into()),
+                    ("request", "GetRecords".into()),
+                    ("resultType", "results".into()),
+                    ("typeNames", "gmd:MD_Metadata".into()),
+                    (
+                        "namespace",
+                        "xmlns(gmd=http://www.isotc211.org/2005/gmd)".into(),
+                    ),
+                    ("elementSetName", "full".into()),
+                    ("outputSchema", "http://www.isotc211.org/2005/gmd".into()),
+                    ("startPosition", start.to_string()),
+                    ("maxRecords", PAGE_SIZE.to_string()),
+                ],
+            )
+            .await?;
+        parse_get_records(&xml, self.base_url.as_str(), &self.language)
+    }
+
+    pub fn paginate_stream(&self) -> BoxStream<'_, Result<Vec<OgcRecord>, AppError>> {
+        struct State {
+            start: usize,
+            pages: usize,
+            seen: HashSet<usize>,
+            done: bool,
+        }
+        Box::pin(futures::stream::unfold(
+            (
+                self.clone(),
+                State {
+                    start: 1,
+                    pages: 0,
+                    seen: HashSet::new(),
+                    done: false,
+                },
+            ),
+            |(client, mut state)| async move {
+                if state.done {
+                    return None;
+                }
+                if state.pages >= MAX_PAGES || !state.seen.insert(state.start) {
+                    state.done = true;
+                    return Some((
+                        Err(AppError::ClientError(
+                            "CSW pagination did not terminate deterministically".into(),
+                        )),
+                        (client, state),
+                    ));
+                }
+                state.pages += 1;
+                match client.page(state.start).await {
+                    Ok(page) => {
+                        if page.next_record == 0 || page.next_record > page.matched {
+                            state.done = true;
+                        } else if page.next_record <= state.start {
+                            state.done = true;
+                            return Some((
+                                Err(AppError::ClientError(format!(
+                                    "CSW nextRecord {} did not advance from {}",
+                                    page.next_record, state.start
+                                ))),
+                                (client, state),
+                            ));
+                        } else {
+                            state.start = page.next_record;
+                        }
+                        Some((Ok(page.records), (client, state)))
+                    }
+                    Err(error) => {
+                        state.done = true;
+                        Some((Err(error), (client, state)))
+                    }
+                }
+            },
+        ))
+    }
+}
+
+impl PortalClient for OgcRecordsClient {
+    type PortalData = OgcRecord;
+    fn portal_type(&self) -> &'static str {
+        "ogc_records"
+    }
+    fn base_url(&self) -> &str {
+        self.base_url.as_str()
+    }
+    async fn list_dataset_ids(&self) -> Result<Vec<String>, AppError> {
+        Ok(self
+            .search_all_datasets()
+            .await?
+            .into_iter()
+            .map(|r| r.identifier)
+            .collect())
+    }
+    async fn get_dataset(&self, id: &str) -> Result<OgcRecord, AppError> {
+        let endpoint = self.bindings().await?.get_record_by_id.clone();
+        let xml = self
+            .bounded_get(
+                endpoint,
+                &[
+                    ("service", "CSW".into()),
+                    ("version", "2.0.2".into()),
+                    ("request", "GetRecordById".into()),
+                    ("elementSetName", "full".into()),
+                    ("outputSchema", "http://www.isotc211.org/2005/gmd".into()),
+                    ("id", id.into()),
+                ],
+            )
+            .await?;
+        parse_single_record(&xml, self.base_url.as_str(), &self.language)
+    }
+    fn into_new_dataset(
+        data: OgcRecord,
+        portal_url: &str,
+        _url_template: Option<&str>,
+        language: &str,
+    ) -> NewDataset {
+        NewDataset {
+            content_hash: NewDataset::compute_content_hash_with_language(
+                &data.title,
+                data.description.as_deref(),
+                language,
+            ),
+            original_id: data.identifier,
+            source_portal: portal_url.into(),
+            url: data.landing_page,
+            title: data.title,
+            description: data.description,
+            record_kind: data.record_kind,
+            embedding: None,
+            metadata: data.metadata,
+        }
+    }
+    async fn search_modified_since(
+        &self,
+        _since: DateTime<Utc>,
+    ) -> Result<Vec<OgcRecord>, AppError> {
+        Err(AppError::ClientError(
+            "CSW incremental sync is not supported".into(),
+        ))
+    }
+    async fn search_all_datasets(&self) -> Result<Vec<OgcRecord>, AppError> {
+        let mut all = Vec::new();
+        let mut stream = self.paginate_stream();
+        while let Some(page) = stream.next().await {
+            all.extend(page?);
+        }
+        Ok(all)
+    }
+    fn search_all_datasets_stream(&self) -> BoxStream<'_, Result<Vec<OgcRecord>, AppError>> {
+        self.paginate_stream()
+    }
+}
+
+fn parse_capabilities(xml: &str, fallback: &Url) -> Result<CswBindings, AppError> {
+    let doc = Document::parse(xml).map_err(xml_error)?;
+    if doc.descendants().any(|n| local(n) == "ExceptionReport") {
+        return Err(csw_exception(&doc));
+    }
+    let operation_url = |name: &str| -> Option<Url> {
+        doc.descendants()
+            .find(|n| local(*n) == "Operation" && n.attribute("name") == Some(name))
+            .and_then(|operation| {
+                operation.descendants().find_map(|n| {
+                    if local(n) != "Get" {
+                        return None;
+                    }
+                    n.attributes()
+                        .find(|a| a.name().ends_with("href"))
+                        .and_then(|a| fallback.join(a.value()).ok())
+                })
+            })
+    };
+    Ok(CswBindings {
+        get_records: operation_url("GetRecords").unwrap_or_else(|| fallback.clone()),
+        get_record_by_id: operation_url("GetRecordById").unwrap_or_else(|| fallback.clone()),
+    })
+}
+
+fn parse_get_records(xml: &str, portal_url: &str, language: &str) -> Result<Page, AppError> {
+    let doc = Document::parse(xml).map_err(xml_error)?;
+    if doc.descendants().any(|n| local(n) == "ExceptionReport") {
+        return Err(csw_exception(&doc));
+    }
+    let results = doc
+        .descendants()
+        .find(|n| local(*n) == "SearchResults")
+        .ok_or_else(|| AppError::ClientError("CSW response is missing SearchResults".into()))?;
+    let number = |name| {
+        results
+            .attribute(name)
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(0)
+    };
+    let records: Vec<OgcRecord> = results
+        .children()
+        .filter(|n| n.is_element())
+        .filter_map(|n| parse_record(n, xml, portal_url, language))
+        .collect();
+    let returned = number("numberOfRecordsReturned");
+    if returned != records.len() {
+        return Err(AppError::ClientError(format!(
+            "CSW declared {returned} returned records but contained {}",
+            records.len()
+        )));
+    }
+    Ok(Page {
+        records,
+        next_record: number("nextRecord"),
+        matched: number("numberOfRecordsMatched"),
+    })
+}
+
+fn parse_single_record(xml: &str, portal_url: &str, language: &str) -> Result<OgcRecord, AppError> {
+    let doc = Document::parse(xml).map_err(xml_error)?;
+    doc.root_element()
+        .children()
+        .find(|n| n.is_element())
+        .and_then(|n| parse_record(n, xml, portal_url, language))
+        .or_else(|| parse_record(doc.root_element(), xml, portal_url, language))
+        .ok_or_else(|| AppError::ClientError("CSW response contained no parseable record".into()))
+}
+
+fn parse_record(
+    node: Node<'_, '_>,
+    xml: &str,
+    portal_url: &str,
+    _language: &str,
+) -> Option<OgcRecord> {
+    let values = |names: &[&str]| -> Vec<String> {
+        node.descendants()
+            .filter(|n| names.contains(&local(*n)))
+            .filter_map(node_value)
+            .collect()
+    };
+    let first = |names: &[&str]| values(names).into_iter().find(|v| !v.trim().is_empty());
+    let identifier = first(&["fileIdentifier", "identifier"])?;
+    // Some legacy ISO records are structurally present but omit the citation
+    // title. Preserve them using their stable identifier as the display
+    // fallback instead of silently dropping the complete source record.
+    let title = first(&["title"]).unwrap_or_else(|| identifier.clone());
+    let description = first(&["abstract", "description"]);
+    let modified_text = first(&["dateStamp", "modified"]);
+    let modified = modified_text.as_deref().and_then(parse_date);
+    let scope = node
+        .descendants()
+        .filter(|n| matches!(local(*n), "MD_ScopeCode" | "hierarchyLevel" | "type"))
+        .find_map(|n| {
+            n.attribute("codeListValue")
+                .map(str::to_owned)
+                .or_else(|| node_value(n))
+        })
+        .unwrap_or_default();
+    let record_kind = classify_kind(&scope);
+    let online_resources: Vec<Value> = node.descendants().filter(|n| local(*n) == "CI_OnlineResource").map(|n| {
+        let url = n.descendants().find(|x| local(*x) == "URL").and_then(node_value);
+        let protocol = n.descendants().find(|x| local(*x) == "protocol").and_then(node_value);
+        let function = n.descendants().find(|x| local(*x) == "CI_OnLineFunctionCode").and_then(|x| x.attribute("codeListValue").map(str::to_owned).or_else(|| node_value(x)));
+        let downloadable = protocol.as_deref().is_some_and(|p| { let p=p.to_ascii_lowercase(); p.contains("download") || p.contains("wfs") || p.contains("file") }) || function.as_deref().is_some_and(|f| f.eq_ignore_ascii_case("download"));
+        json!({"url": url, "protocol": protocol, "function": function, "downloadable": downloadable})
+    }).collect();
+    let landing_page = online_resources
+        .iter()
+        .find_map(|r| r.get("url").and_then(Value::as_str))
+        .unwrap_or(portal_url)
+        .to_string();
+    let raw_xml = xml.get(node.range()).unwrap_or_default();
+    Some(OgcRecord {
+        identifier,
+        title,
+        description,
+        landing_page,
+        modified,
+        record_kind,
+        metadata: json!({
+            "catalog_record_kind": record_kind, "source_format": "application/xml", "source_xml": raw_xml,
+            "scope": scope, "keywords": values(&["keyword", "subject"]), "publisher": first(&["organisationName", "publisher"]),
+            "license": first(&["useLimitation", "accessConstraints", "license"]), "modified": modified_text,
+            "online_resources": online_resources
+        }),
+    })
+}
+
+fn classify_kind(value: &str) -> CatalogRecordKind {
+    match value.to_ascii_lowercase().as_str() {
+        "dataset" => CatalogRecordKind::Dataset,
+        "series" | "collection" => CatalogRecordKind::Series,
+        "service" => CatalogRecordKind::Service,
+        "map" | "model" | "tile" => CatalogRecordKind::Map,
+        _ => CatalogRecordKind::Other,
+    }
+}
+fn local<'a, 'input>(node: Node<'a, 'input>) -> &'input str {
+    node.tag_name().name()
+}
+fn node_value(node: Node<'_, '_>) -> Option<String> {
+    node.descendants().find_map(|n| {
+        if !n.is_text() {
+            return None;
+        }
+        let value = n.text().unwrap_or_default().trim();
+        (!value.is_empty()).then(|| value.to_string())
+    })
+}
+fn parse_date(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|d| d.with_timezone(&Utc))
+        .ok()
+        .or_else(|| {
+            chrono::NaiveDate::parse_from_str(value, "%Y-%m-%d")
+                .ok()
+                .and_then(|d| d.and_hms_opt(0, 0, 0))
+                .map(|d| d.and_utc())
+        })
+}
+fn xml_error(error: roxmltree::Error) -> AppError {
+    AppError::ClientError(format!("Invalid CSW XML: {error}"))
+}
+fn csw_exception(doc: &Document<'_>) -> AppError {
+    AppError::ClientError(
+        doc.descendants()
+            .find(|n| local(*n) == "ExceptionText")
+            .and_then(node_value)
+            .unwrap_or_else(|| "CSW exception response".into()),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn parses_iso_record_and_preserves_xml() {
+        let xml = r#"<csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco"><csw:SearchResults numberOfRecordsMatched="1" numberOfRecordsReturned="1" nextRecord="0"><gmd:MD_Metadata><gmd:fileIdentifier><gco:CharacterString>abc</gco:CharacterString></gmd:fileIdentifier><gmd:hierarchyLevel><gmd:MD_ScopeCode codeListValue="service"/></gmd:hierarchyLevel><gmd:title><gco:CharacterString>Marine service</gco:CharacterString></gmd:title><gmd:abstract><gco:CharacterString>Description</gco:CharacterString></gmd:abstract></gmd:MD_Metadata></csw:SearchResults></csw:GetRecordsResponse>"#;
+        let page = parse_get_records(xml, "https://example.test", "en").unwrap();
+        assert_eq!(page.records[0].record_kind, CatalogRecordKind::Service);
+        assert!(
+            page.records[0].metadata["source_xml"]
+                .as_str()
+                .unwrap()
+                .contains("MD_Metadata")
+        );
+    }
+
+    #[test]
+    fn discovers_get_bindings_from_capabilities() {
+        let xml = r#"<ows:Capabilities xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink"><ows:OperationsMetadata><ows:Operation name="GetRecords"><ows:DCP><ows:HTTP><ows:Get xlink:href="https://catalog.test/query"/></ows:HTTP></ows:DCP></ows:Operation><ows:Operation name="GetRecordById"><ows:DCP><ows:HTTP><ows:Get xlink:href="https://catalog.test/id"/></ows:HTTP></ows:DCP></ows:Operation></ows:OperationsMetadata></ows:Capabilities>"#;
+        let bindings =
+            parse_capabilities(xml, &Url::parse("https://catalog.test/csw").unwrap()).unwrap();
+        assert_eq!(bindings.get_records.as_str(), "https://catalog.test/query");
+        assert_eq!(
+            bindings.get_record_by_id.as_str(),
+            "https://catalog.test/id"
+        );
+    }
+
+    #[test]
+    fn rejects_inconsistent_returned_count() {
+        let xml = r#"<csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"><csw:SearchResults numberOfRecordsMatched="1" numberOfRecordsReturned="1" nextRecord="0"/></csw:GetRecordsResponse>"#;
+        assert!(parse_get_records(xml, "https://catalog.test", "en").is_err());
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network access to EMODnet"]
+    async fn emodnet_csw_smoke() {
+        let client = OgcRecordsClient::new(
+            "https://emodnet.ec.europa.eu",
+            "en",
+            Some("https://emodnet.ec.europa.eu/geonetwork/emodnet/eng/csw"),
+        )
+        .unwrap();
+        client.bindings().await.unwrap();
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network access to Copernicus Marine"]
+    async fn copernicus_marine_csw_smoke() {
+        let client = OgcRecordsClient::new(
+            "https://marine.copernicus.eu",
+            "en",
+            Some("https://csw.marine.copernicus.eu/geonetwork/csw-MYOCEAN-CORE-PRODUCTS/eng/csw"),
+        )
+        .unwrap();
+        client.bindings().await.unwrap();
+    }
+}

--- a/crates/ceres-client/src/opendatasoft.rs
+++ b/crates/ceres-client/src/opendatasoft.rs
@@ -389,6 +389,7 @@ impl OpenDataSoftClient {
             language,
         );
         NewDataset {
+            record_kind: ceres_core::CatalogRecordKind::Dataset,
             original_id: data.id,
             source_portal: portal_url.to_string(),
             url: data.landing_page,

--- a/crates/ceres-client/src/portal.rs
+++ b/crates/ceres-client/src/portal.rs
@@ -22,6 +22,7 @@ use crate::arcgis::{ArcGisClient, ArcGisDataset};
 use crate::ckan::{CkanClient, CkanDataset};
 use crate::datajson::{DataJsonClient, DataJsonDataset};
 use crate::dcat::{DcatClient, DcatDataset};
+use crate::ogc_records::{OgcRecord, OgcRecordsClient};
 use crate::opendatasoft::{OpenDataSoftClient, OpenDataSoftDataset};
 use crate::socrata::{SocrataClient, SocrataDataset};
 use crate::sparql::SparqlDcatClient;
@@ -41,6 +42,8 @@ pub enum PortalDataEnum {
     OpenDataSoft(OpenDataSoftDataset),
     /// Data from an ArcGIS Hub Search API catalog.
     ArcGis(ArcGisDataset),
+    /// Data from an OGC CSW catalogue.
+    OgcRecords(OgcRecord),
 }
 
 /// Unified portal client that wraps concrete portal implementations.
@@ -63,6 +66,8 @@ pub enum PortalClientEnum {
     OpenDataSoft(OpenDataSoftClient),
     /// ArcGIS Hub Search API client.
     ArcGis(ArcGisClient),
+    /// OGC CSW 2.0.2 catalogue client.
+    OgcRecords(OgcRecordsClient),
 }
 
 impl PortalClient for PortalClientEnum {
@@ -77,6 +82,7 @@ impl PortalClient for PortalClientEnum {
             Self::Socrata(c) => c.portal_type(),
             Self::OpenDataSoft(c) => c.portal_type(),
             Self::ArcGis(c) => c.portal_type(),
+            Self::OgcRecords(c) => c.portal_type(),
         }
     }
 
@@ -89,6 +95,7 @@ impl PortalClient for PortalClientEnum {
             Self::Socrata(c) => c.base_url(),
             Self::OpenDataSoft(c) => c.base_url(),
             Self::ArcGis(c) => c.base_url(),
+            Self::OgcRecords(c) => c.base_url(),
         }
     }
 
@@ -101,6 +108,7 @@ impl PortalClient for PortalClientEnum {
             Self::Socrata(c) => c.list_dataset_ids().await,
             Self::OpenDataSoft(c) => c.list_dataset_ids().await,
             Self::ArcGis(c) => c.list_dataset_ids().await,
+            Self::OgcRecords(c) => c.list_dataset_ids().await,
         }
     }
 
@@ -113,6 +121,7 @@ impl PortalClient for PortalClientEnum {
             Self::Socrata(c) => c.get_dataset(id).await.map(PortalDataEnum::Socrata),
             Self::OpenDataSoft(c) => c.get_dataset(id).await.map(PortalDataEnum::OpenDataSoft),
             Self::ArcGis(c) => c.get_dataset(id).await.map(PortalDataEnum::ArcGis),
+            Self::OgcRecords(c) => c.get_dataset(id).await.map(PortalDataEnum::OgcRecords),
         }
     }
 
@@ -140,6 +149,9 @@ impl PortalClient for PortalClientEnum {
             }
             PortalDataEnum::ArcGis(data) => {
                 ArcGisClient::into_new_dataset(data, portal_url, url_template, language)
+            }
+            PortalDataEnum::OgcRecords(data) => {
+                OgcRecordsClient::into_new_dataset(data, portal_url, url_template, language)
             }
         }
     }
@@ -179,6 +191,12 @@ impl PortalClient for PortalClientEnum {
                 .search_modified_since(since)
                 .await
                 .map(|datasets| datasets.into_iter().map(PortalDataEnum::ArcGis).collect()),
+            Self::OgcRecords(c) => c.search_modified_since(since).await.map(|datasets| {
+                datasets
+                    .into_iter()
+                    .map(PortalDataEnum::OgcRecords)
+                    .collect()
+            }),
         }
     }
 
@@ -214,6 +232,12 @@ impl PortalClient for PortalClientEnum {
                 .search_all_datasets()
                 .await
                 .map(|datasets| datasets.into_iter().map(PortalDataEnum::ArcGis).collect()),
+            Self::OgcRecords(c) => c.search_all_datasets().await.map(|datasets| {
+                datasets
+                    .into_iter()
+                    .map(PortalDataEnum::OgcRecords)
+                    .collect()
+            }),
         }
     }
 
@@ -265,6 +289,14 @@ impl PortalClient for PortalClientEnum {
                     r.map(|datasets| datasets.into_iter().map(PortalDataEnum::ArcGis).collect())
                 },
             )),
+            Self::OgcRecords(c) => Box::pin(StreamExt::map(c.paginate_stream(), |r| {
+                r.map(|datasets| {
+                    datasets
+                        .into_iter()
+                        .map(PortalDataEnum::OgcRecords)
+                        .collect()
+                })
+            })),
         }
     }
 
@@ -282,6 +314,9 @@ impl PortalClient for PortalClientEnum {
             Self::Socrata(c) => c.dataset_count().await,
             Self::OpenDataSoft(c) => c.dataset_count().await,
             Self::ArcGis(c) => c.dataset_count().await,
+            Self::OgcRecords(_) => Err(AppError::Generic(
+                "dataset_count is not supported for OGC CSW catalogues".into(),
+            )),
         }
     }
 }
@@ -351,7 +386,10 @@ impl PortalClientFactory for PortalClientFactoryEnum {
                 "A DCAT profile was specified for portal '{portal_url}', but its type is '{portal_type}'. Profiles are only valid for 'dcat' portals."
             )));
         }
-        if sparql_endpoint.is_some() && profile != Some(DcatProfile::Sparql) {
+        if sparql_endpoint.is_some()
+            && profile != Some(DcatProfile::Sparql)
+            && portal_type != PortalType::OgcRecords
+        {
             return Err(AppError::ConfigError(format!(
                 "A SPARQL endpoint was specified for portal '{portal_url}', but its profile is not 'sparql'."
             )));
@@ -364,6 +402,11 @@ impl PortalClientFactory for PortalClientFactoryEnum {
                 OpenDataSoftClient::new(portal_url)?,
             )),
             PortalType::ArcGis => Ok(PortalClientEnum::ArcGis(ArcGisClient::new(portal_url)?)),
+            PortalType::OgcRecords => Ok(PortalClientEnum::OgcRecords(OgcRecordsClient::new(
+                portal_url,
+                language,
+                sparql_endpoint,
+            )?)),
             PortalType::Dcat => match profile.unwrap_or_default() {
                 DcatProfile::UdataRest => Ok(PortalClientEnum::Dcat(DcatClient::new(
                     portal_url, language,

--- a/crates/ceres-client/src/portal.rs
+++ b/crates/ceres-client/src/portal.rs
@@ -380,18 +380,21 @@ impl PortalClientFactory for PortalClientFactoryEnum {
         language: &str,
         profile: Option<DcatProfile>,
         sparql_endpoint: Option<&str>,
+        ogc_endpoint: Option<&str>,
     ) -> Result<Self::Client, AppError> {
         if profile.is_some() && portal_type != PortalType::Dcat {
             return Err(AppError::ConfigError(format!(
                 "A DCAT profile was specified for portal '{portal_url}', but its type is '{portal_type}'. Profiles are only valid for 'dcat' portals."
             )));
         }
-        if sparql_endpoint.is_some()
-            && profile != Some(DcatProfile::Sparql)
-            && portal_type != PortalType::OgcRecords
-        {
+        if sparql_endpoint.is_some() && profile != Some(DcatProfile::Sparql) {
             return Err(AppError::ConfigError(format!(
                 "A SPARQL endpoint was specified for portal '{portal_url}', but its profile is not 'sparql'."
+            )));
+        }
+        if ogc_endpoint.is_some() && portal_type != PortalType::OgcRecords {
+            return Err(AppError::ConfigError(format!(
+                "An OGC endpoint was specified for portal '{portal_url}', but its type is '{portal_type}'. OGC endpoints are only valid for 'ogc_records' portals."
             )));
         }
 
@@ -405,7 +408,7 @@ impl PortalClientFactory for PortalClientFactoryEnum {
             PortalType::OgcRecords => Ok(PortalClientEnum::OgcRecords(OgcRecordsClient::new(
                 portal_url,
                 language,
-                sparql_endpoint,
+                ogc_endpoint,
             )?)),
             PortalType::Dcat => match profile.unwrap_or_default() {
                 DcatProfile::UdataRest => Ok(PortalClientEnum::Dcat(DcatClient::new(
@@ -437,6 +440,7 @@ mod tests {
             "en",
             None,
             None,
+            None,
         );
         assert!(client.is_ok());
         let client = client.unwrap();
@@ -447,7 +451,14 @@ mod tests {
     #[test]
     fn test_factory_creates_dcat_client() {
         let factory = PortalClientFactoryEnum::new();
-        let client = factory.create("https://data.public.lu", PortalType::Dcat, "fr", None, None);
+        let client = factory.create(
+            "https://data.public.lu",
+            PortalType::Dcat,
+            "fr",
+            None,
+            None,
+            None,
+        );
         assert!(client.is_ok());
         let client = client.unwrap();
         assert_eq!(client.portal_type(), "dcat");
@@ -462,6 +473,7 @@ mod tests {
             PortalType::Dcat,
             "en",
             Some(DcatProfile::Sparql),
+            None,
             None,
         );
         assert!(client.is_ok());
@@ -480,6 +492,7 @@ mod tests {
             "nb",
             Some(DcatProfile::Sparql),
             Some("https://sparql.fellesdatakatalog.digdir.no"),
+            None,
         );
         assert!(client.is_ok());
         let client = client.unwrap();
@@ -492,7 +505,14 @@ mod tests {
     fn test_factory_dcat_default_profile_is_udata_rest() {
         let factory = PortalClientFactoryEnum::new();
         let client = factory
-            .create("https://data.public.lu", PortalType::Dcat, "fr", None, None)
+            .create(
+                "https://data.public.lu",
+                PortalType::Dcat,
+                "fr",
+                None,
+                None,
+                None,
+            )
             .unwrap();
         assert!(matches!(client, PortalClientEnum::Dcat(_)));
     }
@@ -506,6 +526,7 @@ mod tests {
                 PortalType::Dcat,
                 "fr",
                 Some(DcatProfile::UdataRest),
+                None,
                 None,
             )
             .unwrap();
@@ -522,6 +543,7 @@ mod tests {
                 "en",
                 Some(DcatProfile::StaticJson),
                 None,
+                None,
             )
             .unwrap();
         assert!(matches!(client, PortalClientEnum::DataJson(_)));
@@ -535,6 +557,7 @@ mod tests {
             PortalType::Ckan,
             "en",
             Some(DcatProfile::Sparql),
+            None,
             None,
         );
         let err = result.err().expect("expected profile-on-ckan error");
@@ -550,6 +573,7 @@ mod tests {
             "fr",
             Some(DcatProfile::UdataRest),
             Some("https://example.org/sparql"),
+            None,
         );
         let err = result
             .err()
@@ -565,6 +589,7 @@ mod tests {
                 "https://opendata.paris.fr",
                 PortalType::OpenDataSoft,
                 "fr",
+                None,
                 None,
                 None,
             )
@@ -583,6 +608,7 @@ mod tests {
             "fr",
             Some(DcatProfile::Sparql),
             None,
+            None,
         );
         let err = result.err().expect("expected profile-on-ods error");
         assert!(err.to_string().contains("only valid for 'dcat'"));
@@ -596,6 +622,7 @@ mod tests {
                 "https://opendata.dc.gov",
                 PortalType::ArcGis,
                 "en",
+                None,
                 None,
                 None,
             )
@@ -614,6 +641,7 @@ mod tests {
             "en",
             Some(DcatProfile::Sparql),
             None,
+            None,
         );
         let err = result.err().expect("expected profile-on-arcgis error");
         assert!(err.to_string().contains("only valid for 'dcat'"));
@@ -629,9 +657,58 @@ mod tests {
                 "en",
                 None,
                 None,
+                None,
             )
             .unwrap();
         assert!(matches!(client, PortalClientEnum::Socrata(_)));
         assert_eq!(client.portal_type(), "socrata");
+    }
+
+    #[test]
+    fn test_factory_creates_ogc_records_client_with_custom_endpoint() {
+        let factory = PortalClientFactoryEnum::new();
+        let client = factory
+            .create(
+                "https://emodnet.ec.europa.eu",
+                PortalType::OgcRecords,
+                "en",
+                None,
+                None,
+                Some("https://emodnet.ec.europa.eu/geonetwork/emodnet/eng/csw"),
+            )
+            .unwrap();
+        assert!(matches!(client, PortalClientEnum::OgcRecords(_)));
+        assert_eq!(client.portal_type(), "ogc_records");
+        assert_eq!(client.base_url(), "https://emodnet.ec.europa.eu/");
+    }
+
+    #[test]
+    fn test_factory_rejects_ogc_endpoint_on_non_ogc_portal() {
+        let factory = PortalClientFactoryEnum::new();
+        let result = factory.create(
+            "https://dati.comune.milano.it",
+            PortalType::Ckan,
+            "en",
+            None,
+            None,
+            Some("https://example.org/csw"),
+        );
+        let err = result.err().expect("expected ogc-endpoint-on-ckan error");
+        assert!(err.to_string().contains("only valid for 'ogc_records'"));
+    }
+
+    #[test]
+    fn test_factory_rejects_sparql_endpoint_on_ogc_portal() {
+        let factory = PortalClientFactoryEnum::new();
+        let result = factory.create(
+            "https://emodnet.ec.europa.eu",
+            PortalType::OgcRecords,
+            "en",
+            None,
+            Some("https://example.org/sparql"),
+            None,
+        );
+        let err = result.err().expect("expected sparql-endpoint-on-ogc error");
+        assert!(err.to_string().contains("not 'sparql'"));
     }
 }

--- a/crates/ceres-client/src/socrata.rs
+++ b/crates/ceres-client/src/socrata.rs
@@ -287,6 +287,7 @@ impl SocrataClient {
             language,
         );
         NewDataset {
+            record_kind: ceres_core::CatalogRecordKind::Dataset,
             original_id: data.id,
             source_portal: portal_url.to_string(),
             url: data.landing_page,

--- a/crates/ceres-client/tests/fixtures/csw_get_records.xml
+++ b/crates/ceres-client/tests/fixtures/csw_get_records.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
+                        xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                        xmlns:gco="http://www.isotc211.org/2005/gco"
+                        xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                        xmlns:xlink="http://www.w3.org/1999/xlink">
+  <csw:SearchStatus timestamp="2026-07-01T08:30:00Z"/>
+  <csw:SearchResults numberOfRecordsMatched="3" numberOfRecordsReturned="3" nextRecord="0"
+                     recordSchema="http://www.isotc211.org/2005/gmd" elementSet="full">
+    <gmd:MD_Metadata>
+      <gmd:fileIdentifier>
+        <gco:CharacterString>b1a7e9c2-0d43-4f6a-9a21-demo-dataset-001</gco:CharacterString>
+      </gmd:fileIdentifier>
+      <gmd:hierarchyLevel>
+        <gmd:MD_ScopeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_ScopeCode"
+                          codeListValue="dataset">dataset</gmd:MD_ScopeCode>
+      </gmd:hierarchyLevel>
+      <gmd:dateStamp>
+        <gco:Date>2026-05-14</gco:Date>
+      </gmd:dateStamp>
+      <gmd:identificationInfo>
+        <gmd:MD_DataIdentification>
+          <gmd:citation>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>Mean sea surface temperature 2000-2025</gco:CharacterString>
+              </gmd:title>
+            </gmd:CI_Citation>
+          </gmd:citation>
+          <gmd:abstract>
+            <gco:CharacterString>Gridded monthly mean sea surface temperature derived from satellite observations.</gco:CharacterString>
+          </gmd:abstract>
+          <gmd:pointOfContact>
+            <gmd:CI_ResponsibleParty>
+              <gmd:organisationName>
+                <gco:CharacterString>European Marine Observation Network</gco:CharacterString>
+              </gmd:organisationName>
+            </gmd:CI_ResponsibleParty>
+          </gmd:pointOfContact>
+          <gmd:descriptiveKeywords>
+            <gmd:MD_Keywords>
+              <gmd:keyword>
+                <gco:CharacterString>oceanography</gco:CharacterString>
+              </gmd:keyword>
+              <gmd:keyword>
+                <gco:CharacterString>temperature</gco:CharacterString>
+              </gmd:keyword>
+            </gmd:MD_Keywords>
+          </gmd:descriptiveKeywords>
+          <gmd:resourceConstraints>
+            <gmd:MD_LegalConstraints>
+              <gmd:useLimitation>
+                <gco:CharacterString>CC-BY 4.0</gco:CharacterString>
+              </gmd:useLimitation>
+            </gmd:MD_LegalConstraints>
+          </gmd:resourceConstraints>
+        </gmd:MD_DataIdentification>
+      </gmd:identificationInfo>
+      <gmd:distributionInfo>
+        <gmd:MD_Distribution>
+          <gmd:transferOptions>
+            <gmd:MD_DigitalTransferOptions>
+              <gmd:onLine>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage>
+                    <gmd:URL>https://catalog.example.test/download/sst-2000-2025.nc</gmd:URL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                    <gco:CharacterString>WWW:DOWNLOAD-1.0-http--download</gco:CharacterString>
+                  </gmd:protocol>
+                </gmd:CI_OnlineResource>
+              </gmd:onLine>
+              <gmd:onLine>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage>
+                    <gmd:URL>https://catalog.example.test/records/demo-dataset-001</gmd:URL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                    <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
+                  </gmd:protocol>
+                </gmd:CI_OnlineResource>
+              </gmd:onLine>
+            </gmd:MD_DigitalTransferOptions>
+          </gmd:transferOptions>
+        </gmd:MD_Distribution>
+      </gmd:distributionInfo>
+    </gmd:MD_Metadata>
+    <gmd:MD_Metadata>
+      <gmd:fileIdentifier>
+        <gco:CharacterString>c2f8d1a4-77b5-4e02-8c3d-demo-series-002</gco:CharacterString>
+      </gmd:fileIdentifier>
+      <gmd:hierarchyLevel>
+        <gmd:MD_ScopeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_ScopeCode"
+                          codeListValue="series">series</gmd:MD_ScopeCode>
+      </gmd:hierarchyLevel>
+      <gmd:dateStamp>
+        <gco:DateTime>2026-06-02T10:15:30Z</gco:DateTime>
+      </gmd:dateStamp>
+      <gmd:identificationInfo>
+        <gmd:MD_DataIdentification>
+          <gmd:citation>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>Coastal bathymetry survey collection</gco:CharacterString>
+              </gmd:title>
+            </gmd:CI_Citation>
+          </gmd:citation>
+          <gmd:abstract>
+            <gco:CharacterString>Collection of high-resolution multibeam bathymetry surveys.</gco:CharacterString>
+          </gmd:abstract>
+        </gmd:MD_DataIdentification>
+      </gmd:identificationInfo>
+    </gmd:MD_Metadata>
+    <gmd:MD_Metadata>
+      <gmd:fileIdentifier>
+        <gco:CharacterString>d9e0f3b6-1c28-49aa-b5e7-demo-service-003</gco:CharacterString>
+      </gmd:fileIdentifier>
+      <gmd:hierarchyLevel>
+        <gmd:MD_ScopeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_ScopeCode"
+                          codeListValue="service">service</gmd:MD_ScopeCode>
+      </gmd:hierarchyLevel>
+      <gmd:dateStamp>
+        <gco:Date>2026-01-20</gco:Date>
+      </gmd:dateStamp>
+      <gmd:identificationInfo>
+        <gmd:MD_DataIdentification>
+          <gmd:citation>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>WMS view service for marine habitats</gco:CharacterString>
+              </gmd:title>
+            </gmd:CI_Citation>
+          </gmd:citation>
+          <gmd:abstract>
+            <gco:CharacterString>OGC Web Map Service exposing marine habitat layers.</gco:CharacterString>
+          </gmd:abstract>
+        </gmd:MD_DataIdentification>
+      </gmd:identificationInfo>
+    </gmd:MD_Metadata>
+  </csw:SearchResults>
+</csw:GetRecordsResponse>

--- a/crates/ceres-core/src/config.rs
+++ b/crates/ceres-core/src/config.rs
@@ -393,6 +393,9 @@ pub enum PortalType {
     OpenDataSoft,
     /// ArcGIS Hub portal (Hub Search API; geospatial-heavy local and regional governments).
     ArcGis,
+    /// OGC catalogue records exposed through CSW 2.0.2.
+    #[serde(rename = "ogc_records")]
+    OgcRecords,
 }
 
 impl fmt::Display for PortalType {
@@ -403,6 +406,7 @@ impl fmt::Display for PortalType {
             Self::Dcat => write!(f, "dcat"),
             Self::OpenDataSoft => write!(f, "opendatasoft"),
             Self::ArcGis => write!(f, "arcgis"),
+            Self::OgcRecords => write!(f, "ogc_records"),
         }
     }
 }
@@ -417,8 +421,9 @@ impl FromStr for PortalType {
             "dcat" => Ok(Self::Dcat),
             "opendatasoft" => Ok(Self::OpenDataSoft),
             "arcgis" => Ok(Self::ArcGis),
+            "ogc_records" | "csw" => Ok(Self::OgcRecords),
             _ => Err(AppError::ConfigError(format!(
-                "Unknown portal type: '{}'. Valid options: ckan, socrata, dcat, opendatasoft, arcgis",
+                "Unknown portal type: '{}'. Valid options: ckan, socrata, dcat, opendatasoft, arcgis, ogc_records",
                 s
             ))),
         }
@@ -619,6 +624,10 @@ pub struct PortalEntry {
     #[serde(default)]
     pub sparql_endpoint: Option<String>,
 
+    /// Optional CSW service endpoint for `ogc_records` portals.
+    #[serde(default)]
+    pub ogc_endpoint: Option<String>,
+
     /// Alternate or mirror base URLs that are the *same logical portal* as `url`.
     ///
     /// Datasets harvested under any of these URLs are folded onto `url` for
@@ -646,6 +655,11 @@ impl PortalEntry {
         self.sparql_endpoint.as_deref()
     }
 
+    /// Returns the custom OGC CSW endpoint URL, if set.
+    pub fn ogc_endpoint(&self) -> Option<&str> {
+        self.ogc_endpoint.as_deref()
+    }
+
     /// Returns the declared alias/mirror base URLs for this portal.
     pub fn aliases(&self) -> &[String] {
         &self.aliases
@@ -666,6 +680,12 @@ impl PortalEntry {
         if self.sparql_endpoint.is_some() && self.profile != Some(DcatProfile::Sparql) {
             return Err(AppError::ConfigError(format!(
                 "Portal '{}': 'sparql_endpoint' is only valid with profile = \"sparql\"",
+                self.name
+            )));
+        }
+        if self.ogc_endpoint.is_some() && self.portal_type != PortalType::OgcRecords {
+            return Err(AppError::ConfigError(format!(
+                "Portal '{}': 'ogc_endpoint' is only valid with type = \"ogc_records\"",
                 self.name
             )));
         }

--- a/crates/ceres-core/src/embedding.rs
+++ b/crates/ceres-core/src/embedding.rs
@@ -358,6 +358,7 @@ where
                             }
                         };
                         NewDataset {
+                            record_kind: crate::CatalogRecordKind::Dataset,
                             original_id: d.original_id.clone(),
                             source_portal: d.source_portal.clone(),
                             url: d.url.clone(),

--- a/crates/ceres-core/src/harvest.rs
+++ b/crates/ceres-core/src/harvest.rs
@@ -171,6 +171,8 @@ pub struct SyncOptions<'a> {
     pub profile: Option<DcatProfile>,
     /// Optional SPARQL endpoint override for SPARQL-backed DCAT portals.
     pub sparql_endpoint: Option<&'a str>,
+    /// Optional CSW service URL override for OGC Records portals.
+    pub ogc_endpoint: Option<&'a str>,
 }
 
 /// Service for harvesting dataset metadata from open data portals.
@@ -316,6 +318,7 @@ where
             PortalType::default(),
             None,
             None,
+            None,
         )
         .await
     }
@@ -340,6 +343,7 @@ where
         portal_type: PortalType,
         profile: Option<DcatProfile>,
         sparql_endpoint: Option<&str>,
+        ogc_endpoint: Option<&str>,
     ) -> Result<SyncStats, AppError> {
         let result = self
             .sync_portal_with_progress_cancellable_internal(
@@ -351,6 +355,7 @@ where
                     portal_type,
                     profile,
                     sparql_endpoint,
+                    ogc_endpoint,
                 },
                 reporter,
                 CancellationToken::new(), // never cancelled
@@ -491,6 +496,7 @@ where
                 portal_type: PortalType::default(),
                 profile: None,
                 sparql_endpoint: None,
+                ogc_endpoint: None,
             },
             &SilentReporter,
             cancel_token,
@@ -510,6 +516,7 @@ where
         portal_type: PortalType,
         profile: Option<DcatProfile>,
         sparql_endpoint: Option<&str>,
+        ogc_endpoint: Option<&str>,
     ) -> Result<SyncResult, AppError> {
         self.sync_portal_with_progress_cancellable_internal(
             SyncOptions {
@@ -520,6 +527,7 @@ where
                 portal_type,
                 profile,
                 sparql_endpoint,
+                ogc_endpoint,
             },
             reporter,
             cancel_token,
@@ -541,6 +549,7 @@ where
         portal_type: PortalType,
         profile: Option<DcatProfile>,
         sparql_endpoint: Option<&str>,
+        ogc_endpoint: Option<&str>,
     ) -> Result<SyncResult, AppError> {
         let force_full_sync = self.config.force_full_sync || force_full_sync;
         self.sync_portal_with_progress_cancellable_internal(
@@ -552,6 +561,7 @@ where
                 portal_type,
                 profile,
                 sparql_endpoint,
+                ogc_endpoint,
             },
             reporter,
             cancel_token,
@@ -573,6 +583,7 @@ where
             portal_type,
             profile,
             sparql_endpoint,
+            ogc_endpoint,
         } = options;
 
         let sync_start = Utc::now();
@@ -595,6 +606,7 @@ where
             language,
             profile,
             sparql_endpoint,
+            ogc_endpoint,
         )?;
 
         // Determine sync plan (IDs for full sync, datasets for incremental)
@@ -1296,7 +1308,8 @@ where
                     cancel_token.clone(),
                     portal.portal_type,
                     portal.profile(),
-                    portal.sparql_endpoint().or(portal.ogc_endpoint()),
+                    portal.sparql_endpoint(),
+                    portal.ogc_endpoint(),
                 )
                 .await
             {

--- a/crates/ceres-core/src/harvest.rs
+++ b/crates/ceres-core/src/harvest.rs
@@ -1296,7 +1296,7 @@ where
                     cancel_token.clone(),
                     portal.portal_type,
                     portal.profile(),
-                    portal.sparql_endpoint(),
+                    portal.sparql_endpoint().or(portal.ogc_endpoint()),
                 )
                 .await
             {

--- a/crates/ceres-core/src/job.rs
+++ b/crates/ceres-core/src/job.rs
@@ -216,6 +216,8 @@ pub struct HarvestJob {
 
     /// Optional SPARQL endpoint override for DCAT harvests.
     pub sparql_endpoint: Option<String>,
+    /// Optional OGC CSW endpoint override.
+    pub ogc_endpoint: Option<String>,
 }
 
 impl HarvestJob {
@@ -260,6 +262,8 @@ pub struct CreateJobRequest {
 
     /// Optional SPARQL endpoint override for DCAT harvests.
     pub sparql_endpoint: Option<String>,
+    /// Optional OGC CSW endpoint override.
+    pub ogc_endpoint: Option<String>,
 }
 
 impl CreateJobRequest {
@@ -275,6 +279,7 @@ impl CreateJobRequest {
             portal_type: PortalType::default(),
             profile: None,
             sparql_endpoint: None,
+            ogc_endpoint: None,
         }
     }
 
@@ -323,6 +328,11 @@ impl CreateJobRequest {
     /// Set the SPARQL endpoint override for DCAT harvests.
     pub fn with_sparql_endpoint(mut self, sparql_endpoint: impl Into<String>) -> Self {
         self.sparql_endpoint = Some(sparql_endpoint.into());
+        self
+    }
+
+    pub fn with_ogc_endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.ogc_endpoint = Some(endpoint.into());
         self
     }
 }
@@ -482,6 +492,7 @@ mod tests {
             language: None,
             profile: None,
             sparql_endpoint: None,
+            ogc_endpoint: None,
         };
 
         assert!(job.can_retry());

--- a/crates/ceres-core/src/lib.rs
+++ b/crates/ceres-core/src/lib.rs
@@ -74,7 +74,7 @@ pub use error::AppError;
 pub use i18n::LocalizedField;
 
 // Domain models
-pub use models::{DatabaseStats, Dataset, NewDataset, SearchResult};
+pub use models::{CatalogRecordKind, DatabaseStats, Dataset, NewDataset, SearchResult};
 pub use schema::{DatasetResource, DatasetSchema, ResourceField};
 
 // Sync types and business logic

--- a/crates/ceres-core/src/models.rs
+++ b/crates/ceres-core/src/models.rs
@@ -1,7 +1,55 @@
 use chrono::{DateTime, Utc};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use std::{fmt, str::FromStr};
 use uuid::Uuid;
+
+/// Semantic kind of a harvested catalog record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CatalogRecordKind {
+    #[default]
+    Dataset,
+    Series,
+    Service,
+    Map,
+    Other,
+}
+
+impl CatalogRecordKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Dataset => "dataset",
+            Self::Series => "series",
+            Self::Service => "service",
+            Self::Map => "map",
+            Self::Other => "other",
+        }
+    }
+}
+
+impl fmt::Display for CatalogRecordKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for CatalogRecordKind {
+    type Err = crate::AppError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.to_ascii_lowercase().as_str() {
+            "dataset" => Ok(Self::Dataset),
+            "series" => Ok(Self::Series),
+            "service" => Ok(Self::Service),
+            "map" => Ok(Self::Map),
+            "other" => Ok(Self::Other),
+            _ => Err(crate::AppError::ConfigError(format!(
+                "Unknown catalog record kind: '{value}'"
+            ))),
+        }
+    }
+}
 
 /// Complete representation of a row from the 'datasets' table.
 ///
@@ -35,6 +83,8 @@ pub struct Dataset {
     pub title: String,
     /// Optional detailed description
     pub description: Option<String>,
+    /// Semantic catalog record kind.
+    pub record_kind: CatalogRecordKind,
 
     /// Optional embedding vector for semantic search
     pub embedding: Option<Vec<f32>>,
@@ -106,6 +156,8 @@ pub struct NewDataset {
     pub title: String,
     /// Optional detailed description
     pub description: Option<String>,
+    /// Semantic catalog record kind.
+    pub record_kind: CatalogRecordKind,
     /// Optional embedding vector for semantic search
     pub embedding: Option<Vec<f32>>,
     /// Additional metadata as JSON
@@ -209,6 +261,7 @@ mod tests {
         let content_hash = NewDataset::compute_content_hash(title, description.as_deref());
 
         let dataset = NewDataset {
+            record_kind: CatalogRecordKind::Dataset,
             original_id: "test-123".to_string(),
             source_portal: "https://example.com".to_string(),
             url: "https://example.com/dataset/test".to_string(),

--- a/crates/ceres-core/src/models.rs
+++ b/crates/ceres-core/src/models.rs
@@ -111,7 +111,7 @@ pub struct Dataset {
 /// # Examples
 ///
 /// ```
-/// use ceres_core::NewDataset;
+/// use ceres_core::{CatalogRecordKind, NewDataset};
 /// use serde_json::json;
 ///
 /// let title = "My Dataset";
@@ -127,6 +127,7 @@ pub struct Dataset {
 ///     embedding: None,
 ///     metadata: json!({"tags": ["open-data", "italy"]}),
 ///     content_hash,
+///     record_kind: CatalogRecordKind::Dataset,
 /// };
 ///
 /// assert_eq!(dataset.title, "My Dataset");
@@ -144,6 +145,7 @@ pub struct Dataset {
 /// * `embedding` - Optional vector of floats for semantic search
 /// * `metadata` - Additional metadata as JSON
 /// * `content_hash` - SHA-256 hash of title + description for delta detection
+/// * `record_kind` - Kind of catalogue record (dataset, series, service, ...)
 #[derive(Debug, Serialize, Clone)]
 pub struct NewDataset {
     /// Original identifier from the source portal

--- a/crates/ceres-core/src/parquet_export.rs
+++ b/crates/ceres-core/src/parquet_export.rs
@@ -354,6 +354,7 @@ struct FlatRecord {
     url: String,
     title: String,
     description: String,
+    record_kind: String,
     tags: String,
     organization: String,
     license: String,
@@ -832,6 +833,7 @@ impl<S: DatasetStore> ParquetExportService<S> {
                 .entry(portal_key.clone())
                 .or_default()
                 .push(FlatRecord {
+                    record_kind: dataset.record_kind.to_string(),
                     original_id: record.original_id.clone(),
                     source_portal: record.source_portal.clone(),
                     portal_name: record.portal_name.clone(),
@@ -1032,6 +1034,7 @@ impl<S: DatasetStore> ParquetExportService<S> {
             url: dataset.url.clone(),
             title: dataset.title.clone(),
             description: dataset.description.clone().unwrap_or_default(),
+            record_kind: dataset.record_kind.to_string(),
             tags: extract_tags(metadata),
             organization: extract_organization(metadata),
             license: extract_license(metadata),
@@ -1057,6 +1060,7 @@ fn arrow_schema() -> Arc<Schema> {
         Field::new("url", DataType::Utf8, false),
         Field::new("title", DataType::Utf8, false),
         Field::new("description", DataType::Utf8, true),
+        Field::new("record_kind", DataType::Utf8, false),
         Field::new("tags", DataType::Utf8, true),
         Field::new("organization", DataType::Utf8, true),
         Field::new("license", DataType::Utf8, true),
@@ -1137,6 +1141,7 @@ fn build_record_batch(
     let mut url = StringBuilder::with_capacity(len, len * 128);
     let mut title = StringBuilder::with_capacity(len, len * 64);
     let mut description = StringBuilder::with_capacity(len, len * 256);
+    let mut record_kind = StringBuilder::with_capacity(len, len * 12);
     let mut tags = StringBuilder::with_capacity(len, len * 64);
     let mut organization = StringBuilder::with_capacity(len, len * 48);
     let mut license = StringBuilder::with_capacity(len, len * 32);
@@ -1153,6 +1158,7 @@ fn build_record_batch(
         url.append_value(&r.url);
         title.append_value(&r.title);
         description.append_value(&r.description);
+        record_kind.append_value(&r.record_kind);
         tags.append_value(&r.tags);
         organization.append_value(&r.organization);
         license.append_value(&r.license);
@@ -1172,6 +1178,7 @@ fn build_record_batch(
             Arc::new(url.finish()),
             Arc::new(title.finish()),
             Arc::new(description.finish()),
+            Arc::new(record_kind.finish()),
             Arc::new(tags.finish()),
             Arc::new(organization.finish()),
             Arc::new(license.finish()),
@@ -1810,6 +1817,7 @@ mod tests {
     fn test_build_record_batch() {
         let schema = arrow_schema();
         let records = vec![FlatRecord {
+            record_kind: "dataset".to_string(),
             original_id: "test-1".to_string(),
             source_portal: "https://example.com".to_string(),
             portal_name: "example".to_string(),
@@ -1828,6 +1836,6 @@ mod tests {
 
         let batch = build_record_batch(&records, &schema).unwrap();
         assert_eq!(batch.num_rows(), 1);
-        assert_eq!(batch.num_columns(), 14);
+        assert_eq!(batch.num_columns(), 15);
     }
 }

--- a/crates/ceres-core/src/pipeline.rs
+++ b/crates/ceres-core/src/pipeline.rs
@@ -106,6 +106,7 @@ where
                 PortalType::default(),
                 None,
                 None,
+                None,
             )
             .await?;
         Ok(result.stats)
@@ -122,6 +123,7 @@ where
         portal_type: PortalType,
         profile: Option<DcatProfile>,
         sparql_endpoint: Option<&str>,
+        ogc_endpoint: Option<&str>,
     ) -> Result<(SyncResult, EmbeddingStats), AppError> {
         self.sync_portal_with_progress_cancellable_with_options(
             portal_url,
@@ -133,6 +135,7 @@ where
             portal_type,
             profile,
             sparql_endpoint,
+            ogc_endpoint,
         )
         .await
     }
@@ -150,6 +153,7 @@ where
         portal_type: PortalType,
         profile: Option<DcatProfile>,
         sparql_endpoint: Option<&str>,
+        ogc_endpoint: Option<&str>,
     ) -> Result<(SyncResult, EmbeddingStats), AppError> {
         // Step 1: Harvest metadata
         let sync_result = self
@@ -164,6 +168,7 @@ where
                 portal_type,
                 profile,
                 sparql_endpoint,
+                ogc_endpoint,
             )
             .await?;
 

--- a/crates/ceres-core/src/traits.rs
+++ b/crates/ceres-core/src/traits.rs
@@ -227,7 +227,10 @@ pub trait PortalClientFactory: Send + Sync + Clone {
     /// * `language` - Preferred language for multilingual portals (e.g. "en", "fr")
     /// * `profile` - Optional DCAT profile for sub-dispatch; defaults to
     ///   [`DcatProfile::UdataRest`] for DCAT portals, must be `None` otherwise
-    /// * `sparql_endpoint` - Optional custom SPARQL endpoint URL (overrides `{url}/sparql`)
+    /// * `sparql_endpoint` - Optional custom SPARQL endpoint URL (overrides `{url}/sparql`);
+    ///   only valid for SPARQL-profile DCAT portals
+    /// * `ogc_endpoint` - Optional CSW service URL (overrides the portal URL);
+    ///   only valid for OGC Records portals
     fn create(
         &self,
         portal_url: &str,
@@ -235,6 +238,7 @@ pub trait PortalClientFactory: Send + Sync + Clone {
         language: &str,
         profile: Option<DcatProfile>,
         sparql_endpoint: Option<&str>,
+        ogc_endpoint: Option<&str>,
     ) -> Result<Self::Client, AppError>;
 }
 

--- a/crates/ceres-core/src/worker.rs
+++ b/crates/ceres-core/src/worker.rs
@@ -306,7 +306,9 @@ where
                 job.force_full_sync,
                 job.portal_type,
                 job.profile,
-                job.sparql_endpoint.as_deref(),
+                job.sparql_endpoint
+                    .as_deref()
+                    .or(job.ogc_endpoint.as_deref()),
             )
             .await;
 

--- a/crates/ceres-core/src/worker.rs
+++ b/crates/ceres-core/src/worker.rs
@@ -306,9 +306,8 @@ where
                 job.force_full_sync,
                 job.portal_type,
                 job.profile,
-                job.sparql_endpoint
-                    .as_deref()
-                    .or(job.ogc_endpoint.as_deref()),
+                job.sparql_endpoint.as_deref(),
+                job.ogc_endpoint.as_deref(),
             )
             .await;
 

--- a/crates/ceres-core/tests/integration/cancellation_tests.rs
+++ b/crates/ceres-core/tests/integration/cancellation_tests.rs
@@ -114,6 +114,7 @@ async fn test_batch_harvest_cancellable() {
             language: None,
             profile: None,
             sparql_endpoint: None,
+            ogc_endpoint: None,
             aliases: Vec::new(),
         },
         ceres_core::PortalEntry {
@@ -126,6 +127,7 @@ async fn test_batch_harvest_cancellable() {
             language: None,
             profile: None,
             sparql_endpoint: None,
+            ogc_endpoint: None,
             aliases: Vec::new(),
         },
     ];

--- a/crates/ceres-core/tests/integration/common.rs
+++ b/crates/ceres-core/tests/integration/common.rs
@@ -209,6 +209,7 @@ impl PortalClientFactory for MockPortalClientFactory {
         _language: &str,
         _profile: Option<ceres_core::config::DcatProfile>,
         _sparql_endpoint: Option<&str>,
+        _ogc_endpoint: Option<&str>,
     ) -> Result<Self::Client, AppError> {
         Ok(MockPortalClient::new(portal_url, self.datasets.clone()))
     }

--- a/crates/ceres-core/tests/integration/common.rs
+++ b/crates/ceres-core/tests/integration/common.rs
@@ -153,6 +153,7 @@ impl PortalClient for MockPortalClient {
         };
 
         NewDataset {
+            record_kind: ceres_core::CatalogRecordKind::Dataset,
             original_id: data.id.clone(),
             source_portal: portal_url.to_string(),
             url,
@@ -297,6 +298,7 @@ impl DatasetStore for MockDatasetStore {
         for stored in datasets.values() {
             if stored.id == id {
                 return Ok(Some(Dataset {
+                    record_kind: ceres_core::CatalogRecordKind::Dataset,
                     id: stored.id,
                     original_id: stored.dataset.original_id.clone(),
                     source_portal: stored.dataset.source_portal.clone(),
@@ -411,6 +413,7 @@ impl DatasetStore for MockDatasetStore {
                 // Create a minimal Dataset for SearchResult
                 SearchResult {
                     dataset: ceres_core::Dataset {
+                        record_kind: ceres_core::CatalogRecordKind::Dataset,
                         id: stored.id,
                         original_id: stored.dataset.original_id.clone(),
                         source_portal: stored.dataset.source_portal.clone(),
@@ -444,6 +447,7 @@ impl DatasetStore for MockDatasetStore {
             .take(limit.unwrap_or(usize::MAX))
             .map(|((_, _), stored)| {
                 Ok(Dataset {
+                    record_kind: ceres_core::CatalogRecordKind::Dataset,
                     id: stored.id,
                     original_id: stored.dataset.original_id.clone(),
                     source_portal: stored.dataset.source_portal.clone(),
@@ -529,6 +533,7 @@ impl DatasetStore for MockDatasetStore {
             })
             .take(limit.unwrap_or(usize::MAX))
             .map(|((_, _), stored)| Dataset {
+                record_kind: ceres_core::CatalogRecordKind::Dataset,
                 id: stored.id,
                 original_id: stored.dataset.original_id.clone(),
                 source_portal: stored.dataset.source_portal.clone(),
@@ -617,6 +622,7 @@ impl MockJobQueue {
             language: None,
             profile: None,
             sparql_endpoint: None,
+            ogc_endpoint: None,
         };
         self.jobs.lock().unwrap().insert(id, job);
         (self, id)
@@ -670,6 +676,7 @@ impl JobQueue for MockJobQueue {
             language: request.language,
             profile: request.profile,
             sparql_endpoint: request.sparql_endpoint,
+            ogc_endpoint: request.ogc_endpoint,
         };
         self.jobs.lock().unwrap().insert(id, job.clone());
         Ok(job)

--- a/crates/ceres-core/tests/integration/export_tests.rs
+++ b/crates/ceres-core/tests/integration/export_tests.rs
@@ -25,6 +25,7 @@ async fn setup_test_datasets(store: &MockDatasetStore, count: usize) -> Vec<Mock
 
     for data in &datasets {
         let new_dataset = NewDataset {
+            record_kind: ceres_core::CatalogRecordKind::Dataset,
             original_id: data.id.clone(),
             source_portal: TEST_PORTAL_URL.to_string(),
             url: format!("{}/dataset/{}", TEST_PORTAL_URL, data.id),
@@ -215,6 +216,7 @@ async fn test_export_csv_empty_store() {
 async fn test_parquet_export_writes_versioned_snapshot_manifest() {
     let store = MockDatasetStore::new();
     let dataset = NewDataset {
+        record_kind: ceres_core::CatalogRecordKind::Dataset,
         original_id: "transport-routes".to_string(),
         source_portal: TEST_PORTAL_URL.to_string(),
         url: format!("{TEST_PORTAL_URL}/dataset/transport-routes"),
@@ -240,6 +242,7 @@ async fn test_parquet_export_writes_versioned_snapshot_manifest() {
             language: None,
             profile: None,
             sparql_endpoint: None,
+            ogc_endpoint: None,
             aliases: Vec::new(),
         }],
     };
@@ -313,6 +316,7 @@ async fn test_parquet_export_writes_coverage_and_quality_report() {
     let store = MockDatasetStore::new();
     // Two datasets: one fully populated, one missing license/org/tags/modified.
     let rich = NewDataset {
+        record_kind: ceres_core::CatalogRecordKind::Dataset,
         original_id: "rich".to_string(),
         source_portal: TEST_PORTAL_URL.to_string(),
         url: format!("{TEST_PORTAL_URL}/dataset/rich"),
@@ -331,6 +335,7 @@ async fn test_parquet_export_writes_coverage_and_quality_report() {
         ),
     };
     let sparse = NewDataset {
+        record_kind: ceres_core::CatalogRecordKind::Dataset,
         original_id: "sparse".to_string(),
         source_portal: TEST_PORTAL_URL.to_string(),
         url: format!("{TEST_PORTAL_URL}/dataset/sparse"),
@@ -357,6 +362,7 @@ async fn test_parquet_export_writes_coverage_and_quality_report() {
             language: Some("en".to_string()),
             profile: None,
             sparql_endpoint: None,
+            ogc_endpoint: None,
             aliases: Vec::new(),
         }],
     };
@@ -424,6 +430,7 @@ fn portal_entry(name: &str, url: &str, aliases: Vec<String>) -> PortalEntry {
         language: Some("en".to_string()),
         profile: None,
         sparql_endpoint: None,
+        ogc_endpoint: None,
         aliases,
     }
 }
@@ -437,6 +444,7 @@ async fn upsert_dataset(
     description: &str,
 ) {
     let dataset = NewDataset {
+        record_kind: ceres_core::CatalogRecordKind::Dataset,
         original_id: id.to_string(),
         source_portal: portal.to_string(),
         url: format!("{portal}/dataset/{id}"),
@@ -674,6 +682,7 @@ async fn test_export_csv_escapes_special_characters() {
 
     // Create a dataset with special characters in description
     let dataset = NewDataset {
+        record_kind: ceres_core::CatalogRecordKind::Dataset,
         original_id: "special-chars".to_string(),
         source_portal: TEST_PORTAL_URL.to_string(),
         url: format!("{}/dataset/special-chars", TEST_PORTAL_URL),
@@ -748,6 +757,7 @@ async fn test_export_with_portal_filter() {
 
     // Create datasets from two different portals
     let dataset1 = NewDataset {
+        record_kind: ceres_core::CatalogRecordKind::Dataset,
         original_id: "dataset-a".to_string(),
         source_portal: "https://portal-a.example.com".to_string(),
         url: "https://portal-a.example.com/dataset/dataset-a".to_string(),
@@ -759,6 +769,7 @@ async fn test_export_with_portal_filter() {
     };
 
     let dataset2 = NewDataset {
+        record_kind: ceres_core::CatalogRecordKind::Dataset,
         original_id: "dataset-b".to_string(),
         source_portal: "https://portal-b.example.com".to_string(),
         url: "https://portal-b.example.com/dataset/dataset-b".to_string(),
@@ -808,6 +819,7 @@ async fn test_export_with_filter_and_limit() {
     // Create 5 datasets from same portal
     for i in 0..5 {
         let dataset = NewDataset {
+            record_kind: ceres_core::CatalogRecordKind::Dataset,
             original_id: format!("dataset-{}", i),
             source_portal: TEST_PORTAL_URL.to_string(),
             url: format!("{}/dataset/dataset-{}", TEST_PORTAL_URL, i),

--- a/crates/ceres-core/tests/integration/search_tests.rs
+++ b/crates/ceres-core/tests/integration/search_tests.rs
@@ -144,6 +144,7 @@ impl DatasetStore for FailingDatasetStore {
 async fn seeded_store() -> MockDatasetStore {
     let store = MockDatasetStore::new();
     let dataset = NewDataset {
+        record_kind: ceres_core::CatalogRecordKind::Dataset,
         original_id: "d1".to_string(),
         source_portal: "https://test.example.com".to_string(),
         url: "https://test.example.com/dataset/d1".to_string(),
@@ -189,6 +190,7 @@ async fn test_search_respects_limit() {
     // Insert multiple datasets
     for i in 0..5 {
         let dataset = NewDataset {
+            record_kind: ceres_core::CatalogRecordKind::Dataset,
             original_id: format!("d{}", i),
             source_portal: "https://test.example.com".to_string(),
             url: format!("https://test.example.com/dataset/d{}", i),

--- a/crates/ceres-core/tests/integration/worker_tests.rs
+++ b/crates/ceres-core/tests/integration/worker_tests.rs
@@ -56,6 +56,7 @@ impl PortalClientFactory for FailingPortalClientFactory {
         _language: &str,
         _profile: Option<ceres_core::DcatProfile>,
         _sparql_endpoint: Option<&str>,
+        _ogc_endpoint: Option<&str>,
     ) -> Result<Self::Client, AppError> {
         Err(AppError::NetworkError(
             "simulated network failure".to_string(),

--- a/crates/ceres-db/src/job_repository.rs
+++ b/crates/ceres-db/src/job_repository.rs
@@ -56,6 +56,7 @@ struct JobRow {
     portal_type: String,
     profile: Option<String>,
     sparql_endpoint: Option<String>,
+    ogc_endpoint: Option<String>,
 }
 
 /// JSON representation of SyncStats for database storage.
@@ -142,6 +143,7 @@ impl From<JobRow> for HarvestJob {
                     .ok()
             }),
             sparql_endpoint: row.sparql_endpoint,
+            ogc_endpoint: row.ogc_endpoint,
         }
     }
 }
@@ -156,8 +158,8 @@ impl JobQueue for JobRepository {
 
         let row: JobRow = sqlx::query_as(
             r#"
-            INSERT INTO harvest_jobs (portal_url, portal_name, force_full_sync, max_retries, url_template, language, portal_type, profile, sparql_endpoint)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            INSERT INTO harvest_jobs (portal_url, portal_name, force_full_sync, max_retries, url_template, language, portal_type, profile, sparql_endpoint, ogc_endpoint)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
             RETURNING *
             "#,
         )
@@ -170,6 +172,7 @@ impl JobQueue for JobRepository {
         .bind(request.portal_type.to_string())
         .bind(request.profile.map(|p| p.as_str()))
         .bind(&request.sparql_endpoint)
+        .bind(&request.ogc_endpoint)
         .fetch_one(&self.pool)
         .await
         .map_err(|e| AppError::DatabaseError(e.to_string()))?;

--- a/crates/ceres-db/src/repository.rs
+++ b/crates/ceres-db/src/repository.rs
@@ -14,13 +14,13 @@ use uuid::Uuid;
 
 /// Column list for SELECT queries. Must remain a const literal to ensure SQL safety
 /// since format!() bypasses sqlx compile-time validation.
-const DATASET_COLUMNS: &str = "id, original_id, source_portal, url, title, description, embedding, metadata, first_seen_at, last_updated_at, content_hash, is_stale";
+const DATASET_COLUMNS: &str = "id, original_id, source_portal, url, title, description, record_kind, embedding, metadata, first_seen_at, last_updated_at, content_hash, is_stale";
 
 // Static queries for list_all_stream to avoid lifetime issues with BoxStream
-const LIST_ALL_QUERY: &str = "SELECT id, original_id, source_portal, url, title, description, embedding, metadata, first_seen_at, last_updated_at, content_hash, is_stale FROM datasets ORDER BY last_updated_at DESC";
-const LIST_ALL_LIMIT_QUERY: &str = "SELECT id, original_id, source_portal, url, title, description, embedding, metadata, first_seen_at, last_updated_at, content_hash, is_stale FROM datasets ORDER BY last_updated_at DESC LIMIT $1";
-const LIST_ALL_PORTAL_QUERY: &str = "SELECT id, original_id, source_portal, url, title, description, embedding, metadata, first_seen_at, last_updated_at, content_hash, is_stale FROM datasets WHERE source_portal = $1 ORDER BY last_updated_at DESC";
-const LIST_ALL_PORTAL_LIMIT_QUERY: &str = "SELECT id, original_id, source_portal, url, title, description, embedding, metadata, first_seen_at, last_updated_at, content_hash, is_stale FROM datasets WHERE source_portal = $1 ORDER BY last_updated_at DESC LIMIT $2";
+const LIST_ALL_QUERY: &str = "SELECT id, original_id, source_portal, url, title, description, record_kind, embedding, metadata, first_seen_at, last_updated_at, content_hash, is_stale FROM datasets ORDER BY last_updated_at DESC";
+const LIST_ALL_LIMIT_QUERY: &str = "SELECT id, original_id, source_portal, url, title, description, record_kind, embedding, metadata, first_seen_at, last_updated_at, content_hash, is_stale FROM datasets ORDER BY last_updated_at DESC LIMIT $1";
+const LIST_ALL_PORTAL_QUERY: &str = "SELECT id, original_id, source_portal, url, title, description, record_kind, embedding, metadata, first_seen_at, last_updated_at, content_hash, is_stale FROM datasets WHERE source_portal = $1 ORDER BY last_updated_at DESC";
+const LIST_ALL_PORTAL_LIMIT_QUERY: &str = "SELECT id, original_id, source_portal, url, title, description, record_kind, embedding, metadata, first_seen_at, last_updated_at, content_hash, is_stale FROM datasets WHERE source_portal = $1 ORDER BY last_updated_at DESC LIMIT $2";
 
 /// Repository for dataset persistence in PostgreSQL with pgvector.
 ///
@@ -67,16 +67,18 @@ impl DatasetRepository {
                 url,
                 title,
                 description,
+                record_kind,
                 embedding,
                 metadata,
                 content_hash,
                 last_updated_at
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())
             ON CONFLICT (source_portal, original_id)
             DO UPDATE SET
                 title = EXCLUDED.title,
                 description = EXCLUDED.description,
+                record_kind = EXCLUDED.record_kind,
                 url = EXCLUDED.url,
                 embedding = COALESCE(EXCLUDED.embedding, datasets.embedding),
                 metadata = EXCLUDED.metadata,
@@ -91,6 +93,7 @@ impl DatasetRepository {
         .bind(&new_data.url)
         .bind(&new_data.title)
         .bind(&new_data.description)
+        .bind(new_data.record_kind.as_str())
         .bind(embedding_vector)
         .bind(serde_json::to_value(&new_data.metadata)?)
         .bind(&new_data.content_hash)
@@ -124,6 +127,7 @@ impl DatasetRepository {
         let mut urls: Vec<String> = Vec::with_capacity(datasets.len());
         let mut titles: Vec<String> = Vec::with_capacity(datasets.len());
         let mut descriptions: Vec<Option<String>> = Vec::with_capacity(datasets.len());
+        let mut record_kinds: Vec<&str> = Vec::with_capacity(datasets.len());
         let mut embeddings: Vec<Option<Vector>> = Vec::with_capacity(datasets.len());
         let mut metadatas: Vec<serde_json::Value> = Vec::with_capacity(datasets.len());
         let mut content_hashes: Vec<String> = Vec::with_capacity(datasets.len());
@@ -134,6 +138,7 @@ impl DatasetRepository {
             urls.push(d.url.clone());
             titles.push(d.title.clone());
             descriptions.push(d.description.clone());
+            record_kinds.push(d.record_kind.as_str());
             embeddings.push(d.embedding.as_ref().map(|v| Vector::from(v.clone())));
             metadatas.push(d.metadata.clone());
             content_hashes.push(d.content_hash.clone());
@@ -147,6 +152,7 @@ impl DatasetRepository {
                 url,
                 title,
                 description,
+                record_kind,
                 embedding,
                 metadata,
                 content_hash,
@@ -158,15 +164,17 @@ impl DatasetRepository {
                 $3::varchar[],
                 $4::text[],
                 $5::text[],
-                $6::vector[],
-                $7::jsonb[],
-                $8::varchar[],
-                (SELECT array_agg(NOW()) FROM generate_series(1, $9))::timestamptz[]
+                $6::varchar[],
+                $7::vector[],
+                $8::jsonb[],
+                $9::varchar[],
+                (SELECT array_agg(NOW()) FROM generate_series(1, $10))::timestamptz[]
             )
             ON CONFLICT (source_portal, original_id)
             DO UPDATE SET
                 title = EXCLUDED.title,
                 description = EXCLUDED.description,
+                record_kind = EXCLUDED.record_kind,
                 url = EXCLUDED.url,
                 embedding = COALESCE(EXCLUDED.embedding, datasets.embedding),
                 metadata = EXCLUDED.metadata,
@@ -181,6 +189,7 @@ impl DatasetRepository {
         .bind(&urls)
         .bind(&titles)
         .bind(&descriptions)
+        .bind(&record_kinds)
         .bind(&embeddings)
         .bind(&metadatas)
         .bind(&content_hashes)
@@ -399,7 +408,7 @@ impl DatasetRepository {
             .unwrap_or(40);
 
         let query = format!(
-            "SELECT {}, 1 - (embedding <=> $1) as similarity_score FROM datasets WHERE embedding IS NOT NULL AND NOT is_stale ORDER BY embedding <=> $1 LIMIT $2",
+            "SELECT {}, 1 - (embedding <=> $1) as similarity_score FROM datasets WHERE embedding IS NOT NULL AND NOT is_stale AND record_kind IN ('dataset', 'series') ORDER BY embedding <=> $1 LIMIT $2",
             DATASET_COLUMNS
         );
 
@@ -443,6 +452,7 @@ impl DatasetRepository {
                     url: row.url,
                     title: row.title,
                     description: row.description,
+                    record_kind: row.record_kind.parse().unwrap_or_default(),
                     embedding: row.embedding.map(|v| v.to_vec()),
                     metadata: row.metadata.0,
                     first_seen_at: row.first_seen_at,
@@ -758,7 +768,7 @@ impl DatasetRepository {
         let rows = if let Some(portal) = portal_filter {
             if let Some(lim) = limit {
                 let query = format!(
-                    "SELECT {} FROM datasets WHERE embedding IS NULL AND NOT is_stale AND TRIM(CONCAT(title, ' ', COALESCE(description, ''))) != '' AND source_portal = $1 ORDER BY last_updated_at DESC LIMIT $2",
+                    "SELECT {} FROM datasets WHERE embedding IS NULL AND NOT is_stale AND record_kind IN ('dataset', 'series') AND TRIM(CONCAT(title, ' ', COALESCE(description, ''))) != '' AND source_portal = $1 ORDER BY last_updated_at DESC LIMIT $2",
                     DATASET_COLUMNS
                 );
                 sqlx::query_as::<_, DatasetRow>(&query)
@@ -768,7 +778,7 @@ impl DatasetRepository {
                     .await
             } else {
                 let query = format!(
-                    "SELECT {} FROM datasets WHERE embedding IS NULL AND NOT is_stale AND TRIM(CONCAT(title, ' ', COALESCE(description, ''))) != '' AND source_portal = $1 ORDER BY last_updated_at DESC",
+                    "SELECT {} FROM datasets WHERE embedding IS NULL AND NOT is_stale AND record_kind IN ('dataset', 'series') AND TRIM(CONCAT(title, ' ', COALESCE(description, ''))) != '' AND source_portal = $1 ORDER BY last_updated_at DESC",
                     DATASET_COLUMNS
                 );
                 sqlx::query_as::<_, DatasetRow>(&query)
@@ -778,7 +788,7 @@ impl DatasetRepository {
             }
         } else if let Some(lim) = limit {
             let query = format!(
-                "SELECT {} FROM datasets WHERE embedding IS NULL AND NOT is_stale AND TRIM(CONCAT(title, ' ', COALESCE(description, ''))) != '' ORDER BY last_updated_at DESC LIMIT $1",
+                "SELECT {} FROM datasets WHERE embedding IS NULL AND NOT is_stale AND record_kind IN ('dataset', 'series') AND TRIM(CONCAT(title, ' ', COALESCE(description, ''))) != '' ORDER BY last_updated_at DESC LIMIT $1",
                 DATASET_COLUMNS
             );
             sqlx::query_as::<_, DatasetRow>(&query)
@@ -787,7 +797,7 @@ impl DatasetRepository {
                 .await
         } else {
             let query = format!(
-                "SELECT {} FROM datasets WHERE embedding IS NULL AND NOT is_stale AND TRIM(CONCAT(title, ' ', COALESCE(description, ''))) != '' ORDER BY last_updated_at DESC",
+                "SELECT {} FROM datasets WHERE embedding IS NULL AND NOT is_stale AND record_kind IN ('dataset', 'series') AND TRIM(CONCAT(title, ' ', COALESCE(description, ''))) != '' ORDER BY last_updated_at DESC",
                 DATASET_COLUMNS
             );
             sqlx::query_as::<_, DatasetRow>(&query)
@@ -897,6 +907,7 @@ struct DatasetRow {
     url: String,
     title: String,
     description: Option<String>,
+    record_kind: String,
     embedding: Option<Vector>,
     metadata: Json<serde_json::Value>,
     first_seen_at: DateTime<Utc>,
@@ -914,6 +925,7 @@ impl From<DatasetRow> for Dataset {
             url: row.url,
             title: row.title,
             description: row.description,
+            record_kind: row.record_kind.parse().unwrap_or_default(),
             embedding: row.embedding.map(|v| v.to_vec()),
             metadata: row.metadata.0,
             first_seen_at: row.first_seen_at,
@@ -949,6 +961,7 @@ struct SearchResultRow {
     url: String,
     title: String,
     description: Option<String>,
+    record_kind: String,
     embedding: Option<Vector>,
     metadata: Json<serde_json::Value>,
     first_seen_at: DateTime<Utc>,
@@ -1121,6 +1134,7 @@ mod tests {
         let content_hash = NewDataset::compute_content_hash(title, description.as_deref());
 
         let new_dataset = NewDataset {
+            record_kind: ceres_core::CatalogRecordKind::Dataset,
             original_id: "test-id".to_string(),
             source_portal: "https://example.com".to_string(),
             url: "https://example.com/dataset/test".to_string(),

--- a/crates/ceres-db/tests/integration/common.rs
+++ b/crates/ceres-db/tests/integration/common.rs
@@ -21,6 +21,7 @@ const MIGRATIONS: &[&str] = &[
         url VARCHAR NOT NULL,
         title TEXT NOT NULL,
         description TEXT,
+        record_kind VARCHAR(16) NOT NULL DEFAULT 'dataset',
         embedding vector(768),
         metadata JSONB DEFAULT '{}'::jsonb,
         first_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -118,6 +119,7 @@ pub fn sample_new_dataset(id: &str, portal: &str) -> NewDataset {
     let embedding_vec: Vec<f32> = (0..768).map(|i| i as f32 / 768.0).collect();
 
     NewDataset {
+        record_kind: ceres_core::CatalogRecordKind::Dataset,
         original_id: id.to_string(),
         source_portal: portal.to_string(),
         url: format!("{}/dataset/{}", portal, id),

--- a/crates/ceres-db/tests/integration/repository_tests.rs
+++ b/crates/ceres-db/tests/integration/repository_tests.rs
@@ -59,6 +59,7 @@ async fn test_upsert_updates_existing_dataset() {
 
     // Update with same (portal, original_id) but different content
     let updated = NewDataset {
+        record_kind: ceres_core::CatalogRecordKind::Dataset,
         original_id: "test-123".to_string(),
         source_portal: "https://example.com".to_string(),
         url: "https://example.com/dataset/test-updated".to_string(),

--- a/crates/ceres-server/src/dto/response.rs
+++ b/crates/ceres-server/src/dto/response.rs
@@ -87,6 +87,8 @@ pub struct SearchResultDto {
     pub url: String,
     /// Source portal URL
     pub source_portal: String,
+    /// Catalog record kind.
+    pub record_kind: String,
     /// Similarity score (0.0 to 1.0)
     pub similarity_score: f32,
 }
@@ -99,6 +101,7 @@ impl From<SearchResult> for SearchResultDto {
             description: r.dataset.description,
             url: r.dataset.url,
             source_portal: r.dataset.source_portal,
+            record_kind: r.dataset.record_kind.to_string(),
             similarity_score: r.similarity_score,
         }
     }
@@ -121,6 +124,8 @@ pub struct PortalInfoResponse {
     pub profile: Option<String>,
     /// Custom SPARQL endpoint URL, if applicable
     pub sparql_endpoint: Option<String>,
+    /// Custom OGC CSW endpoint URL, if applicable.
+    pub ogc_endpoint: Option<String>,
     /// Whether the portal is enabled for harvesting
     pub enabled: bool,
     /// Portal description
@@ -253,6 +258,8 @@ pub struct DatasetResponse {
     pub title: String,
     /// Dataset description
     pub description: Option<String>,
+    /// Catalog record kind.
+    pub record_kind: String,
     /// Additional metadata
     pub metadata: serde_json::Value,
     /// First indexed timestamp
@@ -270,6 +277,7 @@ impl From<ceres_core::Dataset> for DatasetResponse {
             url: d.url,
             title: d.title,
             description: d.description,
+            record_kind: d.record_kind.to_string(),
             metadata: d.metadata,
             first_seen_at: d.first_seen_at,
             last_updated_at: d.last_updated_at,

--- a/crates/ceres-server/src/handlers/mod.rs
+++ b/crates/ceres-server/src/handlers/mod.rs
@@ -33,6 +33,9 @@ pub(crate) fn build_harvest_job_request(
     if let Some(ref sparql_endpoint) = portal.sparql_endpoint {
         request = request.with_sparql_endpoint(sparql_endpoint.as_str());
     }
+    if let Some(ref endpoint) = portal.ogc_endpoint {
+        request = request.with_ogc_endpoint(endpoint.as_str());
+    }
 
     if force_full_sync {
         request = request.with_full_sync();

--- a/crates/ceres-server/src/handlers/portals.rs
+++ b/crates/ceres-server/src/handlers/portals.rs
@@ -48,6 +48,7 @@ pub async fn list_portals(
                 portal_type: portal.portal_type.to_string(),
                 profile: portal.profile.map(|p| p.to_string()),
                 sparql_endpoint: portal.sparql_endpoint.clone(),
+                ogc_endpoint: portal.ogc_endpoint.clone(),
                 enabled: portal.enabled,
                 description: portal.description.clone(),
                 last_sync: sync_status.as_ref().and_then(|s| s.last_successful_sync),

--- a/crates/ceres-server/tests/integration/common.rs
+++ b/crates/ceres-server/tests/integration/common.rs
@@ -70,9 +70,10 @@ const MIGRATIONS: &[&str] = &[
         url_template TEXT,
         language TEXT,
         portal_type TEXT NOT NULL DEFAULT 'ckan'
-            CHECK (portal_type IN ('ckan', 'dcat', 'socrata')),
+            CHECK (portal_type IN ('ckan', 'dcat', 'socrata', 'opendatasoft', 'arcgis', 'ogc_records')),
         profile TEXT,
         sparql_endpoint TEXT,
+        ogc_endpoint TEXT,
         CONSTRAINT chk_harvest_jobs_status CHECK (
             status IN ('pending', 'running', 'completed', 'failed', 'cancelled')
         )

--- a/crates/ceres-server/tests/integration/common.rs
+++ b/crates/ceres-server/tests/integration/common.rs
@@ -29,6 +29,7 @@ const MIGRATIONS: &[&str] = &[
         url VARCHAR NOT NULL,
         title TEXT NOT NULL,
         description TEXT,
+        record_kind VARCHAR(16) NOT NULL DEFAULT 'dataset',
         embedding vector(768),
         metadata JSONB DEFAULT '{}'::jsonb,
         first_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),

--- a/crates/ceres-server/tests/integration/handler_tests.rs
+++ b/crates/ceres-server/tests/integration/handler_tests.rs
@@ -182,6 +182,7 @@ async fn test_harvest_all_creates_jobs_for_supported_portal_configs() {
                 language: Some("it".to_string()),
                 profile: None,
                 sparql_endpoint: None,
+                ogc_endpoint: None,
                 aliases: vec![],
             },
             PortalEntry {
@@ -194,6 +195,7 @@ async fn test_harvest_all_creates_jobs_for_supported_portal_configs() {
                 language: Some("fr".to_string()),
                 profile: None,
                 sparql_endpoint: None,
+                ogc_endpoint: None,
                 aliases: vec![],
             },
             PortalEntry {
@@ -206,6 +208,7 @@ async fn test_harvest_all_creates_jobs_for_supported_portal_configs() {
                 language: Some("en".to_string()),
                 profile: Some(DcatProfile::Sparql),
                 sparql_endpoint: Some("https://sparql.example.org/query".to_string()),
+                ogc_endpoint: None,
                 aliases: vec![],
             },
             PortalEntry {
@@ -218,6 +221,7 @@ async fn test_harvest_all_creates_jobs_for_supported_portal_configs() {
                 language: Some("en".to_string()),
                 profile: Some(DcatProfile::Sparql),
                 sparql_endpoint: Some("https://disabled.example.org/sparql".to_string()),
+                ogc_endpoint: None,
                 aliases: vec![],
             },
         ],

--- a/examples/PORTAL_CURATION_2026-07.md
+++ b/examples/PORTAL_CURATION_2026-07.md
@@ -137,3 +137,34 @@ already present, adding roughly 9,535 titles. Data Vlaanderen returned only
 three of six declared DCAT resources and blocked partition queries with HTTP
 403; the EU Publications Office endpoint exposed RDF application profiles
 rather than harvestable open-data records. Both were rejected.
+
+## OGC CSW implementation harvest pass
+
+The new capability-driven CSW 2.0.2 client was exercised against independent
+live catalogs before promotion. Five catalogs completed full metadata-only
+harvests with no final record failures and preserved raw source XML:
+
+- EMODnet central catalogue: 7,167 records processed (7,164 unique stored IDs)
+- Copernicus Marine: 307 records
+- Marine Regions / VLIZ: 831 records
+- EEA marine SDI: 73 records
+- French Géoplateforme: 314 records
+
+The live session exposed two interoperability cases now covered by the client:
+pretty-printed ISO XML with leading whitespace before `CharacterString` values,
+and legacy ISO records without citation titles. The latter are retained using
+their stable identifiers as display fallbacks. BGS was removed because its
+documented GeoNetwork endpoint returned HTTP 404; Italy's RNDT exposed live
+capabilities but rejected the client's ISO `GetRecords` query shape.
+
+The same session added four reliable missing catalogs through existing clients:
+Western Pennsylvania CKAN (369), U.S. Treasury `data.json` (233), Rouen
+Métropole OpenDataSoft (107), and Arizona AZGeo ArcGIS Hub (703). Socrata probes
+for Seattle and Austin returned zero dataset-scoped records and were rejected.
+The EU Publications Office SPARQL endpoint advertised DCAT resources but yielded
+zero records through Ceres' normalized metadata query, confirming the earlier
+decision not to curate it.
+
+Overall the session added 10,101 stored rows and nine logical portal sources,
+raising the local index from 2,232,257 rows / 373 sources to 2,242,358 rows /
+382 sources.

--- a/examples/portals.toml
+++ b/examples/portals.toml
@@ -3,6 +3,8 @@
 # This file defines CKAN portals to harvest.
 # Copy this file to ~/.config/ceres/portals.toml to use it.
 #
+# OGC CSW catalogues are configured with type = "ogc_records" and may keep a
+# separate logical portal URL by specifying an explicit ogc_endpoint.
 # Usage:
 #   ceres harvest                 # Harvest all enabled portals
 #   ceres harvest --portal milano # Harvest specific portal by name
@@ -1263,3 +1265,81 @@ type = "arcgis"
 language = "en"
 enabled = false
 description = "Missouri Spatial Data Information Service (ArcGIS Hub, ~140 datasets)"
+
+[[portals]]
+name = "emodnet-csw"
+url = "https://emodnet.ec.europa.eu"
+type = "ogc_records"
+language = "en"
+enabled = false
+ogc_endpoint = "https://emodnet.ec.europa.eu/geonetwork/emodnet/eng/csw"
+description = "EMODnet central GeoNetwork catalogue via CSW 2.0.2"
+
+[[portals]]
+name = "copernicus-marine-csw"
+url = "https://marine.copernicus.eu"
+type = "ogc_records"
+language = "en"
+enabled = false
+ogc_endpoint = "https://csw.marine.copernicus.eu/geonetwork/csw-MYOCEAN-CORE-PRODUCTS/eng/csw"
+description = "Copernicus Marine product catalogue via CSW 2.0.2"
+
+[[portals]]
+name = "marine-regions-csw"
+url = "https://www.marineregions.org"
+type = "ogc_records"
+language = "en"
+enabled = false
+ogc_endpoint = "http://geonetwork.vliz.be/geonetwork/srv/eng/csw"
+description = "Marine Regions GeoNetwork catalogue via CSW 2.0.2"
+
+[[portals]]
+name = "eea-marine-csw"
+url = "https://sdi.eea.europa.eu"
+type = "ogc_records"
+language = "en"
+enabled = false
+ogc_endpoint = "https://sdi.eea.europa.eu/catalogue/marine/eng/csw"
+description = "European Environment Agency marine catalogue via CSW 2.0.2"
+
+[[portals]]
+name = "geoplateforme-csw"
+url = "https://cartes.gouv.fr"
+type = "ogc_records"
+language = "fr"
+enabled = false
+ogc_endpoint = "https://data.geopf.fr/csw"
+description = "French Géoplateforme metadata catalogue via CSW ISO AP 2.0.2"
+
+[[portals]]
+name = "western-pennsylvania"
+url = "https://data.wprdc.org"
+type = "ckan"
+language = "en"
+enabled = false
+description = "Western Pennsylvania Regional Data Center CKAN catalogue"
+
+[[portals]]
+name = "us-treasury-data-json"
+url = "https://www.treasury.gov/data.json"
+type = "dcat"
+profile = "static_json"
+language = "en"
+enabled = false
+description = "United States Department of the Treasury Project Open Data catalog"
+
+[[portals]]
+name = "rouen-metropole"
+url = "https://data.metropole-rouen-normandie.fr"
+type = "opendatasoft"
+language = "fr"
+enabled = false
+description = "Métropole Rouen Normandie OpenDataSoft catalogue"
+
+[[portals]]
+name = "arizona-geo"
+url = "https://azgeo-open-data-agic.hub.arcgis.com"
+type = "arcgis"
+language = "en"
+enabled = false
+description = "Arizona Geographic Information Council ArcGIS Hub catalogue"

--- a/migrations/202607120001_add_record_kind.sql
+++ b/migrations/202607120001_add_record_kind.sql
@@ -1,0 +1,13 @@
+ALTER TABLE datasets
+    ADD COLUMN record_kind VARCHAR(16) NOT NULL DEFAULT 'dataset';
+
+ALTER TABLE datasets
+    ADD CONSTRAINT datasets_record_kind_check
+    CHECK (record_kind IN ('dataset', 'series', 'service', 'map', 'other'));
+
+CREATE INDEX idx_datasets_searchable_embedding
+    ON datasets (source_portal, last_updated_at DESC)
+    WHERE embedding IS NULL AND NOT is_stale
+      AND record_kind IN ('dataset', 'series');
+
+ALTER TABLE harvest_jobs ADD COLUMN ogc_endpoint TEXT;

--- a/migrations/202607120001_add_record_kind.sql
+++ b/migrations/202607120001_add_record_kind.sql
@@ -11,3 +11,9 @@ CREATE INDEX idx_datasets_searchable_embedding
       AND record_kind IN ('dataset', 'series');
 
 ALTER TABLE harvest_jobs ADD COLUMN ogc_endpoint TEXT;
+
+-- The inline CHECK from 202603270001 predates the OpenDataSoft, ArcGIS, and
+-- OGC Records portal types and would reject their harvest jobs.
+ALTER TABLE harvest_jobs DROP CONSTRAINT harvest_jobs_portal_type_check;
+ALTER TABLE harvest_jobs ADD CONSTRAINT harvest_jobs_portal_type_check
+    CHECK (portal_type IN ('ckan', 'dcat', 'socrata', 'opendatasoft', 'arcgis', 'ogc_records'));

--- a/website/src/content/docs/HARVESTING.md
+++ b/website/src/content/docs/HARVESTING.md
@@ -18,6 +18,11 @@ Today the shipping portal clients cover:
 - Socrata catalogs through the Discovery API (via `--type socrata`)
 - OpenDataSoft catalogs through the Explore API v2.1 (via `--type opendatasoft`)
 - ArcGIS Hub catalogs through the Hub Search API (via `--type arcgis`)
+- OGC CSW 2.0.2 catalogues (via `--type ogc_records`)
+
+OGC catalogues are capability-driven: Ceres reads `GetCapabilities`, follows
+the advertised record bindings, and streams bounded result windows. Configure
+`ogc_endpoint` when the CSW service differs from the logical portal URL.
 
 See [Supported portals](/portals/) for per-portal configuration, examples, and
 current coverage numbers.

--- a/website/src/content/docs/PORTALS.md
+++ b/website/src/content/docs/PORTALS.md
@@ -20,6 +20,7 @@ detection, streaming page-by-page processing, and stale dataset marking.
 | Socrata | `--type socrata` | Socrata Discovery API catalogs | data.cityofnewyork.us, data.wa.gov |
 | OpenDataSoft | `--type opendatasoft` | OpenDataSoft Explore API v2.1 catalogs | opendata.paris.fr, data.economie.gouv.fr |
 | ArcGIS Hub | `--type arcgis` | ArcGIS Hub Search API catalogs | opendata.dc.gov, opendata.gis.utah.gov |
+| OGC Records | `--type ogc_records` | CSW 2.0.2 / GeoNetwork catalogues | EMODnet, British Geological Survey |
 
 Every client preserves the complete source metadata payload, so downstream
 features like resource-schema extraction keep working no matter which portal a
@@ -48,6 +49,9 @@ ceres harvest https://opendata.paris.fr --type opendatasoft --metadata-only
 
 # ArcGIS Hub Search API
 ceres harvest https://opendata.dc.gov --type arcgis --metadata-only
+
+# OGC CSW 2.0.2
+ceres harvest https://emodnet.ec.europa.eu/geonetwork/emodnet/eng/csw --type ogc_records --metadata-only
 ```
 
 Or configure them once in `portals.toml` and harvest in batch:


### PR DESCRIPTION
- Introduced `CatalogRecordKind` enum to represent semantic kinds of catalog records (Dataset, Series, Service, Map, Other).
- Updated `Dataset` and `NewDataset` structs to include `record_kind` field.
- Modified relevant database queries and repository methods to handle the new `record_kind` field.
- Enhanced Parquet export functionality to include `record_kind`.
- Updated integration tests and examples to accommodate changes in dataset structure and handling.
- Added support for OGC CSW endpoints in job processing and portal configurations.
- Created migration script to add `record_kind` column to the datasets table and updated constraints.

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- If this PR addresses an issue, link it here (e.g., "Fixes #123") -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [ ] My code follows the code style of this project (`cargo fmt`)
- [ ] I have run `cargo clippy` and addressed any warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally (`cargo test`)
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

## Additional Notes

<!-- Any additional information that reviewers should know -->
