### PR TITLE
feat: add STAC collection harvesting and finish CSW

### DIFF
--- a/.claude/skills/ceres/SKILL.md
+++ b/.claude/skills/ceres/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ceres
-description: Use when working with Ceres — a Rust harvest-first toolkit and public open data metadata index. Covers harvesting and synchronization, optional embedding and search, CKAN, DCAT udata, SPARQL-backed DCAT, Project Open Data data.json, Socrata Discovery, OpenDataSoft Explore, ArcGIS Hub, and OGC CSW portal support, Parquet snapshot manifests/reports/changelogs, Ollama or hosted providers, CLI commands, REST API endpoints, portal configuration, architecture, extending via traits, release workflow, and contributing to the Ceres codebase.
+description: Use when working with Ceres — a Rust harvest-first toolkit and public open data metadata index. Covers harvesting and synchronization, optional embedding and search, CKAN, DCAT udata, SPARQL-backed DCAT, Project Open Data data.json, Socrata Discovery, OpenDataSoft Explore, ArcGIS Hub, OGC CSW, and collection-level STAC portal support, Parquet snapshot manifests/reports/changelogs, Ollama or hosted providers, CLI commands, REST API endpoints, portal configuration, architecture, extending via traits, release workflow, and contributing to the Ceres codebase.
 ---
 
 # Ceres — Harvest-First Toolkit for Open Data Portals
@@ -25,7 +25,7 @@ Harvesting and embedding are decoupled: `HarvestService` handles metadata, `Embe
 - Harvest first and keep metadata synchronized over time
 - Add embeddings later only if you want semantic retrieval
 - Prefer Ollama for local embedding, with Gemini and OpenAI still supported
-- Support CKAN, DCAT-AP udata REST, SPARQL-backed DCAT, Project Open Data `data.json`, Socrata Discovery, OpenDataSoft Explore, and ArcGIS Hub portals in the current client factory
+- Support CKAN, DCAT-AP udata REST, SPARQL-backed DCAT, Project Open Data `data.json`, Socrata Discovery, OpenDataSoft Explore, ArcGIS Hub, OGC CSW, and collection-level STAC portals in the current client factory
 - Publish reproducible Parquet snapshots for the public Open Data Index
 - Expose search, export, and API workflows over the same harvested catalog
 
@@ -34,7 +34,7 @@ Harvesting and embedding are decoupled: `HarvestService` handles metadata, `Embe
 | Crate | Purpose | Key Exports |
 |---|---|---|
 | `ceres-core` | Business logic, traits, services | `HarvestService`, `EmbeddingService`, `HarvestPipeline`, `SearchService`, `ExportService`, `WorkerService`, `CircuitBreaker`, traits |
-| `ceres-client` | Portal clients and embedding providers | `CkanClient`, `DcatClient`, `ArcGisClient`, `GeminiClient`, `OpenAIClient`, `OllamaClient`, `PortalClientFactoryEnum`, `EmbeddingProviderEnum` |
+| `ceres-client` | Portal clients and embedding providers | `CkanClient`, `DcatClient`, `ArcGisClient`, `OgcRecordsClient`, `StacClient`, `GeminiClient`, `OpenAIClient`, `OllamaClient`, `PortalClientFactoryEnum`, `EmbeddingProviderEnum` |
 | `ceres-db` | PostgreSQL + pgvector repository | `DatasetRepository`, `HarvestJobRepository` |
 | `ceres-server` | Axum REST API with Swagger UI | Routes, DTOs, bearer auth, OpenAPI/Swagger |
 | `ceres-cli` | Command-line interface | `harvest`, `embed`, `search`, `export`, `stats` subcommands |
@@ -163,11 +163,11 @@ ceres stats
 - **crates.io package:** `ceres-search`
 - Harvesting and embedding are decoupled: `--metadata-only` harvests without API key, `embed` command generates embeddings separately
 - Ollama is the preferred local embedding path; Gemini and OpenAI remain available
-- Current portal client factory supports CKAN, Socrata, OpenDataSoft, ArcGIS Hub, and DCAT (`udata_rest` default profile plus `sparql` and `static_json` profiles)
+- Current portal client factory supports CKAN, Socrata, OpenDataSoft, ArcGIS Hub, OGC CSW, collection-level STAC, and DCAT (`udata_rest` default profile plus `sparql` and `static_json` profiles)
 - ArcGIS Hub clients reject empty `catalogV2` item scopes because those endpoints expose global ArcGIS search results rather than portal-owned datasets
 - Stale dataset detection: datasets removed from portals are soft-marked (`is_stale`) during full syncs
 - Supports Ollama, Gemini, and OpenAI embeddings
 - Parquet export publishes a portable snapshot: `all.parquet` (canonical), per-portal subsets, `identity.parquet`, a versioned snapshot manifest (`metadata.json` with `snapshot_id`, provenance, alias-aware duplicate metadata, and SHA-256 checksums), coverage/quality reports (`reports.json`, `report.md`), and snapshot changelogs (`changelog.json`, `changelog.md` when `--previous` is supplied)
-- v0.6.0 milestone focus: portal coverage expansion — DCAT profile cleanup, Project Open Data `data.json`, Socrata, OpenDataSoft, and ArcGIS Hub have shipped
+- v0.6.0 milestone focus: portal coverage expansion — the earlier client families plus OGC CSW and collection-level STAC have shipped; validation and metadata-only harvesting at scale remain
 - v0.7.0 milestone focus: resource-level metadata depth tracked in issue #68
 - HuggingFace dataset: `AndreaBozzo/ceres-open-data-index`

--- a/.claude/skills/ceres/references/cli-and-server.md
+++ b/.claude/skills/ceres/references/cli-and-server.md
@@ -229,7 +229,7 @@ Fields:
 |---|---|---|---|
 | `name` | Yes | | Portal identifier (used with `--portal` flag) |
 | `url` | Yes | | Portal API base URL |
-| `type` | No | `ckan` | Portal type (`ckan`, `dcat`, `socrata`, `opendatasoft`, `arcgis`, `ogc_records`) |
+| `type` | No | `ckan` | Portal type (`ckan`, `dcat`, `socrata`, `opendatasoft`, `arcgis`, `ogc_records`, `stac`) |
 | `profile` | No | | DCAT profile selector, e.g. `sparql`; omitted DCAT defaults to udata REST |
 | `sparql_endpoint` | No | | Override SPARQL endpoint for `profile = "sparql"` portals |
 | `ogc_endpoint` | No | | CSW service URL for `type = "ogc_records"` portals when it differs from `url` |

--- a/.claude/skills/ceres/references/extending.md
+++ b/.claude/skills/ceres/references/extending.md
@@ -81,7 +81,7 @@ Key design notes:
 - `search_modified_since` enables incremental sync. Return `Err` if the portal doesn't support it — Ceres will fall back to full sync.
 - `search_all_datasets` is an optimization for bulk fetch. Default returns an error, falling back to `list_dataset_ids()` + `get_dataset()`.
 
-**Built-in:** `CkanClient`, `DcatClient`, `SparqlDcatClient`, `DataJsonClient`, `SocrataClient`, `OpenDataSoftClient`, `ArcGisClient`, and `OgcRecordsClient`.
+**Built-in:** `CkanClient`, `DcatClient`, `SparqlDcatClient`, `DataJsonClient`, `SocrataClient`, `OpenDataSoftClient`, `ArcGisClient`, `OgcRecordsClient`, and `StacClient` (Collections only).
 
 ### PortalClientFactory
 

--- a/.claude/skills/ceres/references/harvesting.md
+++ b/.claude/skills/ceres/references/harvesting.md
@@ -139,7 +139,7 @@ This converges faster than halving (5 vs 8 iterations) and handles portals with 
 
 `HarvestService::batch_harvest_with_progress()` processes all enabled portals from `portals.toml` sequentially, producing a `BatchHarvestSummary` with per-portal results. The CLI and server both use this for bulk harvesting.
 
-Current production-facing portal support in the factory is CKAN, DCAT udata REST, SPARQL-backed DCAT, static Project Open Data `data.json`, Socrata, OpenDataSoft, and ArcGIS Hub. For ad-hoc SPARQL DCAT harvests, use `--type dcat --profile sparql`; for config-driven harvests, set `profile = "sparql"` and optionally `sparql_endpoint`. ArcGIS Hub sites whose injected `catalogV2` has an empty item scope are rejected because their search endpoint returns global ArcGIS content instead of datasets belonging to that portal.
+Current production-facing portal support in the factory is CKAN, DCAT udata REST, SPARQL-backed DCAT, static Project Open Data `data.json`, Socrata, OpenDataSoft, ArcGIS Hub, OGC CSW, and STAC Collections. For ad-hoc SPARQL DCAT harvests, use `--type dcat --profile sparql`; for config-driven harvests, set `profile = "sparql"` and optionally `sparql_endpoint`. ArcGIS Hub sites whose injected `catalogV2` has an empty item scope are rejected because their search endpoint returns global ArcGIS content instead of datasets belonging to that portal. STAC harvesting follows landing-page and pagination links but never follows Collection `items` links.
 
 ## Graceful Shutdown
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ---
 
-Open data is fragmented across thousands of portals speaking different APIs — CKAN, DCAT, SPARQL endpoints, static `data.json` catalogs, Socrata. Ceres harvests them all into **one synchronized PostgreSQL catalog**: incremental sync, delta detection, stale tracking, bounded memory on multi-million-dataset sources.
+Open data is fragmented across thousands of portals speaking different APIs — CKAN, DCAT, SPARQL, `data.json`, Socrata, OGC CSW, and STAC. Ceres harvests them into **one synchronized PostgreSQL catalog**: incremental sync, delta detection, stale tracking, bounded memory on multi-million-dataset sources.
 
 Everything else is layered on top, and optional: local embeddings, semantic search, a REST API, and reproducible Parquet snapshots published as the public **[Ceres Open Data Index](https://huggingface.co/datasets/AndreaBozzo/ceres-open-data-index)**.
 
@@ -28,9 +28,9 @@ Everything else is layered on top, and optional: local embeddings, semantic sear
 
 ## At a Glance
 
-- **300+ portals** harvested and kept in sync — national portals (data.gov, data.europa.eu, data.slovensko.sk, govdata.de), cities (Milano, NYC, Zurich), and agencies
-- **2M+ datasets** in the live catalog; 1.85M+ curated in the latest published snapshot
-- **7 harvest paths** shipped: CKAN, DCAT udata REST, SPARQL-backed DCAT, Project Open Data `data.json`, Socrata Discovery, OpenDataSoft Explore, and ArcGIS Hub — with more clients landing on the [roadmap](#roadmap)
+- **120+ portals** harvested and kept in sync — national portals (data.gov, data.europa.eu, data.slovensko.sk, govdata.de), cities (Milano, NYC, Zurich), and agencies
+- **2M+ datasets** in the live catalog and published snapshots
+- **9 harvest paths** shipped, including OGC CSW 2.0.2 and collection-level STAC alongside the major open-data portal families
 - **Metadata-only by default** — no embedding provider, API key, or GPU required to build and maintain a catalog
 - **Local-first embeddings** via Ollama when you want semantic search; Gemini and OpenAI supported
 - **Reproducible exports** — Parquet snapshots with versioned manifests, SHA-256 checksums, coverage/quality reports, and changelogs
@@ -60,6 +60,8 @@ Ceres splits the system accordingly:
 | Socrata | `--type socrata` | Socrata Discovery API catalogs | data.cityofnewyork.us, data.wa.gov |
 | OpenDataSoft | `--type opendatasoft` | OpenDataSoft Explore API v2.1 catalogs | opendata.paris.fr, data.economie.gouv.fr |
 | ArcGIS Hub | `--type arcgis` | ArcGIS Hub Search API catalogs | opendata.dc.gov, opendata.gis.utah.gov |
+| OGC Records | `--type ogc_records` | CSW 2.0.2 / GeoNetwork catalogs | EMODnet, Copernicus Marine |
+| STAC | `--type stac` | Collection-level STAC APIs | Copernicus Data Space, Canada DataCube |
 
 All clients stream page-by-page, preserve the complete source metadata for downstream use, and share the same sync machinery (incremental sync, content-hash delta detection, stale marking).
 
@@ -109,6 +111,9 @@ cargo run --bin ceres -- harvest https://opendata.paris.fr --type opendatasoft -
 
 # ArcGIS Hub portal (no credentials required)
 cargo run --bin ceres -- harvest https://opendata.dc.gov --type arcgis --metadata-only
+
+# STAC API (one row per Collection; Items are never harvested)
+cargo run --bin ceres -- harvest https://stac.dataspace.copernicus.eu/v1/ --type stac --metadata-only
 
 # All enabled portals from config
 cargo run --bin ceres -- harvest --config examples/portals.toml --metadata-only
@@ -362,7 +367,7 @@ Ceres ships with agent support in-repo:
 ## Roadmap
 
 - **Now (v0.5.0)** — trustable published index: versioned snapshot manifests, integrity checksums, coverage/quality reports, alias-aware duplicate semantics, snapshot changelogs; Socrata Discovery and static `data.json` harvest paths
-- **Next (v0.6.0)** — portal coverage expansion: OpenDataSoft Explore and ArcGIS Hub clients (both shipped), job-based harvesting for every supported client, newly validated portals at scale
+- **Next (v0.6.0)** — validate OGC CSW and collection-level STAC coverage at scale, finish the reproducible metadata-only portal set, and exercise job-based harvesting for every client
 - **Later (v0.7.0)** — resource-level metadata depth ([#68](https://github.com/AndreaBozzo/Ceres/issues/68))
 
 ## Related Projects

--- a/crates/ceres-cli/src/config.rs
+++ b/crates/ceres-cli/src/config.rs
@@ -82,6 +82,7 @@ pub enum Command {
   ceres harvest https://opendata.paris.fr --type opendatasoft  # Harvest OpenDataSoft portal
   ceres harvest https://opendata.dc.gov --type arcgis  # Harvest ArcGIS Hub portal
   ceres harvest https://emodnet.ec.europa.eu/geonetwork/emodnet/eng/csw --type ogc_records
+  ceres harvest https://stac.dataspace.copernicus.eu/v1/ --type stac
   ceres harvest --portal milano                       # Harvest portal by name from config
   ceres harvest --config ~/custom.toml                # Use custom config file
   ceres harvest --full-sync                           # Force full sync even if incremental is available")]

--- a/crates/ceres-client/README.md
+++ b/crates/ceres-client/README.md
@@ -8,8 +8,11 @@ OGC catalogue records are harvested through CSW 2.0.2 with
 `type = "ogc_records"`; use `ogc_endpoint` when the CSW service URL differs
 from the logical portal URL.
 
+STAC APIs are harvested with `type = "stac"`. Ceres indexes Collections as
+series and deliberately never follows Item links.
+
 ### What it provides
-* **Portal Clients**: CKAN, DCAT profiles, Socrata, OpenDataSoft, ArcGIS Hub, and OGC CSW 2.0.2.
+* **Portal Clients**: CKAN, DCAT profiles, Socrata, OpenDataSoft, ArcGIS Hub, OGC CSW 2.0.2, and collection-level STAC.
 * **Embedding Providers**: Ollama, Gemini, and OpenAI via the `EmbeddingProvider` trait.
 * **HTTP Handling**: Robust request handling with retries.
 

--- a/crates/ceres-client/src/ckan.rs
+++ b/crates/ceres-client/src/ckan.rs
@@ -245,8 +245,11 @@ impl CkanClient {
     /// Shared constructor: builds the HTTP client and assembles the struct.
     fn build(base_url: Url, action_base: Url, api_key: Option<String>) -> Result<Self, AppError> {
         let client = Client::builder()
-            // TODO(config): Make User-Agent configurable or use version from Cargo.toml
-            .user_agent("Ceres/0.1 (semantic-search-bot)")
+            .user_agent(concat!(
+                "Ceres/",
+                env!("CARGO_PKG_VERSION"),
+                " (+https://github.com/AndreaBozzo/Ceres)"
+            ))
             // Client-level timeout is the hard ceiling; each request sets its own
             // (adaptive) timeout via `.timeout()`, which overrides this per-request.
             .timeout(Self::MAX_PAGE_TIMEOUT)

--- a/crates/ceres-client/src/lib.rs
+++ b/crates/ceres-client/src/lib.rs
@@ -27,6 +27,7 @@
 //! | OpenDataSoft | Supported | Explore API v2.1 (`/api/explore/v2.1/catalog/datasets`) |
 //! | ArcGIS Hub | Supported | Hub Search API (`/api/search/v1/collections/dataset/items`) |
 //! | OGC Records | Supported | CSW 2.0.2 catalog service |
+//! | STAC | Supported | Collection-level STAC API harvesting |
 //!
 //! # Embedding Providers
 //!
@@ -53,6 +54,7 @@ pub mod portal;
 pub mod provider;
 pub mod socrata;
 pub mod sparql;
+pub mod stac;
 
 // Re-export main client types
 pub use arcgis::{ArcGisClient, ArcGisDataset};
@@ -70,3 +72,4 @@ pub use provider::MockEmbeddingClient;
 pub use provider::{EmbeddingConfig, EmbeddingProviderEnum};
 pub use socrata::{SocrataClient, SocrataDataset};
 pub use sparql::SparqlDcatClient;
+pub use stac::{StacClient, StacCollection};

--- a/crates/ceres-client/src/ogc_records.rs
+++ b/crates/ceres-client/src/ogc_records.rs
@@ -359,7 +359,7 @@ fn parse_record(
     node: Node<'_, '_>,
     xml: &str,
     portal_url: &str,
-    _language: &str,
+    language: &str,
 ) -> Option<OgcRecord> {
     let values = |names: &[&str]| -> Vec<String> {
         node.descendants()
@@ -372,8 +372,8 @@ fn parse_record(
     // Some legacy ISO records are structurally present but omit the citation
     // title. Preserve them using their stable identifier as the display
     // fallback instead of silently dropping the complete source record.
-    let title = first(&["title"]).unwrap_or_else(|| identifier.clone());
-    let description = first(&["abstract", "description"]);
+    let title = localized_field(node, &["title"], language).unwrap_or_else(|| identifier.clone());
+    let description = localized_field(node, &["abstract", "description"], language);
     let modified_text = first(&["dateStamp", "modified"]);
     let modified = modified_text.as_deref().and_then(parse_date);
     let scope = node
@@ -422,9 +422,54 @@ fn parse_record(
         .collect();
     let landing_page = online_resources
         .iter()
-        .find_map(|r| r.get("url").and_then(Value::as_str))
+        .filter(|resource| resource.get("downloadable") != Some(&Value::Bool(true)))
+        .find_map(|resource| resource.get("url").and_then(Value::as_str))
+        .or_else(|| {
+            online_resources
+                .iter()
+                .find_map(|resource| resource.get("url").and_then(Value::as_str))
+        })
         .unwrap_or(portal_url)
         .to_string();
+    let number = |name: &str| first(&[name]).and_then(|value| value.parse::<f64>().ok());
+    let spatial_bbox = match (
+        number("westBoundLongitude"),
+        number("southBoundLatitude"),
+        number("eastBoundLongitude"),
+        number("northBoundLatitude"),
+    ) {
+        (Some(west), Some(south), Some(east), Some(north)) => {
+            Some(json!([west, south, east, north]))
+        }
+        _ => None,
+    };
+    let contacts: Vec<Value> = node
+        .descendants()
+        .filter(|candidate| local(*candidate) == "CI_ResponsibleParty")
+        .map(|contact| {
+            let contact_value = |name: &str| {
+                contact
+                    .descendants()
+                    .find(|candidate| local(*candidate) == name)
+                    .and_then(node_value)
+            };
+            let role = contact
+                .descendants()
+                .find(|candidate| local(*candidate) == "CI_RoleCode")
+                .and_then(|candidate| {
+                    candidate
+                        .attribute("codeListValue")
+                        .map(str::to_owned)
+                        .or_else(|| node_value(candidate))
+                });
+            json!({
+                "individual": contact_value("individualName"),
+                "organization": contact_value("organisationName"),
+                "email": contact_value("electronicMailAddress"),
+                "role": role,
+            })
+        })
+        .collect();
     let raw_xml = xml.get(node.range()).unwrap_or_default();
     Some(OgcRecord {
         identifier,
@@ -440,11 +485,56 @@ fn parse_record(
             "scope": scope,
             "keywords": values(&["keyword", "subject"]),
             "publisher": first(&["organisationName", "publisher"]),
-            "license": first(&["useLimitation", "accessConstraints", "license"]),
+            "license": first(&["useLimitation", "license"]),
+            "access_constraints": values(&["accessConstraints", "otherConstraints"]),
             "modified": modified_text,
+            "spatial": {"bbox": spatial_bbox},
+            "temporal": {
+                "start": first(&["beginPosition"]),
+                "end": first(&["endPosition"]),
+            },
+            "contacts": contacts,
             "online_resources": online_resources,
         }),
     })
+}
+
+fn localized_field(node: Node<'_, '_>, names: &[&str], language: &str) -> Option<String> {
+    let requested = language
+        .split(['-', '_'])
+        .next()
+        .unwrap_or(language)
+        .trim_start_matches('#')
+        .to_ascii_lowercase();
+    let fields: Vec<Node<'_, '_>> = node
+        .descendants()
+        .filter(|candidate| names.contains(&local(*candidate)))
+        .collect();
+    fields
+        .iter()
+        .flat_map(|field| field.descendants())
+        .filter(|candidate| local(*candidate) == "LocalisedCharacterString")
+        .find(|candidate| {
+            candidate
+                .attribute("locale")
+                .map(|locale| {
+                    locale
+                        .trim_start_matches('#')
+                        .to_ascii_lowercase()
+                        .starts_with(&requested)
+                })
+                .unwrap_or(false)
+        })
+        .and_then(node_value)
+        .or_else(|| {
+            fields.iter().find_map(|field| {
+                field
+                    .descendants()
+                    .find(|candidate| matches!(local(*candidate), "CharacterString" | "Anchor"))
+                    .and_then(node_value)
+            })
+        })
+        .or_else(|| fields.into_iter().find_map(node_value))
 }
 
 fn classify_kind(value: &str) -> CatalogRecordKind {
@@ -526,10 +616,10 @@ mod tests {
                 .unwrap()
                 .contains("sea surface temperature")
         );
-        // Landing page comes from the first online resource.
+        // Landing pages prefer a descriptive link over a download URL.
         assert_eq!(
             dataset.landing_page,
-            "https://catalog.example.test/download/sst-2000-2025.nc"
+            "https://catalog.example.test/records/demo-dataset-001"
         );
         assert_eq!(
             dataset.modified.unwrap().date_naive().to_string(),
@@ -562,6 +652,24 @@ mod tests {
         assert_eq!(resources[0]["downloadable"], true);
         assert_eq!(resources[0]["protocol"], "WWW:DOWNLOAD-1.0-http--download");
         assert_eq!(resources[1]["downloadable"], false);
+    }
+
+    #[test]
+    fn selects_localized_text_and_normalizes_extent_and_contacts() {
+        let xml = r##"<csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco"><csw:SearchResults numberOfRecordsMatched="1" numberOfRecordsReturned="1" nextRecord="0"><gmd:MD_Metadata><gmd:fileIdentifier><gco:CharacterString>localized</gco:CharacterString></gmd:fileIdentifier><gmd:title><gco:CharacterString>Default title</gco:CharacterString><gmd:PT_FreeText><gmd:textGroup><gmd:LocalisedCharacterString locale="#FR">Titre français</gmd:LocalisedCharacterString></gmd:textGroup></gmd:PT_FreeText></gmd:title><gmd:abstract><gco:CharacterString>Default description</gco:CharacterString><gmd:PT_FreeText><gmd:textGroup><gmd:LocalisedCharacterString locale="#FR">Description française</gmd:LocalisedCharacterString></gmd:textGroup></gmd:PT_FreeText></gmd:abstract><gmd:EX_GeographicBoundingBox><gmd:westBoundLongitude><gco:Decimal>-5</gco:Decimal></gmd:westBoundLongitude><gmd:eastBoundLongitude><gco:Decimal>10</gco:Decimal></gmd:eastBoundLongitude><gmd:southBoundLatitude><gco:Decimal>40</gco:Decimal></gmd:southBoundLatitude><gmd:northBoundLatitude><gco:Decimal>52</gco:Decimal></gmd:northBoundLatitude></gmd:EX_GeographicBoundingBox><gmd:CI_ResponsibleParty><gmd:organisationName><gco:CharacterString>Marine Office</gco:CharacterString></gmd:organisationName><gmd:electronicMailAddress><gco:CharacterString>data@example.test</gco:CharacterString></gmd:electronicMailAddress><gmd:role><gmd:CI_RoleCode codeListValue="publisher"/></gmd:role></gmd:CI_ResponsibleParty></gmd:MD_Metadata></csw:SearchResults></csw:GetRecordsResponse>"##;
+        let page = parse_get_records(xml, "https://example.test", "fr").unwrap();
+        let record = &page.records[0];
+        assert_eq!(record.title, "Titre français");
+        assert_eq!(record.description.as_deref(), Some("Description française"));
+        assert_eq!(
+            record.metadata["spatial"]["bbox"],
+            json!([-5.0, 40.0, 10.0, 52.0])
+        );
+        assert_eq!(
+            record.metadata["contacts"][0]["organization"],
+            "Marine Office"
+        );
+        assert_eq!(record.metadata["contacts"][0]["role"], "publisher");
     }
 
     #[test]
@@ -604,7 +712,8 @@ mod tests {
             Some("https://emodnet.ec.europa.eu/geonetwork/emodnet/eng/csw"),
         )
         .unwrap();
-        client.bindings().await.unwrap();
+        let first_page = client.paginate_stream().next().await.unwrap().unwrap();
+        assert!(!first_page.is_empty());
     }
 
     #[tokio::test]
@@ -616,6 +725,7 @@ mod tests {
             Some("https://csw.marine.copernicus.eu/geonetwork/csw-MYOCEAN-CORE-PRODUCTS/eng/csw"),
         )
         .unwrap();
-        client.bindings().await.unwrap();
+        let first_page = client.paginate_stream().next().await.unwrap().unwrap();
+        assert!(!first_page.is_empty());
     }
 }

--- a/crates/ceres-client/src/ogc_records.rs
+++ b/crates/ceres-client/src/ogc_records.rs
@@ -431,18 +431,28 @@ fn parse_record(
         })
         .unwrap_or(portal_url)
         .to_string();
-    let number = |name: &str| first(&[name]).and_then(|value| value.parse::<f64>().ok());
-    let spatial_bbox = match (
-        number("westBoundLongitude"),
-        number("southBoundLatitude"),
-        number("eastBoundLongitude"),
-        number("northBoundLatitude"),
-    ) {
-        (Some(west), Some(south), Some(east), Some(north)) => {
-            Some(json!([west, south, east, north]))
-        }
-        _ => None,
-    };
+    let spatial_bbox = node
+        .descendants()
+        .filter(|candidate| local(*candidate) == "EX_GeographicBoundingBox")
+        .find_map(|bbox| {
+            let number = |name: &str| {
+                bbox.descendants()
+                    .find(|candidate| local(*candidate) == name)
+                    .and_then(node_value)
+                    .and_then(|value| value.parse::<f64>().ok())
+            };
+            match (
+                number("westBoundLongitude"),
+                number("southBoundLatitude"),
+                number("eastBoundLongitude"),
+                number("northBoundLatitude"),
+            ) {
+                (Some(west), Some(south), Some(east), Some(north)) => {
+                    Some(json!([west, south, east, north]))
+                }
+                _ => None,
+            }
+        });
     let contacts: Vec<Value> = node
         .descendants()
         .filter(|candidate| local(*candidate) == "CI_ResponsibleParty")
@@ -682,6 +692,16 @@ mod tests {
                 .as_str()
                 .unwrap()
                 .contains("MD_Metadata")
+        );
+    }
+
+    #[test]
+    fn bbox_coordinates_are_taken_from_one_complete_extent() {
+        let xml = r#"<csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco"><csw:SearchResults numberOfRecordsMatched="1" numberOfRecordsReturned="1" nextRecord="0"><gmd:MD_Metadata><gmd:fileIdentifier><gco:CharacterString>multi-extent</gco:CharacterString></gmd:fileIdentifier><gmd:title><gco:CharacterString>Multiple extents</gco:CharacterString></gmd:title><gmd:EX_GeographicBoundingBox><gmd:westBoundLongitude><gco:Decimal>-20</gco:Decimal></gmd:westBoundLongitude><gmd:eastBoundLongitude><gco:Decimal>20</gco:Decimal></gmd:eastBoundLongitude></gmd:EX_GeographicBoundingBox><gmd:EX_GeographicBoundingBox><gmd:westBoundLongitude><gco:Decimal>-5</gco:Decimal></gmd:westBoundLongitude><gmd:southBoundLatitude><gco:Decimal>40</gco:Decimal></gmd:southBoundLatitude><gmd:eastBoundLongitude><gco:Decimal>10</gco:Decimal></gmd:eastBoundLongitude><gmd:northBoundLatitude><gco:Decimal>52</gco:Decimal></gmd:northBoundLatitude></gmd:EX_GeographicBoundingBox></gmd:MD_Metadata></csw:SearchResults></csw:GetRecordsResponse>"#;
+        let page = parse_get_records(xml, "https://example.test", "en").unwrap();
+        assert_eq!(
+            page.records[0].metadata["spatial"]["bbox"],
+            json!([-5.0, 40.0, 10.0, 52.0])
         );
     }
 

--- a/crates/ceres-client/src/portal.rs
+++ b/crates/ceres-client/src/portal.rs
@@ -26,6 +26,7 @@ use crate::ogc_records::{OgcRecord, OgcRecordsClient};
 use crate::opendatasoft::{OpenDataSoftClient, OpenDataSoftDataset};
 use crate::socrata::{SocrataClient, SocrataDataset};
 use crate::sparql::SparqlDcatClient;
+use crate::stac::{StacClient, StacCollection};
 
 /// Portal-specific dataset data, wrapping concrete types from each portal client.
 #[derive(Debug, Clone)]
@@ -44,6 +45,8 @@ pub enum PortalDataEnum {
     ArcGis(ArcGisDataset),
     /// Data from an OGC CSW catalogue.
     OgcRecords(OgcRecord),
+    /// Data from a STAC API Collection.
+    Stac(StacCollection),
 }
 
 /// Unified portal client that wraps concrete portal implementations.
@@ -68,6 +71,8 @@ pub enum PortalClientEnum {
     ArcGis(ArcGisClient),
     /// OGC CSW 2.0.2 catalogue client.
     OgcRecords(OgcRecordsClient),
+    /// Collection-level STAC API client.
+    Stac(StacClient),
 }
 
 impl PortalClient for PortalClientEnum {
@@ -83,6 +88,7 @@ impl PortalClient for PortalClientEnum {
             Self::OpenDataSoft(c) => c.portal_type(),
             Self::ArcGis(c) => c.portal_type(),
             Self::OgcRecords(c) => c.portal_type(),
+            Self::Stac(c) => c.portal_type(),
         }
     }
 
@@ -96,6 +102,7 @@ impl PortalClient for PortalClientEnum {
             Self::OpenDataSoft(c) => c.base_url(),
             Self::ArcGis(c) => c.base_url(),
             Self::OgcRecords(c) => c.base_url(),
+            Self::Stac(c) => c.base_url(),
         }
     }
 
@@ -109,6 +116,7 @@ impl PortalClient for PortalClientEnum {
             Self::OpenDataSoft(c) => c.list_dataset_ids().await,
             Self::ArcGis(c) => c.list_dataset_ids().await,
             Self::OgcRecords(c) => c.list_dataset_ids().await,
+            Self::Stac(c) => c.list_dataset_ids().await,
         }
     }
 
@@ -122,6 +130,7 @@ impl PortalClient for PortalClientEnum {
             Self::OpenDataSoft(c) => c.get_dataset(id).await.map(PortalDataEnum::OpenDataSoft),
             Self::ArcGis(c) => c.get_dataset(id).await.map(PortalDataEnum::ArcGis),
             Self::OgcRecords(c) => c.get_dataset(id).await.map(PortalDataEnum::OgcRecords),
+            Self::Stac(c) => c.get_dataset(id).await.map(PortalDataEnum::Stac),
         }
     }
 
@@ -152,6 +161,9 @@ impl PortalClient for PortalClientEnum {
             }
             PortalDataEnum::OgcRecords(data) => {
                 OgcRecordsClient::into_new_dataset(data, portal_url, url_template, language)
+            }
+            PortalDataEnum::Stac(data) => {
+                StacClient::into_new_dataset(data, portal_url, url_template, language)
             }
         }
     }
@@ -197,6 +209,10 @@ impl PortalClient for PortalClientEnum {
                     .map(PortalDataEnum::OgcRecords)
                     .collect()
             }),
+            Self::Stac(c) => c
+                .search_modified_since(since)
+                .await
+                .map(|datasets| datasets.into_iter().map(PortalDataEnum::Stac).collect()),
         }
     }
 
@@ -238,6 +254,10 @@ impl PortalClient for PortalClientEnum {
                     .map(PortalDataEnum::OgcRecords)
                     .collect()
             }),
+            Self::Stac(c) => c
+                .search_all_datasets()
+                .await
+                .map(|datasets| datasets.into_iter().map(PortalDataEnum::Stac).collect()),
         }
     }
 
@@ -297,6 +317,9 @@ impl PortalClient for PortalClientEnum {
                         .collect()
                 })
             })),
+            Self::Stac(c) => Box::pin(StreamExt::map(c.paginate_stream(), |r| {
+                r.map(|datasets| datasets.into_iter().map(PortalDataEnum::Stac).collect())
+            })),
         }
     }
 
@@ -316,6 +339,9 @@ impl PortalClient for PortalClientEnum {
             Self::ArcGis(c) => c.dataset_count().await,
             Self::OgcRecords(_) => Err(AppError::Generic(
                 "dataset_count is not supported for OGC CSW catalogues".into(),
+            )),
+            Self::Stac(_) => Err(AppError::Generic(
+                "dataset_count is not supported for STAC APIs".into(),
             )),
         }
     }
@@ -410,6 +436,7 @@ impl PortalClientFactory for PortalClientFactoryEnum {
                 language,
                 ogc_endpoint,
             )?)),
+            PortalType::Stac => Ok(PortalClientEnum::Stac(StacClient::new(portal_url)?)),
             PortalType::Dcat => match profile.unwrap_or_default() {
                 DcatProfile::UdataRest => Ok(PortalClientEnum::Dcat(DcatClient::new(
                     portal_url, language,
@@ -680,6 +707,23 @@ mod tests {
         assert!(matches!(client, PortalClientEnum::OgcRecords(_)));
         assert_eq!(client.portal_type(), "ogc_records");
         assert_eq!(client.base_url(), "https://emodnet.ec.europa.eu/");
+    }
+
+    #[test]
+    fn test_factory_creates_stac_client() {
+        let factory = PortalClientFactoryEnum::new();
+        let client = factory
+            .create(
+                "https://stac.dataspace.copernicus.eu/v1/",
+                PortalType::Stac,
+                "en",
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        assert!(matches!(client, PortalClientEnum::Stac(_)));
+        assert_eq!(client.portal_type(), "stac");
     }
 
     #[test]

--- a/crates/ceres-client/src/stac.rs
+++ b/crates/ceres-client/src/stac.rs
@@ -1,0 +1,537 @@
+//! Collection-level SpatioTemporal Asset Catalog (STAC) API client.
+//!
+//! Ceres deliberately harvests one row per STAC Collection. It never follows
+//! Collection `items` links, which keeps imagery catalogs from expanding into
+//! millions of scene-level records by accident.
+
+use std::{collections::HashSet, sync::Arc, time::Duration};
+
+use ceres_core::{AppError, CatalogRecordKind, NewDataset, traits::PortalClient};
+use chrono::{DateTime, Utc};
+use futures::{StreamExt, stream::BoxStream};
+use reqwest::{Client, Url};
+use serde_json::Value;
+use tokio::sync::OnceCell;
+
+const MAX_PAGES: usize = 100_000;
+const MAX_RESPONSE_BYTES: usize = 32 * 1024 * 1024;
+
+/// A normalized STAC Collection plus its complete source JSON.
+#[derive(Debug, Clone)]
+pub struct StacCollection {
+    pub id: String,
+    pub title: String,
+    pub description: Option<String>,
+    pub landing_page: String,
+    pub modified: Option<DateTime<Utc>>,
+    pub metadata: Value,
+}
+
+#[derive(Debug)]
+struct Page {
+    collections: Vec<StacCollection>,
+    next: Option<Url>,
+}
+
+/// Client for the Collections conformance class of a STAC API.
+#[derive(Clone)]
+pub struct StacClient {
+    client: Client,
+    base_url: Url,
+    collections_url: Arc<OnceCell<Url>>,
+}
+
+impl StacClient {
+    pub fn new(base_url: &str) -> Result<Self, AppError> {
+        let base_url =
+            Url::parse(base_url).map_err(|_| AppError::InvalidPortalUrl(base_url.to_string()))?;
+        if !matches!(base_url.scheme(), "http" | "https") {
+            return Err(AppError::InvalidPortalUrl(base_url.to_string()));
+        }
+        let client = Client::builder()
+            .user_agent("Ceres/0.6 (open-data-harvester)")
+            .timeout(Duration::from_secs(120))
+            .build()
+            .map_err(|error| AppError::ClientError(error.to_string()))?;
+        Ok(Self {
+            client,
+            base_url,
+            collections_url: Arc::new(OnceCell::new()),
+        })
+    }
+
+    async fn bounded_get_json(&self, url: Url) -> Result<(Value, Url), AppError> {
+        let response = self
+            .client
+            .get(url.clone())
+            .header(reqwest::header::ACCEPT, "application/json")
+            .send()
+            .await
+            .map_err(|error| AppError::ClientError(error.to_string()))?;
+        if !response.status().is_success() {
+            return Err(AppError::ClientError(format!(
+                "HTTP {} from {url}",
+                response.status()
+            )));
+        }
+        if response
+            .content_length()
+            .is_some_and(|n| n > MAX_RESPONSE_BYTES as u64)
+        {
+            return Err(AppError::ClientError(format!(
+                "STAC response exceeds {MAX_RESPONSE_BYTES} bytes"
+            )));
+        }
+        let response_url = response.url().clone();
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|error| AppError::ClientError(error.to_string()))?;
+        if bytes.len() > MAX_RESPONSE_BYTES {
+            return Err(AppError::ClientError(format!(
+                "STAC response exceeds {MAX_RESPONSE_BYTES} bytes"
+            )));
+        }
+        let json = serde_json::from_slice(&bytes)
+            .map_err(|error| AppError::ClientError(format!("Invalid STAC JSON: {error}")))?;
+        Ok((json, response_url))
+    }
+
+    async fn collections_url(&self) -> Result<&Url, AppError> {
+        self.collections_url
+            .get_or_try_init(|| async {
+                let (landing, response_url) = self.bounded_get_json(self.base_url.clone()).await?;
+                discover_collections_url(&landing, &response_url)
+            })
+            .await
+    }
+
+    async fn page(&self, url: Url) -> Result<Page, AppError> {
+        let (json, response_url) = self.bounded_get_json(url).await?;
+        parse_collections_page(json, &response_url)
+    }
+
+    /// Streams Collection pages by following `rel=next` links. Only GET links
+    /// are accepted; an API advertising a stateful POST cursor fails explicitly
+    /// instead of silently treating a partial result as complete.
+    pub fn paginate_stream(&self) -> BoxStream<'_, Result<Vec<StacCollection>, AppError>> {
+        struct State {
+            next: Option<Url>,
+            pages: usize,
+            seen: HashSet<String>,
+            done: bool,
+        }
+
+        Box::pin(futures::stream::unfold(
+            (
+                self.clone(),
+                State {
+                    next: None,
+                    pages: 0,
+                    seen: HashSet::new(),
+                    done: false,
+                },
+            ),
+            |(client, mut state)| async move {
+                if state.done {
+                    return None;
+                }
+                let url = match state.next.take() {
+                    Some(url) => url,
+                    None => match client.collections_url().await {
+                        Ok(url) => url.clone(),
+                        Err(error) => {
+                            state.done = true;
+                            return Some((Err(error), (client, state)));
+                        }
+                    },
+                };
+                if state.pages >= MAX_PAGES || !state.seen.insert(url.as_str().to_string()) {
+                    state.done = true;
+                    return Some((
+                        Err(AppError::ClientError(
+                            "STAC pagination did not terminate deterministically".into(),
+                        )),
+                        (client, state),
+                    ));
+                }
+                state.pages += 1;
+                match client.page(url).await {
+                    Ok(page) => {
+                        state.next = page.next;
+                        state.done = state.next.is_none();
+                        Some((Ok(page.collections), (client, state)))
+                    }
+                    Err(error) => {
+                        state.done = true;
+                        Some((Err(error), (client, state)))
+                    }
+                }
+            },
+        ))
+    }
+}
+
+impl PortalClient for StacClient {
+    type PortalData = StacCollection;
+
+    fn portal_type(&self) -> &'static str {
+        "stac"
+    }
+
+    fn base_url(&self) -> &str {
+        self.base_url.as_str()
+    }
+
+    async fn list_dataset_ids(&self) -> Result<Vec<String>, AppError> {
+        Ok(self
+            .search_all_datasets()
+            .await?
+            .into_iter()
+            .map(|collection| collection.id)
+            .collect())
+    }
+
+    async fn get_dataset(&self, id: &str) -> Result<StacCollection, AppError> {
+        self.search_all_datasets()
+            .await?
+            .into_iter()
+            .find(|collection| collection.id == id)
+            .ok_or_else(|| AppError::ClientError(format!("STAC Collection '{id}' not found")))
+    }
+
+    fn into_new_dataset(
+        data: StacCollection,
+        portal_url: &str,
+        _url_template: Option<&str>,
+        language: &str,
+    ) -> NewDataset {
+        NewDataset {
+            content_hash: NewDataset::compute_content_hash_with_language(
+                &data.title,
+                data.description.as_deref(),
+                language,
+            ),
+            original_id: data.id,
+            source_portal: portal_url.to_string(),
+            url: data.landing_page,
+            title: data.title,
+            description: data.description,
+            record_kind: CatalogRecordKind::Series,
+            embedding: None,
+            metadata: data.metadata,
+        }
+    }
+
+    async fn search_modified_since(
+        &self,
+        _since: DateTime<Utc>,
+    ) -> Result<Vec<StacCollection>, AppError> {
+        Err(AppError::ClientError(
+            "STAC Collection incremental sync is not supported".into(),
+        ))
+    }
+
+    async fn search_all_datasets(&self) -> Result<Vec<StacCollection>, AppError> {
+        let mut collections = Vec::new();
+        let mut stream = self.paginate_stream();
+        while let Some(page) = stream.next().await {
+            collections.extend(page?);
+        }
+        Ok(collections)
+    }
+
+    fn search_all_datasets_stream(&self) -> BoxStream<'_, Result<Vec<StacCollection>, AppError>> {
+        self.paginate_stream()
+    }
+}
+
+fn discover_collections_url(landing: &Value, base: &Url) -> Result<Url, AppError> {
+    let stac_version = landing
+        .get("stac_version")
+        .and_then(Value::as_str)
+        .ok_or_else(|| AppError::ClientError("STAC landing page is missing stac_version".into()))?;
+    if !(stac_version.starts_with("1.0") || stac_version.starts_with("1.1")) {
+        return Err(AppError::ClientError(format!(
+            "Unsupported STAC version '{stac_version}' (expected 1.0 or 1.1)"
+        )));
+    }
+    let conforms = landing
+        .get("conformsTo")
+        .or_else(|| landing.get("conforms_to"))
+        .and_then(Value::as_array)
+        .ok_or_else(|| AppError::ClientError("STAC landing page is missing conformsTo".into()))?;
+    if !conforms.iter().filter_map(Value::as_str).any(|uri| {
+        let uri = uri.to_ascii_lowercase();
+        uri.contains("stac") && (uri.contains("collection") || uri.ends_with("/core"))
+    }) {
+        return Err(AppError::ClientError(
+            "STAC API does not declare Core or Collections conformance".into(),
+        ));
+    }
+    find_link(landing, base, "data")?.ok_or_else(|| {
+        AppError::ClientError("STAC landing page has no rel=data Collections link".into())
+    })
+}
+
+fn parse_collections_page(json: Value, base: &Url) -> Result<Page, AppError> {
+    let raw_collections = json
+        .get("collections")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            AppError::ClientError("STAC response is missing collections array".into())
+        })?;
+    let collections = raw_collections
+        .iter()
+        .cloned()
+        .map(|collection| parse_collection(collection, base))
+        .collect::<Result<Vec<_>, _>>()?;
+    let next = find_link(&json, base, "next")?;
+    Ok(Page { collections, next })
+}
+
+fn parse_collection(metadata: Value, base: &Url) -> Result<StacCollection, AppError> {
+    let id = metadata
+        .get("id")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| AppError::ClientError("STAC Collection is missing id".into()))?
+        .to_string();
+    let title = metadata
+        .get("title")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or(&id)
+        .to_string();
+    let description = metadata
+        .get("description")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_string);
+    let landing_page = ["about", "canonical", "self"]
+        .into_iter()
+        .find_map(|rel| find_link(&metadata, base, rel).transpose())
+        .transpose()?
+        .unwrap_or_else(|| base.clone())
+        .to_string();
+    let modified = ["updated", "created"]
+        .into_iter()
+        .find_map(|key| metadata.get(key).and_then(Value::as_str))
+        .and_then(parse_date);
+    Ok(StacCollection {
+        id,
+        title,
+        description,
+        landing_page,
+        modified,
+        metadata,
+    })
+}
+
+fn find_link(document: &Value, base: &Url, rel: &str) -> Result<Option<Url>, AppError> {
+    let Some(link) = document
+        .get("links")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .find(|link| link.get("rel").and_then(Value::as_str) == Some(rel))
+    else {
+        return Ok(None);
+    };
+    if link
+        .get("method")
+        .and_then(Value::as_str)
+        .is_some_and(|method| !method.eq_ignore_ascii_case("GET"))
+    {
+        return Err(AppError::ClientError(format!(
+            "STAC rel={rel} link requires an unsupported non-GET request"
+        )));
+    }
+    let href = link
+        .get("href")
+        .and_then(Value::as_str)
+        .ok_or_else(|| AppError::ClientError(format!("STAC rel={rel} link is missing href")))?;
+    let url = base
+        .join(href)
+        .map_err(|error| AppError::ClientError(format!("Invalid STAC rel={rel} URL: {error}")))?;
+    if !matches!(url.scheme(), "http" | "https") {
+        return Err(AppError::ClientError(format!(
+            "Unsupported STAC link scheme '{}'",
+            url.scheme()
+        )));
+    }
+    Ok(Some(url))
+}
+
+fn parse_date(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|date| date.with_timezone(&Utc))
+        .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{method, path},
+    };
+
+    const COLLECTIONS_1_0: &[u8] = include_bytes!("../tests/fixtures/stac_collections_1_0.json");
+    const COLLECTIONS_1_1: &[u8] = include_bytes!("../tests/fixtures/stac_collections_1_1.json");
+
+    #[test]
+    fn discovers_collections_from_landing_links() {
+        let landing = serde_json::json!({
+            "stac_version": "1.1.0",
+            "conformsTo": ["https://api.stacspec.org/v1.0.0/collections"],
+            "links": [{"rel": "data", "href": "./collections", "type": "application/json"}]
+        });
+        let url =
+            discover_collections_url(&landing, &Url::parse("https://catalog.test/stac/").unwrap())
+                .unwrap();
+        assert_eq!(url.as_str(), "https://catalog.test/stac/collections");
+    }
+
+    #[test]
+    fn parses_stac_1_0_collection_and_preserves_source() {
+        let json: Value = serde_json::from_slice(COLLECTIONS_1_0).unwrap();
+        let page = parse_collections_page(
+            json,
+            &Url::parse("https://catalog.test/collections").unwrap(),
+        )
+        .unwrap();
+        assert_eq!(page.collections.len(), 1);
+        let collection = &page.collections[0];
+        assert_eq!(collection.id, "sentinel-2-l2a");
+        assert_eq!(collection.title, "Sentinel-2 Level 2A");
+        assert_eq!(
+            collection.landing_page,
+            "https://catalog.test/collections/sentinel-2-l2a"
+        );
+        assert_eq!(collection.metadata["license"], "proprietary");
+        assert!(collection.metadata["extent"]["spatial"]["bbox"].is_array());
+        assert!(collection.metadata["providers"].is_array());
+        assert!(collection.metadata["summaries"].is_object());
+        assert!(collection.metadata["assets"].is_object());
+    }
+
+    #[test]
+    fn parses_stac_1_1_page_and_next_link() {
+        let json: Value = serde_json::from_slice(COLLECTIONS_1_1).unwrap();
+        let page = parse_collections_page(
+            json,
+            &Url::parse("https://catalog.test/collections?limit=1").unwrap(),
+        )
+        .unwrap();
+        assert_eq!(page.collections[0].id, "landsat-c2-l2");
+        assert_eq!(
+            page.collections[0]
+                .modified
+                .unwrap()
+                .date_naive()
+                .to_string(),
+            "2026-06-15"
+        );
+        assert_eq!(
+            page.next.unwrap().as_str(),
+            "https://catalog.test/collections?limit=1&token=next"
+        );
+    }
+
+    #[test]
+    fn normalizes_collection_as_series() {
+        let json: Value = serde_json::from_slice(COLLECTIONS_1_0).unwrap();
+        let collection = parse_collections_page(
+            json,
+            &Url::parse("https://catalog.test/collections").unwrap(),
+        )
+        .unwrap()
+        .collections
+        .remove(0);
+        let dataset = StacClient::into_new_dataset(collection, "https://catalog.test", None, "en");
+        assert_eq!(dataset.record_kind, CatalogRecordKind::Series);
+        assert_eq!(dataset.original_id, "sentinel-2-l2a");
+        assert_eq!(dataset.metadata["stac_version"], "1.0.0");
+    }
+
+    #[tokio::test]
+    async fn streams_linked_collection_pages_without_following_items() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "stac_version": "1.1.0",
+                "conformsTo": ["https://api.stacspec.org/v1.0.0/collections"],
+                "links": [{"rel": "data", "href": format!("{}/collections/page-1", server.uri())}]
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/collections/page-1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "collections": [minimal_collection("first", &server.uri())],
+                "links": [{"rel": "next", "href": format!("{}/collections/page-2", server.uri())}]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/collections/page-2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "collections": [minimal_collection("second", &server.uri())],
+                "links": []
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = StacClient::new(&format!("{}/", server.uri())).unwrap();
+        let ids: Vec<String> = client
+            .search_all_datasets()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|collection| collection.id)
+            .collect();
+        assert_eq!(ids, ["first", "second"]);
+    }
+
+    fn minimal_collection(id: &str, base: &str) -> Value {
+        serde_json::json!({
+            "stac_version": "1.1.0",
+            "type": "Collection",
+            "id": id,
+            "description": format!("Collection {id}"),
+            "license": "proprietary",
+            "extent": {
+                "spatial": {"bbox": [[-180, -90, 180, 90]]},
+                "temporal": {"interval": [[null, null]]}
+            },
+            "links": [
+                {"rel": "self", "href": format!("{base}/collections/{id}")},
+                {"rel": "items", "href": format!("{base}/collections/{id}/items")}
+            ]
+        })
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network access to the Copernicus Data Space STAC API"]
+    async fn copernicus_stac_smoke() {
+        let url = std::env::var("CERES_STAC_COPERNICUS_URL")
+            .unwrap_or_else(|_| "https://stac.dataspace.copernicus.eu/v1/".into());
+        let client = StacClient::new(&url).unwrap();
+        let first_page = client.paginate_stream().next().await.unwrap().unwrap();
+        assert!(!first_page.is_empty());
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network access to the Canada DataCube STAC API"]
+    async fn canada_datacube_stac_smoke() {
+        let url = std::env::var("CERES_STAC_CANADA_URL")
+            .unwrap_or_else(|_| "https://datacube.services.geo.ca/stac/api/".into());
+        let client = StacClient::new(&url).unwrap();
+        let first_page = client.paginate_stream().next().await.unwrap().unwrap();
+        assert!(!first_page.is_empty());
+    }
+}

--- a/crates/ceres-client/src/stac.rs
+++ b/crates/ceres-client/src/stac.rs
@@ -49,7 +49,9 @@ impl StacClient {
             return Err(AppError::InvalidPortalUrl(base_url.to_string()));
         }
         let client = Client::builder()
-            .user_agent("Ceres/0.6 (open-data-harvester)")
+            // A project URL keeps the agent identifiable without the generic
+            // "harvester" token that some public STAC WAF rules reject.
+            .user_agent("Ceres/0.6 (+https://github.com/AndreaBozzo/Ceres)")
             .timeout(Duration::from_secs(120))
             .build()
             .map_err(|error| AppError::ClientError(error.to_string()))?;

--- a/crates/ceres-client/src/stac.rs
+++ b/crates/ceres-client/src/stac.rs
@@ -353,7 +353,15 @@ fn find_link(document: &Value, base: &Url, rel: &str) -> Result<Option<Url>, App
         .get("href")
         .and_then(Value::as_str)
         .ok_or_else(|| AppError::ClientError(format!("STAC rel={rel} link is missing href")))?;
-    let url = base
+    let mut resolution_base = base.clone();
+    if (href.starts_with("./") || href.starts_with("../")) && !resolution_base.path().ends_with('/')
+    {
+        resolution_base
+            .path_segments_mut()
+            .map_err(|_| AppError::ClientError("STAC base URL cannot resolve paths".into()))?
+            .push("");
+    }
+    let url = resolution_base
         .join(href)
         .map_err(|error| AppError::ClientError(format!("Invalid STAC rel={rel} URL: {error}")))?;
     if !matches!(url.scheme(), "http" | "https") {
@@ -427,6 +435,10 @@ mod tests {
         )
         .unwrap();
         assert_eq!(page.collections[0].id, "landsat-c2-l2");
+        assert_eq!(
+            page.collections[0].landing_page,
+            "https://catalog.test/collections/landsat-c2-l2"
+        );
         assert_eq!(
             page.collections[0]
                 .modified

--- a/crates/ceres-client/tests/fixtures/stac_collections_1_0.json
+++ b/crates/ceres-client/tests/fixtures/stac_collections_1_0.json
@@ -1,0 +1,25 @@
+{
+  "collections": [
+    {
+      "stac_version": "1.0.0",
+      "type": "Collection",
+      "id": "sentinel-2-l2a",
+      "title": "Sentinel-2 Level 2A",
+      "description": "Surface reflectance imagery.",
+      "license": "proprietary",
+      "keywords": ["satellite", "optical"],
+      "providers": [{"name": "ESA", "roles": ["producer", "licensor"]}],
+      "extent": {
+        "spatial": {"bbox": [[-180, -90, 180, 90]]},
+        "temporal": {"interval": [["2015-06-27T00:00:00Z", null]]}
+      },
+      "summaries": {"platform": ["sentinel-2a", "sentinel-2b"]},
+      "assets": {"thumbnail": {"href": "https://catalog.test/thumb.png", "type": "image/png"}},
+      "links": [
+        {"rel": "self", "href": "https://catalog.test/collections/sentinel-2-l2a", "type": "application/json"},
+        {"rel": "items", "href": "https://catalog.test/collections/sentinel-2-l2a/items", "type": "application/geo+json"}
+      ]
+    }
+  ],
+  "links": []
+}

--- a/crates/ceres-client/tests/fixtures/stac_collections_1_1.json
+++ b/crates/ceres-client/tests/fixtures/stac_collections_1_1.json
@@ -1,0 +1,25 @@
+{
+  "collections": [
+    {
+      "stac_version": "1.1.0",
+      "type": "Collection",
+      "id": "landsat-c2-l2",
+      "title": "Landsat Collection 2 Level-2",
+      "description": "Analysis-ready Landsat imagery.",
+      "license": "PDDL-1.0",
+      "created": "2020-12-01T00:00:00Z",
+      "updated": "2026-06-15T12:00:00Z",
+      "extent": {
+        "spatial": {"bbox": [[-180, -90, 180, 90]]},
+        "temporal": {"interval": [["1982-08-22T00:00:00Z", null]]}
+      },
+      "providers": [{"name": "USGS", "roles": ["producer", "host"]}],
+      "summaries": {"platform": ["landsat-4", "landsat-5", "landsat-7", "landsat-8", "landsat-9"]},
+      "assets": {},
+      "links": [{"rel": "self", "href": "./landsat-c2-l2", "type": "application/json"}]
+    }
+  ],
+  "links": [
+    {"rel": "next", "href": "?limit=1&token=next", "type": "application/json", "method": "GET"}
+  ]
+}

--- a/crates/ceres-core/src/config.rs
+++ b/crates/ceres-core/src/config.rs
@@ -396,6 +396,8 @@ pub enum PortalType {
     /// OGC catalogue records exposed through CSW 2.0.2.
     #[serde(rename = "ogc_records")]
     OgcRecords,
+    /// SpatioTemporal Asset Catalog API, harvested at Collection granularity.
+    Stac,
 }
 
 impl fmt::Display for PortalType {
@@ -407,6 +409,7 @@ impl fmt::Display for PortalType {
             Self::OpenDataSoft => write!(f, "opendatasoft"),
             Self::ArcGis => write!(f, "arcgis"),
             Self::OgcRecords => write!(f, "ogc_records"),
+            Self::Stac => write!(f, "stac"),
         }
     }
 }
@@ -422,8 +425,9 @@ impl FromStr for PortalType {
             "opendatasoft" => Ok(Self::OpenDataSoft),
             "arcgis" => Ok(Self::ArcGis),
             "ogc_records" | "csw" => Ok(Self::OgcRecords),
+            "stac" => Ok(Self::Stac),
             _ => Err(AppError::ConfigError(format!(
-                "Unknown portal type: '{}'. Valid options: ckan, socrata, dcat, opendatasoft, arcgis, ogc_records",
+                "Unknown portal type: '{}'. Valid options: ckan, socrata, dcat, opendatasoft, arcgis, ogc_records, stac",
                 s
             ))),
         }
@@ -1195,6 +1199,23 @@ type = "arcgis"
 
         let err = "arcgishub".parse::<PortalType>().unwrap_err();
         assert!(err.to_string().contains("arcgis"));
+    }
+
+    #[test]
+    fn test_portal_type_stac_parse_display_deserialize() {
+        assert_eq!("stac".parse::<PortalType>().unwrap(), PortalType::Stac);
+        assert_eq!("STAC".parse::<PortalType>().unwrap(), PortalType::Stac);
+        assert_eq!(PortalType::Stac.to_string(), "stac");
+
+        let toml = r#"
+[[portals]]
+name = "copernicus-stac"
+url = "https://stac.dataspace.copernicus.eu/v1/"
+type = "stac"
+"#;
+        let config: PortalsConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.portals[0].portal_type, PortalType::Stac);
+        assert!(config.portals[0].validate().is_ok());
     }
 
     #[test]

--- a/crates/ceres-server/tests/integration/common.rs
+++ b/crates/ceres-server/tests/integration/common.rs
@@ -70,7 +70,7 @@ const MIGRATIONS: &[&str] = &[
         url_template TEXT,
         language TEXT,
         portal_type TEXT NOT NULL DEFAULT 'ckan'
-            CHECK (portal_type IN ('ckan', 'dcat', 'socrata', 'opendatasoft', 'arcgis', 'ogc_records')),
+            CHECK (portal_type IN ('ckan', 'dcat', 'socrata', 'opendatasoft', 'arcgis', 'ogc_records', 'stac')),
         profile TEXT,
         sparql_endpoint TEXT,
         ogc_endpoint TEXT,

--- a/examples/PORTAL_CURATION_2026-07.md
+++ b/examples/PORTAL_CURATION_2026-07.md
@@ -174,12 +174,13 @@ raising the local index from 2,232,257 rows / 373 sources to 2,242,358 rows /
 A new live search covered every implemented metadata client. Candidates were
 first excluded by canonical hostname against both `portals.toml` and the local
 database, then checked through the protocol endpoint rather than by testing the
-landing page alone. The resulting disabled curation tranche contains 33 portal
+landing page alone. The resulting disabled curation tranche contains 34 portal
 sources pending a later incremental stability check:
 
-- 7 CKAN catalogs, discovered from the public data-portal registry and checked
+- 8 CKAN catalogs, discovered from the public data-portal registry and checked
   with `package_search`; advertised sizes range from 49 records at Sweden's
-  Traffic Data portal to about 21,100 at California Natural Resources.
+  Traffic Data portal to about 21,100 at California Natural Resources. NETL EDX
+  adds roughly 18,000 energy datasets.
 - 4 Socrata domains absent from the index, discovered through the global
   Discovery API. A full dry run of New Brunswick returned 311 normalized
   datasets without failures.
@@ -207,9 +208,10 @@ but the large CKAN, OpenDataSoft, `data.json`, and national geospatial catalogs
 still need a second scheduled sync before being enabled by default. Málaga was
 re-probed successfully but remains excluded
 because the earlier full comparison found 99.8% title overlap with
-`datos.gob.es`. NETL EDX was also removed after its count request succeeded but
-the first real `package_search` page returned HTTP 403. OPM and the Federal
-Reserve were removed after full harvests showed 100% exact-title overlap with
+`datos.gob.es`. NETL EDX initially rejected the client's obsolete bot-style
+User-Agent with HTTP 403; after replacing it with the package version and
+project URL, real paged harvesting succeeded and EDX was retained. OPM and the
+Federal Reserve were removed after full harvests showed 100% exact-title overlap with
 Data.gov; California Health and Human Services was likewise 100% contained by
 the California `data.json` aggregate. Those redundant rows were removed from
 the local index.

--- a/examples/PORTAL_CURATION_2026-07.md
+++ b/examples/PORTAL_CURATION_2026-07.md
@@ -168,3 +168,64 @@ decision not to curate it.
 Overall the session added 10,101 stored rows and nine logical portal sources,
 raising the local index from 2,232,257 rows / 373 sources to 2,242,358 rows /
 382 sources.
+
+## Protocol-wide discovery pass (14 July 2026)
+
+A new live search covered every implemented metadata client. Candidates were
+first excluded by canonical hostname against both `portals.toml` and the local
+database, then checked through the protocol endpoint rather than by testing the
+landing page alone. The resulting disabled curation tranche contains 33 portal
+sources pending a later incremental stability check:
+
+- 7 CKAN catalogs, discovered from the public data-portal registry and checked
+  with `package_search`; advertised sizes range from 49 records at Sweden's
+  Traffic Data portal to about 21,100 at California Natural Resources.
+- 4 Socrata domains absent from the index, discovered through the global
+  Discovery API. A full dry run of New Brunswick returned 311 normalized
+  datasets without failures.
+- 2 OpenDataSoft catalogs found by grouping the federation hub on source
+  domain: Banque de France (35,839) and PNDB (17,837). They add about 305 and
+  698 titles respectively beyond the federation hub's current snapshot.
+- Serbia's production udata API, advertising 3,450 datasets through Hydra and
+  returning the JSON-LD catalog shape expected by the client.
+- The GSA Project Open Data feed (344 records), retained because 176 normalized
+  titles were absent from the Data.gov aggregate.
+- Croatia's national DCAT SPARQL endpoint, returning 3,873 distinct
+  `dcat:Dataset` resources to the client's count query.
+- 8 correctly scoped ArcGIS Hub sites. Their injected `catalogV2` item filters
+  were non-empty and the Hub Search API advertised between 80 and 2,701
+  datasets for the retained sites; Dundee completed an 80-record dry run.
+- Spain's IDEE CSW catalog, whose capabilities bindings and `GetRecords` pages
+  return ISO 19139 `gmd:MD_Metadata` (43,884 matched records).
+- 8 STAC APIs from the maintained STAC Index list. Each landing page declared
+  STAC 1.0 or 1.1 and exposed a working Collections relation; Thünen completed
+  a seven-Collection dry run without failures. Static STAC catalogs and APIs
+  whose Collections relation returned 404 were rejected.
+
+This tranche intentionally remains `enabled = false`: the endpoints are valid,
+but the large CKAN, OpenDataSoft, `data.json`, and national geospatial catalogs
+still need a second scheduled sync before being enabled by default. Málaga was
+re-probed successfully but remains excluded
+because the earlier full comparison found 99.8% title overlap with
+`datos.gob.es`. NETL EDX was also removed after its count request succeeded but
+the first real `package_search` page returned HTTP 403. OPM and the Federal
+Reserve were removed after full harvests showed 100% exact-title overlap with
+Data.gov; California Health and Human Services was likewise 100% contained by
+the California `data.json` aggregate. Those redundant rows were removed from
+the local index.
+
+IMOS was excluded after the live full harvest: its CSW intermittently declares
+50 or 100 returned records while serializing one fewer `MD_Metadata` element.
+Ceres rejects that inconsistent page rather than silently accepting a partial
+catalog. Digital Earth Australia's sandbox STAC endpoint initially rejected the
+generic `open-data-harvester` user-agent token; the client now sends an
+identifiable project URL instead. Digital Earth Africa's production landing
+page was excluded because its advertised Collections link returns an HTML page
+rather than STAC JSON.
+
+Spain's CODSI was also excluded after deeper pagination checks. Its first page
+works, but later positions throw server-side null-pointer exceptions even with
+`maxRecords=1`; no client page size can produce a complete deterministic walk.
+Centre-Val de Loire was removed because all 377 titles are already in the
+OpenDataSoft federation hub. The FCC Socrata portal was likewise removed after
+51 of its 56 titles matched Data.gov, leaving too little independent scope.

--- a/examples/PORTAL_CURATION_2026-07.md
+++ b/examples/PORTAL_CURATION_2026-07.md
@@ -211,8 +211,8 @@ because the earlier full comparison found 99.8% title overlap with
 `datos.gob.es`. NETL EDX initially rejected the client's obsolete bot-style
 User-Agent with HTTP 403; after replacing it with the package version and
 project URL, real paged harvesting succeeded and EDX was retained. OPM and the
-Federal Reserve were removed after full harvests showed 100% exact-title overlap with
-Data.gov; California Health and Human Services was likewise 100% contained by
+Federal Reserve were removed after full harvests showed 100% exact-title overlap
+with Data.gov; California Health and Human Services was likewise 100% contained by
 the California `data.json` aggregate. Those redundant rows were removed from
 the local index.
 

--- a/examples/portals.toml
+++ b/examples/portals.toml
@@ -1365,6 +1365,14 @@ description = "Natural Resources Canada DataCube STAC API (~50 collections; coll
 
 # CKAN
 [[portals]]
+name = "netl-edx"
+url = "https://edx.netl.doe.gov"
+type = "ckan"
+language = "en"
+enabled = false
+description = "US National Energy Technology Laboratory Energy Data eXchange CKAN catalogue"
+
+[[portals]]
 name = "sweden-traffic-data"
 url = "https://trafficdata.se"
 type = "ckan"

--- a/examples/portals.toml
+++ b/examples/portals.toml
@@ -1359,3 +1359,284 @@ type = "stac"
 language = "en"
 enabled = false
 description = "Natural Resources Canada DataCube STAC API (~50 collections; collection-level only)"
+
+# July 2026 deep-discovery tranche. Each endpoint below was checked against the
+# live protocol API and was absent from both this file and the local index.
+
+# CKAN
+[[portals]]
+name = "sweden-traffic-data"
+url = "https://trafficdata.se"
+type = "ckan"
+language = "sv"
+enabled = false
+description = "Swedish Traffic Data CKAN catalogue"
+
+[[portals]]
+name = "lublin"
+url = "https://otwartedane.lublin.eu"
+type = "ckan"
+language = "pl"
+enabled = false
+description = "City of Lublin open data CKAN catalogue"
+
+[[portals]]
+name = "upper-silesia-metropolis"
+url = "https://otwartedane.metropoliagzm.pl"
+type = "ckan"
+language = "pl"
+enabled = false
+description = "Górnośląsko-Zagłębiowska Metropolia CKAN catalogue (~1,180 datasets)"
+
+[[portals]]
+name = "milwaukee"
+url = "https://data.milwaukee.gov"
+type = "ckan"
+language = "en"
+enabled = false
+description = "City of Milwaukee open data CKAN catalogue"
+
+[[portals]]
+name = "americaview"
+url = "https://ckan.americaview.org"
+type = "ckan"
+language = "en"
+enabled = false
+description = "AmericaView remote-sensing resources CKAN catalogue"
+
+[[portals]]
+name = "phoenix"
+url = "https://phoenixopendata.com"
+type = "ckan"
+language = "en"
+enabled = false
+description = "City of Phoenix open data CKAN catalogue"
+
+[[portals]]
+name = "california-natural-resources"
+url = "https://data.cnra.ca.gov"
+type = "ckan"
+language = "en"
+enabled = false
+description = "California Natural Resources Agency CKAN catalogue"
+
+# Socrata
+[[portals]]
+name = "nova-scotia"
+url = "https://data.novascotia.ca"
+type = "socrata"
+language = "en"
+enabled = false
+description = "Province of Nova Scotia Socrata catalogue"
+
+[[portals]]
+name = "cook-county"
+url = "https://datacatalog.cookcountyil.gov"
+type = "socrata"
+language = "en"
+enabled = false
+description = "Cook County, Illinois Socrata catalogue"
+
+[[portals]]
+name = "new-brunswick"
+url = "https://gnb.socrata.com"
+type = "socrata"
+language = "en"
+enabled = false
+description = "Government of New Brunswick Socrata catalogue"
+
+[[portals]]
+name = "michigan"
+url = "https://data.michigan.gov"
+type = "socrata"
+language = "en"
+enabled = false
+description = "State of Michigan Socrata catalogue"
+
+# OpenDataSoft
+[[portals]]
+name = "banque-de-france"
+url = "https://webstat.banque-france.fr"
+type = "opendatasoft"
+language = "fr"
+enabled = false
+description = "Banque de France Webstat OpenDataSoft catalogue"
+
+[[portals]]
+name = "pndb"
+url = "https://pndb.opendatasoft.com"
+type = "opendatasoft"
+language = "fr"
+enabled = false
+description = "French National Biodiversity Data Hub OpenDataSoft catalogue"
+
+# udata REST DCAT
+[[portals]]
+name = "serbia"
+url = "https://data.gov.rs"
+type = "dcat"
+profile = "udata_rest"
+language = "sr"
+enabled = false
+description = "Serbian national udata JSON-LD catalogue (~3,450 datasets)"
+
+# Project Open Data data.json
+[[portals]]
+name = "us-gsa-data-json"
+url = "https://open.gsa.gov/data.json"
+type = "dcat"
+profile = "static_json"
+language = "en"
+enabled = false
+description = "US General Services Administration Project Open Data catalog"
+
+# SPARQL-backed DCAT
+[[portals]]
+name = "croatia"
+url = "https://data.gov.hr"
+type = "dcat"
+profile = "sparql"
+sparql_endpoint = "https://data.gov.hr/sparql"
+language = "hr"
+enabled = false
+description = "Croatian national DCAT catalogue via SPARQL (~3,870 datasets)"
+
+# ArcGIS Hub
+[[portals]]
+name = "california-geoportal"
+url = "https://gis.data.ca.gov"
+type = "arcgis"
+language = "en"
+enabled = false
+description = "California State Geoportal ArcGIS Hub catalogue"
+
+[[portals]]
+name = "miami-dade"
+url = "https://opendata.miamidade.gov"
+type = "arcgis"
+language = "en"
+enabled = false
+description = "Miami-Dade County ArcGIS Hub catalogue"
+
+[[portals]]
+name = "los-angeles-geohub"
+url = "https://data-lahub.opendata.arcgis.com"
+type = "arcgis"
+language = "en"
+enabled = false
+description = "City of Los Angeles GeoHub ArcGIS catalogue"
+
+[[portals]]
+name = "detroit"
+url = "https://data.detroitmi.gov"
+type = "arcgis"
+language = "en"
+enabled = false
+description = "City of Detroit ArcGIS Hub catalogue"
+
+[[portals]]
+name = "dundee"
+url = "https://opendata-dundeecity.hub.arcgis.com"
+type = "arcgis"
+language = "en"
+enabled = false
+description = "Dundee City Council ArcGIS Hub catalogue"
+
+[[portals]]
+name = "louisville"
+url = "https://louisville-metro-opendata-lojic.hub.arcgis.com"
+type = "arcgis"
+language = "en"
+enabled = false
+description = "Louisville Metro Open Data ArcGIS Hub catalogue"
+
+[[portals]]
+name = "los-angeles-county"
+url = "https://data.lacounty.gov"
+type = "arcgis"
+language = "en"
+enabled = false
+description = "County of Los Angeles ArcGIS Hub catalogue"
+
+[[portals]]
+name = "rio-de-janeiro"
+url = "https://www.data.rio"
+type = "arcgis"
+language = "pt"
+enabled = false
+description = "DATA.RIO municipal ArcGIS Hub catalogue"
+
+# OGC CSW 2.0.2 / ISO 19139
+[[portals]]
+name = "spain-idee-csw"
+url = "https://www.idee.es/csw-inspire-idee"
+type = "ogc_records"
+language = "es"
+enabled = false
+ogc_endpoint = "https://www.idee.es/csw-inspire-idee/srv/spa/csw"
+description = "Spain IDEE national discovery catalogue via CSW (~43,880 records)"
+
+# STAC APIs (Collections are indexed as dataset metadata; Items are not fetched)
+[[portals]]
+name = "swisstopo-stac"
+url = "https://data.geo.admin.ch/api/stac/v1/"
+type = "stac"
+language = "en"
+enabled = false
+description = "Swiss federal geodata STAC API"
+
+[[portals]]
+name = "digital-earth-australia-sandbox-stac"
+url = "https://explorer.sandbox.dea.ga.gov.au/stac/"
+type = "stac"
+language = "en"
+enabled = false
+description = "Digital Earth Australia sandbox STAC API"
+
+[[portals]]
+name = "dlr-eoc-stac"
+url = "https://geoservice.dlr.de/eoc/ogc/stac/v1/"
+type = "stac"
+language = "en"
+enabled = false
+description = "German Aerospace Center Earth Observation Center STAC API"
+
+[[portals]]
+name = "inpe-bdc-stac"
+url = "https://data.inpe.br/bdc/stac/v1/"
+type = "stac"
+language = "en"
+enabled = false
+description = "Brazilian National Institute for Space Research data cube STAC API"
+
+[[portals]]
+name = "paituli-stac"
+url = "https://paituli.csc.fi/geoserver/ogc/stac/v1/"
+type = "stac"
+language = "en"
+enabled = false
+description = "CSC Finland Paituli geodata STAC API"
+
+[[portals]]
+name = "thuenen-stac"
+url = "https://eodata.thuenen.de/stac/api/v1/"
+type = "stac"
+language = "en"
+enabled = false
+description = "Thünen Institute Earth observation STAC API"
+
+[[portals]]
+name = "usgs-landsat-stac"
+url = "https://landsatlook.usgs.gov/stac-server/"
+type = "stac"
+language = "en"
+enabled = false
+description = "USGS LandsatLook STAC API"
+
+[[portals]]
+name = "worldpop-stac"
+url = "https://api.stac.worldpop.org/"
+type = "stac"
+language = "en"
+enabled = false
+description = "WorldPop population geodata STAC API"

--- a/examples/portals.toml
+++ b/examples/portals.toml
@@ -1343,3 +1343,19 @@ type = "arcgis"
 language = "en"
 enabled = false
 description = "Arizona Geographic Information Council ArcGIS Hub catalogue"
+
+[[portals]]
+name = "copernicus-data-space-stac"
+url = "https://stac.dataspace.copernicus.eu/v1/"
+type = "stac"
+language = "en"
+enabled = false
+description = "Copernicus Data Space STAC API (~380 collections; collection-level only)"
+
+[[portals]]
+name = "canada-datacube-stac"
+url = "https://datacube.services.geo.ca/stac/api/"
+type = "stac"
+language = "en"
+enabled = false
+description = "Natural Resources Canada DataCube STAC API (~50 collections; collection-level only)"

--- a/migrations/202607140001_add_stac_portal_type.sql
+++ b/migrations/202607140001_add_stac_portal_type.sql
@@ -1,0 +1,4 @@
+-- Allow collection-level STAC harvests to be queued by background workers.
+ALTER TABLE harvest_jobs DROP CONSTRAINT harvest_jobs_portal_type_check;
+ALTER TABLE harvest_jobs ADD CONSTRAINT harvest_jobs_portal_type_check
+    CHECK (portal_type IN ('ckan', 'dcat', 'socrata', 'opendatasoft', 'arcgis', 'ogc_records', 'stac'));

--- a/website/src/content/docs/HARVESTING.md
+++ b/website/src/content/docs/HARVESTING.md
@@ -19,10 +19,27 @@ Today the shipping portal clients cover:
 - OpenDataSoft catalogs through the Explore API v2.1 (via `--type opendatasoft`)
 - ArcGIS Hub catalogs through the Hub Search API (via `--type arcgis`)
 - OGC CSW 2.0.2 catalogues (via `--type ogc_records`)
+- STAC APIs at Collection granularity (via `--type stac`)
 
 OGC catalogues are capability-driven: Ceres reads `GetCapabilities`, follows
 the advertised record bindings, and streams bounded result windows. Configure
 `ogc_endpoint` when the CSW service differs from the logical portal URL.
+
+STAC harvesting is link-driven: Ceres reads the API landing page, verifies
+STAC conformance, follows its `rel=data` Collections link, and follows
+`rel=next` page links. Each Collection becomes one `series` record with its
+complete JSON preserved. Item links are never followed, preventing accidental
+scene-level catalog expansion.
+
+The live protocol smokes are opt-in and metadata-only; normal tests remain
+offline and deterministic:
+
+```bash
+cargo test -p ceres-client ogc_records::tests::emodnet_csw_smoke -- --ignored --exact
+cargo test -p ceres-client ogc_records::tests::copernicus_marine_csw_smoke -- --ignored --exact
+cargo test -p ceres-client stac::tests::copernicus_stac_smoke -- --ignored --exact
+cargo test -p ceres-client stac::tests::canada_datacube_stac_smoke -- --ignored --exact
+```
 
 See [Supported portals](/portals/) for per-portal configuration, examples, and
 current coverage numbers.

--- a/website/src/content/docs/PORTALS.md
+++ b/website/src/content/docs/PORTALS.md
@@ -7,7 +7,7 @@ description: The portal APIs Ceres can harvest today, how to configure each one,
 
 Ceres currently harvests **120+ portals** into a single synchronized catalog of
 **2M+ datasets** — national portals, EU aggregators, US federal agencies, and
-city open data sites. Seven harvest paths are shipped today, and every one of
+city open data sites. Nine harvest paths are shipped today, and every one of
 them shares the same sync machinery: incremental sync, content-hash delta
 detection, streaming page-by-page processing, and stale dataset marking.
 
@@ -21,6 +21,7 @@ detection, streaming page-by-page processing, and stale dataset marking.
 | OpenDataSoft | `--type opendatasoft` | OpenDataSoft Explore API v2.1 catalogs | opendata.paris.fr, data.economie.gouv.fr |
 | ArcGIS Hub | `--type arcgis` | ArcGIS Hub Search API catalogs | opendata.dc.gov, opendata.gis.utah.gov |
 | OGC Records | `--type ogc_records` | CSW 2.0.2 / GeoNetwork catalogues | EMODnet, British Geological Survey |
+| STAC | `--type stac` | Collection-level STAC APIs | Copernicus Data Space, Canada DataCube |
 
 Every client preserves the complete source metadata payload, so downstream
 features like resource-schema extraction keep working no matter which portal a
@@ -52,6 +53,9 @@ ceres harvest https://opendata.dc.gov --type arcgis --metadata-only
 
 # OGC CSW 2.0.2
 ceres harvest https://emodnet.ec.europa.eu/geonetwork/emodnet/eng/csw --type ogc_records --metadata-only
+
+# STAC Collections (never individual Items)
+ceres harvest https://stac.dataspace.copernicus.eu/v1/ --type stac --metadata-only
 ```
 
 Or configure them once in `portals.toml` and harvest in batch:
@@ -130,6 +134,20 @@ for a larger, curated configuration set.
 - Hub sites with an empty `catalogV2` item scope are rejected because their search endpoint returns global ArcGIS content rather than datasets belonging to that portal
 - No credentials required for public reads
 
+### OGC Records / CSW
+
+- Discovers `GetRecords` and `GetRecordById` bindings from CSW 2.0.2 `GetCapabilities`
+- Streams bounded record windows and preserves each complete source XML record
+- Resolves localized titles and abstracts, spatial/temporal extents, contacts, constraints, and online resources
+- Classifies datasets, series, services, and maps instead of treating every catalog record as a downloadable dataset
+
+### STAC
+
+- Discovers the Collections endpoint from the landing page `rel=data` link and follows `rel=next` pagination
+- Stores one Ceres `series` record per STAC Collection, preserving the complete Collection JSON (extent, providers, assets, summaries, and extension fields)
+- Never follows Collection `items` links; item/scene-level indexing is intentionally out of scope
+- Supports STAC 1.0 and 1.1 APIs; public reads require no credentials unless the catalog itself is private
+
 ## The published index
 
 The catalog Ceres maintains is published as the
@@ -139,10 +157,9 @@ checksums, coverage/quality reports, and snapshot-to-snapshot changelogs.
 
 ## What's next
 
-Coverage keeps expanding. With **OpenDataSoft** and **ArcGIS Hub** shipped, the
-[v0.6.0 milestone](https://github.com/AndreaBozzo/Ceres/milestones) continues
-with job-based harvesting for every supported client and newly validated
-portals at scale.
+Coverage keeps expanding. The [v0.6.0 milestone](https://github.com/AndreaBozzo/Ceres/milestones)
+now focuses on validating the OGC CSW and collection-level STAC clients across
+more portals and publishing a reproducible metadata-only coverage set.
 
 Want a portal that none of the current clients cover? The client layer is
 trait-based and designed for extension — see


### PR DESCRIPTION
## Summary

- add a collection-level STAC 1.0/1.1 portal client with landing-page discovery and link-driven bounded pagination
- preserve complete Collection JSON, classify Collections as series, and explicitly avoid traversing Item links
- finish OGC CSW normalization for localized text, extents, contacts, constraints, and landing-page selection
- add offline fixtures, real-page opt-in smoke tests, curated portal entries, job migration, and public/in-repo documentation

## Why

The v0.6.0 coverage milestone still had two open client tickets. CSW existed but did not yet cover all normalization and acceptance-level live validation requirements, while STAC was not implemented. This makes both families usable for metadata-only coverage harvesting without accidental scene-level STAC expansion.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p ceres-client -p ceres-core`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `npm ci && npm run build` in `website/`
- live first-page smoke harvests for EMODnet CSW, Copernicus Marine CSW, Copernicus Data Space STAC, and Canada DataCube STAC

Closes #177
Closes #178