### PR TITLE
feat: resource parity baseline and DCAT @graph distribution resolution (#187, #188)

### DIFF
--- a/crates/ceres-client/src/dcat.rs
+++ b/crates/ceres-client/src/dcat.rs
@@ -20,6 +20,7 @@
 //! the harvest hot path uses `search_all_datasets`, `get_dataset` is not implemented
 //! and returns an error. Implement it if single-dataset lookup becomes necessary.
 
+use std::collections::HashMap;
 use std::time::Duration;
 
 use ceres_core::HttpConfig;
@@ -237,10 +238,12 @@ impl DcatClient {
                 }
             };
 
-            // Extract Dataset nodes from @graph
+            // Extract Dataset nodes from @graph, resolving distribution
+            // references against the other nodes on the same page.
+            let index = GraphIndex::build(&graph);
             for node in &graph {
                 if is_dataset_node(node)
-                    && let Some(dataset) = extract_dataset(node, &self.language)
+                    && let Some(dataset) = extract_dataset(node, &self.language, &index)
                 {
                     all_datasets.push(dataset);
                 }
@@ -314,11 +317,13 @@ impl DcatClient {
                         return None;
                     }
                 };
-                // Extract Dataset nodes from @graph
+                // Extract Dataset nodes from @graph, resolving distribution
+                // references against the other nodes on the same page.
+                let index = GraphIndex::build(&graph);
                 let mut datasets = Vec::new();
                 for node in &graph {
                     if is_dataset_node(node)
-                        && let Some(dataset) = extract_dataset(node, &self.language)
+                        && let Some(dataset) = extract_dataset(node, &self.language, &index)
                     {
                         datasets.push(dataset);
                     }
@@ -667,13 +672,95 @@ fn get_jsonld_property<'a>(node: &'a Value, keys: &[&str]) -> Option<&'a Value> 
     keys.iter().find_map(|key| node.get(*key))
 }
 
+/// Lookup of a page's `@graph` nodes by `@id`, used to resolve the intra-document
+/// references DCAT-AP uses between a dataset and its distributions.
+pub struct GraphIndex<'a>(HashMap<&'a str, &'a Value>);
+
+impl<'a> GraphIndex<'a> {
+    /// Indexes every node in `graph` that carries a non-empty `@id`.
+    pub fn build(graph: &'a [Value]) -> Self {
+        Self(
+            graph
+                .iter()
+                .filter_map(|node| {
+                    let id = node.get("@id")?.as_str()?;
+                    (!id.is_empty()).then_some((id, node))
+                })
+                .collect(),
+        )
+    }
+
+    fn get(&self, id: &str) -> Option<&'a Value> {
+        self.0.get(id).copied()
+    }
+}
+
+/// The `@id` a distribution reference points at.
+///
+/// DCAT-AP producers write the reference either as a bare URI string or as an
+/// `{"@id": "..."}` object; both appear in harvested catalogs.
+fn reference_id(value: &Value) -> Option<&str> {
+    match value {
+        Value::String(id) => Some(id.as_str()),
+        Value::Object(obj) => obj.get("@id").and_then(Value::as_str),
+        _ => None,
+    }
+}
+
+/// Inlines distributions held as separate `@graph` nodes onto the dataset node.
+///
+/// Without this the persisted `metadata` keeps only an opaque reference, and the
+/// distribution's format, media type, and download URL — which live on the
+/// sibling node — are lost to `DatasetSchema::from_metadata`.
+///
+/// Resolution is additive and conservative: the key is rewritten only when at
+/// least one reference resolves, references that cannot be resolved (for example
+/// a distribution node paginated onto a later page) are preserved verbatim, and
+/// distributions already inlined by the portal are left untouched.
+fn inline_distributions(node: &mut Value, index: &GraphIndex<'_>) {
+    for key in ["distribution", "dcat:distribution"] {
+        let Some(value) = node.get(key) else {
+            continue;
+        };
+
+        let references: Vec<&Value> = match value {
+            Value::Array(items) => items.iter().collect(),
+            single => vec![single],
+        };
+
+        let mut resolved = Vec::with_capacity(references.len());
+        let mut any_resolved = false;
+        for reference in references {
+            match reference_id(reference).and_then(|id| index.get(id)) {
+                Some(target) => {
+                    resolved.push(target.clone());
+                    any_resolved = true;
+                }
+                None => resolved.push(reference.clone()),
+            }
+        }
+
+        if any_resolved && let Some(object) = node.as_object_mut() {
+            object.insert(key.to_string(), Value::Array(resolved));
+        }
+    }
+}
+
 /// Parses a single `@graph` node into a `DcatDataset`.
 ///
 /// Returns `None` if the node is missing required fields (`@id` or a non-empty title).
 ///
 /// The `identifier` field is taken from `dcat:identifier` when present; otherwise
 /// it falls back to the last path segment of `@id`.
-pub fn extract_dataset(node: &Value, language: &str) -> Option<DcatDataset> {
+///
+/// `index` covers the nodes of the same page, so distributions the portal
+/// published as separate `@graph` entries are inlined into the preserved `raw`
+/// metadata rather than left as bare references.
+pub fn extract_dataset(
+    node: &Value,
+    language: &str,
+    index: &GraphIndex<'_>,
+) -> Option<DcatDataset> {
     let id_uri = node.get("@id")?.as_str()?.to_string();
     if id_uri.is_empty() {
         return None;
@@ -707,12 +794,15 @@ pub fn extract_dataset(node: &Value, language: &str) -> Option<DcatDataset> {
         .map(|v| resolve_jsonld_text(v, language))
         .filter(|s| !s.is_empty());
 
+    let mut raw = node.clone();
+    inline_distributions(&mut raw, index);
+
     Some(DcatDataset {
         id_uri,
         identifier,
         title,
         description,
-        raw: node.clone(),
+        raw,
     })
 }
 
@@ -874,6 +964,12 @@ mod tests {
 
     // ---- extract_dataset ---------------------------------------------------
 
+    /// An index over no sibling nodes, for cases where resolution is not under test.
+    fn no_graph() -> GraphIndex<'static> {
+        const EMPTY: &[Value] = &[];
+        GraphIndex::build(EMPTY)
+    }
+
     #[test]
     fn extract_udata_catalog_fixture() {
         let document: Value = serde_json::from_slice(UDATA_CATALOG_FIXTURE).unwrap();
@@ -881,7 +977,7 @@ mod tests {
         let datasets: Vec<_> = graph
             .iter()
             .filter(|node| is_dataset_node(node))
-            .filter_map(|node| extract_dataset(node, "en"))
+            .filter_map(|node| extract_dataset(node, "en", &GraphIndex::build(graph)))
             .collect();
 
         assert_eq!(datasets.len(), 2);
@@ -895,6 +991,77 @@ mod tests {
     }
 
     #[test]
+    fn inlines_distributions_held_as_separate_graph_nodes() {
+        const FIXTURE: &[u8] = include_bytes!("../tests/fixtures/dcat_udata_distributions.jsonld");
+
+        let document: Value = serde_json::from_slice(FIXTURE).unwrap();
+        let graph = document["@graph"].as_array().unwrap();
+        let index = GraphIndex::build(graph);
+        let datasets: Vec<_> = graph
+            .iter()
+            .filter(|node| is_dataset_node(node))
+            .filter_map(|node| extract_dataset(node, "en", &index))
+            .collect();
+
+        assert_eq!(datasets.len(), 3);
+
+        // Both reference forms resolve: `{"@id": ...}` and a bare URI string.
+        let air_quality = &datasets[0];
+        let distributions = air_quality.raw["distribution"].as_array().unwrap();
+        assert_eq!(distributions.len(), 2);
+        assert_eq!(
+            distributions[0]["dcat:mediaType"].as_str(),
+            Some("text/csv"),
+            "an @id-object reference should resolve to the sibling node"
+        );
+        assert_eq!(
+            distributions[1]["format"].as_str(),
+            Some("JSON"),
+            "a bare string reference should resolve to the sibling node"
+        );
+
+        // A single (non-array) string reference is normalized to an array.
+        let population = &datasets[1];
+        let distributions = population.raw["distribution"].as_array().unwrap();
+        assert_eq!(distributions.len(), 1);
+        assert_eq!(distributions[0]["dct:format"].as_str(), Some("XLSX"));
+
+        // A dataset without distributions keeps its shape.
+        assert!(datasets[2].raw.get("distribution").is_none());
+    }
+
+    #[test]
+    fn unresolvable_distribution_references_are_preserved_verbatim() {
+        // A distribution paginated onto a later page cannot be resolved; the
+        // reference must survive rather than be dropped or blanked.
+        let node = json!({
+            "@id": "https://example.org/datasets/1",
+            "@type": "Dataset",
+            "identifier": "1",
+            "title": "Dangling reference",
+            "distribution": "https://example.org/distributions/elsewhere"
+        });
+        let dataset = extract_dataset(&node, "en", &no_graph()).unwrap();
+        assert_eq!(
+            dataset.raw["distribution"].as_str(),
+            Some("https://example.org/distributions/elsewhere")
+        );
+    }
+
+    #[test]
+    fn portal_inlined_distributions_are_left_untouched() {
+        let node = json!({
+            "@id": "https://example.org/datasets/1",
+            "@type": "Dataset",
+            "identifier": "1",
+            "title": "Already inlined",
+            "distribution": [{"dct:format": "CSV", "dcat:downloadURL": "https://example.org/a.csv"}]
+        });
+        let dataset = extract_dataset(&node, "en", &no_graph()).unwrap();
+        assert_eq!(dataset.raw["distribution"], node["distribution"]);
+    }
+
+    #[test]
     fn extract_dataset_basic() {
         let node = json!({
             "@id": "https://data.public.lu/datasets/abc123/",
@@ -903,7 +1070,7 @@ mod tests {
             "title": "Test Dataset",
             "description": "A test description"
         });
-        let dataset = extract_dataset(&node, "en").unwrap();
+        let dataset = extract_dataset(&node, "en", &no_graph()).unwrap();
         assert_eq!(dataset.id_uri, "https://data.public.lu/datasets/abc123/");
         assert_eq!(dataset.identifier, "abc123");
         assert_eq!(dataset.title, "Test Dataset");
@@ -923,7 +1090,7 @@ mod tests {
             "dct:description": {"@language": "en", "@value": "Description"}
         });
 
-        let dataset = extract_dataset(&node, "en").unwrap();
+        let dataset = extract_dataset(&node, "en", &no_graph()).unwrap();
         assert_eq!(dataset.identifier, "example-id");
         assert_eq!(dataset.title, "English Title");
         assert_eq!(dataset.description.as_deref(), Some("Description"));
@@ -936,20 +1103,20 @@ mod tests {
             "@type": "Dataset",
             "title": "My Dataset"
         });
-        let dataset = extract_dataset(&node, "en").unwrap();
+        let dataset = extract_dataset(&node, "en", &no_graph()).unwrap();
         assert_eq!(dataset.identifier, "my-dataset");
     }
 
     #[test]
     fn extract_dataset_missing_id_returns_none() {
         let node = json!({"@type": "Dataset", "title": "No ID"});
-        assert!(extract_dataset(&node, "en").is_none());
+        assert!(extract_dataset(&node, "en", &no_graph()).is_none());
     }
 
     #[test]
     fn extract_dataset_missing_title_returns_none() {
         let node = json!({"@id": "https://example.org/d/1", "@type": "Dataset"});
-        assert!(extract_dataset(&node, "en").is_none());
+        assert!(extract_dataset(&node, "en", &no_graph()).is_none());
     }
 
     // ---- into_new_dataset --------------------------------------------------

--- a/crates/ceres-client/src/sparql.rs
+++ b/crates/ceres-client/src/sparql.rs
@@ -26,7 +26,7 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 use tokio::time::sleep;
 
-use crate::dcat::{DcatDataset, extract_dataset, is_dataset_node};
+use crate::dcat::{DcatDataset, GraphIndex, extract_dataset, is_dataset_node};
 
 /// Delay between paginated SPARQL requests.
 const PAGE_DELAY: Duration = Duration::from_millis(300);
@@ -964,7 +964,9 @@ impl SparqlDcatClient {
 
             if is_dataset_node(node) {
                 entries += 1;
-                if let Some(dataset) = extract_dataset(node, &self.language) {
+                if let Some(dataset) =
+                    extract_dataset(node, &self.language, &GraphIndex::build(graph))
+                {
                     datasets.push(dataset);
                 }
                 continue;
@@ -972,8 +974,11 @@ impl SparqlDcatClient {
 
             if let Some(nested) = node.get("@graph").and_then(|v| v.as_array()) {
                 entries += 1;
+                // A registry entry carries its own `@graph`, so distribution
+                // references resolve against the nested nodes, not the outer page.
                 if let Some(dataset_node) = nested.iter().find(|n| is_dataset_node(n))
-                    && let Some(mut dataset) = extract_dataset(dataset_node, &self.language)
+                    && let Some(mut dataset) =
+                        extract_dataset(dataset_node, &self.language, &GraphIndex::build(nested))
                 {
                     dataset.raw = node.clone();
                     datasets.push(dataset);

--- a/crates/ceres-client/src/sparql.rs
+++ b/crates/ceres-client/src/sparql.rs
@@ -957,6 +957,10 @@ impl SparqlDcatClient {
 
         let mut datasets = Vec::new();
         let mut entries = 0usize;
+        // Built once per page: the page-level index is the same for every
+        // top-level dataset node, so rebuilding it per node would make this
+        // quadratic in the number of `@graph` nodes.
+        let page_index = GraphIndex::build(graph);
         for node in graph {
             if is_hydra_view_node(node) {
                 continue;
@@ -964,9 +968,7 @@ impl SparqlDcatClient {
 
             if is_dataset_node(node) {
                 entries += 1;
-                if let Some(dataset) =
-                    extract_dataset(node, &self.language, &GraphIndex::build(graph))
-                {
+                if let Some(dataset) = extract_dataset(node, &self.language, &page_index) {
                     datasets.push(dataset);
                 }
                 continue;
@@ -975,7 +977,9 @@ impl SparqlDcatClient {
             if let Some(nested) = node.get("@graph").and_then(|v| v.as_array()) {
                 entries += 1;
                 // A registry entry carries its own `@graph`, so distribution
-                // references resolve against the nested nodes, not the outer page.
+                // references resolve against the nested nodes rather than the
+                // outer page. This index is per entry by necessity — `nested`
+                // differs for every registry entry, so it cannot be hoisted.
                 if let Some(dataset_node) = nested.iter().find(|n| is_dataset_node(n))
                     && let Some(mut dataset) =
                         extract_dataset(dataset_node, &self.language, &GraphIndex::build(nested))

--- a/crates/ceres-client/tests/fixtures/ckan_package_search.json
+++ b/crates/ceres-client/tests/fixtures/ckan_package_search.json
@@ -13,8 +13,24 @@
         "resources": [
           {
             "id": "resource-csv",
+            "name": "Air quality readings (CSV)",
+            "description": "Hourly readings, one row per station-hour.",
             "format": "CSV",
-            "url": "https://example.org/data/air-quality.csv"
+            "mimetype": "text/csv",
+            "url": "https://example.org/data/air-quality.csv",
+            "schema": {
+              "fields": [
+                { "name": "station", "type": "string", "description": "Station identifier" },
+                { "name": "measured_at", "type": "datetime" },
+                { "name": "pm10", "type": "number" }
+              ]
+            }
+          },
+          {
+            "id": "resource-pdf",
+            "name": "Methodology note",
+            "format": "PDF",
+            "url": "https://example.org/data/methodology.pdf"
           }
         ]
       },

--- a/crates/ceres-client/tests/fixtures/dcat_udata_distributions.jsonld
+++ b/crates/ceres-client/tests/fixtures/dcat_udata_distributions.jsonld
@@ -1,0 +1,86 @@
+{
+  "@context": "https://www.w3.org/ns/dcat.jsonld",
+  "@graph": [
+    {
+      "@id": "https://data.example.org/datasets/air-quality/",
+      "@type": "dcat:Dataset",
+      "identifier": "air-quality",
+      "title": {
+        "@language": "en",
+        "@value": "Air quality"
+      },
+      "description": {
+        "@language": "en",
+        "@value": "Hourly monitoring observations."
+      },
+      "landingPage": {
+        "@id": "https://data.example.org/datasets/air-quality/"
+      },
+      "distribution": [
+        {
+          "@id": "https://data.example.org/distributions/air-quality-csv"
+        },
+        "https://data.example.org/distributions/air-quality-json"
+      ]
+    },
+    {
+      "@id": "https://data.example.org/datasets/population/",
+      "@type": "Dataset",
+      "identifier": "population",
+      "title": {
+        "@language": "en",
+        "@value": "Population"
+      },
+      "distribution": "https://data.example.org/distributions/population-xlsx"
+    },
+    {
+      "@id": "https://data.example.org/datasets/no-distribution/",
+      "@type": "Dataset",
+      "identifier": "no-distribution",
+      "title": {
+        "@language": "en",
+        "@value": "Register without distributions"
+      }
+    },
+    {
+      "@id": "https://data.example.org/distributions/air-quality-csv",
+      "@type": "dcat:Distribution",
+      "dct:title": {
+        "@language": "en",
+        "@value": "Air quality CSV"
+      },
+      "dct:description": {
+        "@language": "en",
+        "@value": "Comma-separated hourly readings."
+      },
+      "dct:format": {
+        "@id": "http://publications.europa.eu/resource/authority/file-type/CSV"
+      },
+      "dcat:mediaType": "text/csv",
+      "dcat:downloadURL": {
+        "@id": "https://data.example.org/files/air-quality.csv"
+      },
+      "dcat:byteSize": 20480
+    },
+    {
+      "@id": "https://data.example.org/distributions/air-quality-json",
+      "@type": "Distribution",
+      "title": "Air quality JSON",
+      "format": "JSON",
+      "mediaType": "application/json",
+      "downloadURL": "https://data.example.org/files/air-quality.json"
+    },
+    {
+      "@id": "https://data.example.org/distributions/population-xlsx",
+      "@type": "dcat:Distribution",
+      "dct:title": {
+        "@language": "en",
+        "@value": "Population workbook"
+      },
+      "dct:format": "XLSX",
+      "dcat:accessURL": {
+        "@id": "https://data.example.org/files/population.xlsx"
+      }
+    }
+  ]
+}

--- a/crates/ceres-client/tests/resource_parity.rs
+++ b/crates/ceres-client/tests/resource_parity.rs
@@ -1,0 +1,550 @@
+//! Cross-client resource-parity suite.
+//!
+//! [`DatasetSchema::from_metadata`] derives resource/distribution detail *on
+//! read* from the `metadata` JSON each client persists. Whether that yields
+//! anything therefore depends entirely on the shape each client stores — a
+//! property no single-client test can guard.
+//!
+//! This suite closes that loop end to end: every portal family is driven
+//! through its **real** client against a mock server serving a representative
+//! catalog payload, and the assertion runs on the `metadata` the client
+//! actually persists. A client that stops preserving resource detail fails
+//! here even if its own unit tests still pass.
+//!
+//! # Reading the expectation table
+//!
+//! [`expectations`] records, per family, what resource detail is reachable
+//! **today**. Families whose source payload carries resource detail that
+//! [`DatasetSchema`] cannot yet reach are marked [`Expect::Gap`] with the
+//! tracking issue. Those rows assert the gap is still *exactly* as described,
+//! so closing one without updating this table fails the suite rather than
+//! silently drifting — the table is the milestone's ratchet, not a wishlist.
+
+use std::collections::BTreeMap;
+
+use ceres_core::schema::DatasetSchema;
+use ceres_core::traits::PortalClient;
+use ceres_core::{DatasetResource, NewDataset};
+use serde_json::{Value, json};
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use ceres_client::{
+    ArcGisClient, CkanClient, DataJsonClient, DcatClient, OgcRecordsClient, OpenDataSoftClient,
+    SocrataClient, StacClient,
+};
+
+// ---------------------------------------------------------------------------
+// Expectation table
+// ---------------------------------------------------------------------------
+
+/// What a portal family is expected to yield through `DatasetSchema`.
+#[derive(Debug)]
+enum Expect {
+    /// The family reaches its resource detail. Asserts at least one dataset
+    /// exposes a resource whose listed facets are populated.
+    Resources {
+        /// Facets that must be non-`None` on at least one resource.
+        facets: &'static [Facet],
+        /// Whether at least one resource must carry column-level fields.
+        fields: bool,
+    },
+    /// The source payload carries resource detail that `DatasetSchema` cannot
+    /// reach yet. `where_it_lives` documents the key holding it, so the row
+    /// doubles as the specification for closing the gap.
+    Gap {
+        issue: &'static str,
+        where_it_lives: &'static str,
+    },
+}
+
+/// A normalized resource facet, named so failures point at a concrete field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Facet {
+    Name,
+    Format,
+    MediaType,
+    Url,
+}
+
+impl Facet {
+    fn get(self, resource: &DatasetResource) -> Option<&str> {
+        match self {
+            Facet::Name => resource.name.as_deref(),
+            Facet::Format => resource.format.as_deref(),
+            Facet::MediaType => resource.media_type.as_deref(),
+            Facet::Url => resource.url.as_deref(),
+        }
+    }
+}
+
+/// The reachability baseline, one row per portal family.
+///
+/// Measured against the live index at the time of writing: of 2.62M harvested
+/// datasets, the `Resources` rows below account for ~1.33M with reachable
+/// resources, while the `Gap` rows account for ~289k whose detail is harvested
+/// but unreachable.
+fn expectations() -> BTreeMap<&'static str, Expect> {
+    BTreeMap::from([
+        (
+            "ckan",
+            Expect::Resources {
+                facets: &[Facet::Name, Facet::Format, Facet::MediaType, Facet::Url],
+                fields: true,
+            },
+        ),
+        (
+            "project_open_data",
+            Expect::Resources {
+                facets: &[Facet::Name, Facet::Format, Facet::Url],
+                fields: false,
+            },
+        ),
+        (
+            "dcat_udata",
+            Expect::Resources {
+                facets: &[Facet::Name, Facet::Format, Facet::MediaType, Facet::Url],
+                fields: false,
+            },
+        ),
+        (
+            "socrata",
+            Expect::Gap {
+                issue: "#187 follow-up",
+                where_it_lives: "`resource.columns_name` / `columns_datatype` — a full column \
+                                 schema, but not shaped as a resource array",
+            },
+        ),
+        (
+            "opendatasoft",
+            Expect::Gap {
+                issue: "#187 follow-up",
+                where_it_lives: "dataset-level `fields[]` — a full column schema; the dataset \
+                                 is itself the single resource",
+            },
+        ),
+        (
+            "arcgis",
+            Expect::Gap {
+                issue: "#187 follow-up",
+                where_it_lives: "`properties.url` — the service endpoint, with `properties.type` \
+                                 as its format",
+            },
+        ),
+        (
+            "stac",
+            Expect::Gap {
+                issue: "#187 follow-up",
+                where_it_lives: "`assets` — a keyed object rather than an array",
+            },
+        ),
+        (
+            "ogc_csw",
+            Expect::Gap {
+                issue: "#187 follow-up",
+                where_it_lives: "`online_resources[]` — already normalized by the client, \
+                                 merely under a key `DatasetSchema` does not read",
+            },
+        ),
+    ])
+}
+
+// ---------------------------------------------------------------------------
+// The parity test
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn every_client_family_matches_its_documented_resource_reachability() {
+    let harvested: BTreeMap<&'static str, Vec<NewDataset>> = BTreeMap::from([
+        ("ckan", harvest_ckan().await),
+        ("project_open_data", harvest_project_open_data().await),
+        ("dcat_udata", harvest_dcat().await),
+        ("socrata", harvest_socrata().await),
+        ("opendatasoft", harvest_opendatasoft().await),
+        ("arcgis", harvest_arcgis().await),
+        ("stac", harvest_stac().await),
+        ("ogc_csw", harvest_ogc_csw().await),
+    ]);
+
+    let expectations = expectations();
+    assert_eq!(
+        harvested.keys().collect::<Vec<_>>(),
+        expectations.keys().collect::<Vec<_>>(),
+        "every harvested family needs a row in the expectation table"
+    );
+
+    for (family, datasets) in &harvested {
+        assert!(
+            !datasets.is_empty(),
+            "{family}: the mock catalog yielded no datasets, so this row proves nothing"
+        );
+
+        let schemas: Vec<DatasetSchema> = datasets
+            .iter()
+            .map(|dataset| DatasetSchema::from_metadata(&dataset.metadata))
+            .collect();
+        // Only *informative* resources count. A DCAT `{"@id": "..."}` reference
+        // node is a JSON object, so `extract_resource` happily normalizes it
+        // into a resource with every field `None` — a phantom that proves no
+        // resource depth and would inflate the completeness signals in #192.
+        let resources: Vec<&DatasetResource> = schemas
+            .iter()
+            .flat_map(|schema| schema.resources.iter())
+            .filter(|resource| is_informative(resource))
+            .collect();
+
+        match &expectations[family] {
+            Expect::Resources { facets, fields } => {
+                assert!(
+                    !resources.is_empty(),
+                    "{family}: expected reachable resources but DatasetSchema found none — \
+                     the client stopped preserving resource detail in `metadata`"
+                );
+
+                for facet in *facets {
+                    assert!(
+                        resources.iter().any(|r| facet.get(r).is_some()),
+                        "{family}: no resource populated {facet:?}, though the source payload \
+                         provides it"
+                    );
+                }
+
+                if *fields {
+                    assert!(
+                        resources.iter().any(|r| !r.fields.is_empty()),
+                        "{family}: no resource carried column-level fields"
+                    );
+                }
+            }
+            Expect::Gap {
+                issue,
+                where_it_lives,
+            } => {
+                assert!(
+                    resources.is_empty(),
+                    "{family}: resources are now reachable ({} found) — the {issue} gap is \
+                     closed, so move this row to Expect::Resources. Detail lived in: \
+                     {where_it_lives}",
+                    resources.len()
+                );
+
+                assert!(
+                    datasets
+                        .iter()
+                        .any(|dataset| carries_unreachable_detail(family, &dataset.metadata)),
+                    "{family}: the mock payload no longer carries the unreachable resource \
+                     detail this row describes ({where_it_lives}), so the gap assertion is \
+                     vacuous"
+                );
+            }
+        }
+    }
+}
+
+/// Opt-in check that `@graph` distribution resolution holds against a live
+/// DCAT-AP portal, not just the fixture:
+///
+/// ```text
+/// cargo test -p ceres-client --test resource_parity dcat_resource_smoke -- --ignored --exact
+/// ```
+///
+/// Override the portal with `CERES_DCAT_SMOKE_URL`.
+#[tokio::test]
+#[ignore = "requires network access to a public DCAT-AP portal"]
+async fn dcat_resource_smoke() {
+    let portal_url = std::env::var("CERES_DCAT_SMOKE_URL")
+        .unwrap_or_else(|_| "https://data.public.lu".to_string());
+
+    let client = DcatClient::new(&portal_url, "en").unwrap();
+    let datasets = normalize(client.search_all_datasets().await.unwrap(), |record| {
+        DcatClient::into_new_dataset(record, &portal_url, None, "en")
+    });
+    assert!(!datasets.is_empty(), "{portal_url} returned no datasets");
+
+    let with_resources = datasets
+        .iter()
+        .filter(|dataset| {
+            DatasetSchema::from_metadata(&dataset.metadata)
+                .resources
+                .iter()
+                .any(is_informative)
+        })
+        .count();
+
+    eprintln!(
+        "{portal_url}: {with_resources}/{} datasets expose informative resources",
+        datasets.len()
+    );
+    assert!(
+        with_resources > 0,
+        "{portal_url}: no dataset exposed an informative resource, so `@graph` \
+         distribution resolution is not reaching real portal payloads"
+    );
+}
+
+/// Whether a normalized resource carries any usable detail.
+///
+/// A resource with no name, format, media type, URL, or fields tells a consumer
+/// nothing; counting it as resource depth would overstate coverage.
+fn is_informative(resource: &DatasetResource) -> bool {
+    resource.name.is_some()
+        || resource.format.is_some()
+        || resource.media_type.is_some()
+        || resource.url.is_some()
+        || !resource.fields.is_empty()
+}
+
+/// Confirms a `Gap` family really does hold resource detail in `metadata`, so
+/// the "still empty" assertion above cannot pass vacuously against a payload
+/// that simply has no resources to find.
+fn carries_unreachable_detail(family: &str, metadata: &Value) -> bool {
+    match family {
+        "dcat_udata" => metadata.get("distribution").is_some_and(|distribution| {
+            !distribution.is_array() || distribution.as_array().is_some_and(|d| !d.is_empty())
+        }),
+        "socrata" => metadata
+            .pointer("/resource/columns_name")
+            .and_then(Value::as_array)
+            .is_some_and(|columns| !columns.is_empty()),
+        "opendatasoft" => metadata
+            .get("fields")
+            .and_then(Value::as_array)
+            .is_some_and(|fields| !fields.is_empty()),
+        "arcgis" => metadata.pointer("/properties/url").is_some(),
+        "stac" => metadata
+            .get("assets")
+            .and_then(Value::as_object)
+            .is_some_and(|assets| !assets.is_empty()),
+        "ogc_csw" => metadata
+            .get("online_resources")
+            .and_then(Value::as_array)
+            .is_some_and(|resources| !resources.is_empty()),
+        _ => false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-family harvests
+//
+// Each helper serves the crate's existing catalog fixture over a mock server
+// and returns what the real client would persist. Endpoints and pagination
+// terminators mirror the per-client tests in `src/`.
+// ---------------------------------------------------------------------------
+
+async fn harvest_ckan() -> Vec<NewDataset> {
+    const FIXTURE: &[u8] = include_bytes!("fixtures/ckan_package_search.json");
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/3/action/package_search"))
+        .respond_with(json_body(FIXTURE))
+        .mount(&server)
+        .await;
+
+    let portal_url = server.uri();
+    let client = CkanClient::new(&server.uri()).unwrap();
+    normalize(client.search_all_datasets().await.unwrap(), |record| {
+        CkanClient::into_new_dataset(record, &portal_url, None, "en")
+    })
+}
+
+async fn harvest_project_open_data() -> Vec<NewDataset> {
+    const FIXTURE: &[u8] = include_bytes!("fixtures/project_open_data.json");
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/data.json"))
+        .respond_with(json_body(FIXTURE))
+        .mount(&server)
+        .await;
+
+    let portal_url = server.uri();
+    let client = DataJsonClient::new(&format!("{}/data.json", server.uri()), "en").unwrap();
+    normalize(client.search_all_datasets().await.unwrap(), |record| {
+        DataJsonClient::into_new_dataset(record, &portal_url, None, "en")
+    })
+}
+
+async fn harvest_dcat() -> Vec<NewDataset> {
+    const FIXTURE: &[u8] = include_bytes!("fixtures/dcat_udata_distributions.jsonld");
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/1/site/catalog.jsonld"))
+        .respond_with(json_body(FIXTURE))
+        .mount(&server)
+        .await;
+
+    let portal_url = server.uri();
+    let client = DcatClient::new(&server.uri(), "en").unwrap();
+    normalize(client.search_all_datasets().await.unwrap(), |record| {
+        DcatClient::into_new_dataset(record, &portal_url, None, "en")
+    })
+}
+
+async fn harvest_socrata() -> Vec<NewDataset> {
+    const FIXTURE: &[u8] = include_bytes!("fixtures/socrata_catalog.json");
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/catalog/v1"))
+        .respond_with(json_body(FIXTURE))
+        .mount(&server)
+        .await;
+
+    let portal_url = server.uri();
+    let client = SocrataClient::new(&server.uri()).unwrap();
+    normalize(client.search_all_datasets().await.unwrap(), |record| {
+        SocrataClient::into_new_dataset(record, &portal_url, None, "en")
+    })
+}
+
+async fn harvest_opendatasoft() -> Vec<NewDataset> {
+    const FIXTURE: &[u8] = include_bytes!("fixtures/opendatasoft_catalog.json");
+
+    let server = MockServer::start().await;
+    // The full-catalog walk sweeps dated datasets first, then the datasets
+    // without a `modified` timestamp; only the dated sweep serves the fixture.
+    Mock::given(method("GET"))
+        .and(path("/api/explore/v2.1/catalog/datasets"))
+        .and(query_param("where", "modified is null"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "total_count": 0,
+            "results": [],
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/explore/v2.1/catalog/datasets"))
+        .respond_with(json_body(FIXTURE))
+        .mount(&server)
+        .await;
+
+    let portal_url = server.uri();
+    let client = OpenDataSoftClient::new(&server.uri()).unwrap();
+    normalize(client.search_all_datasets().await.unwrap(), |record| {
+        OpenDataSoftClient::into_new_dataset(record, &portal_url, None, "en")
+    })
+}
+
+async fn harvest_arcgis() -> Vec<NewDataset> {
+    const FIXTURE: &[u8] = include_bytes!("fixtures/arcgis_items.json");
+
+    let server = MockServer::start().await;
+    // Site-scope validation reads the site root before the catalog API; a page
+    // without an injected catalog scope is treated as validly scoped.
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("<html></html>"))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/search/v1/collections/dataset/items"))
+        .respond_with(json_body(FIXTURE))
+        .mount(&server)
+        .await;
+
+    let portal_url = server.uri();
+    let client = ArcGisClient::new(&server.uri()).unwrap();
+    normalize(client.search_all_datasets().await.unwrap(), |record| {
+        ArcGisClient::into_new_dataset(record, &portal_url, None, "en")
+    })
+}
+
+async fn harvest_stac() -> Vec<NewDataset> {
+    const FIXTURE: &[u8] = include_bytes!("fixtures/stac_collections_1_0.json");
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "stac_version": "1.0.0",
+            "type": "Catalog",
+            "id": "test-catalog",
+            "description": "Parity fixture catalog",
+            "conformsTo": ["https://api.stacspec.org/v1.0.0/collections"],
+            "links": [{
+                "rel": "data",
+                "href": format!("{}/collections", server.uri()),
+                "type": "application/json",
+            }],
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/collections"))
+        .respond_with(json_body(FIXTURE))
+        .mount(&server)
+        .await;
+
+    let portal_url = server.uri();
+    let client = StacClient::new(&server.uri()).unwrap();
+    normalize(client.search_all_datasets().await.unwrap(), |record| {
+        StacClient::into_new_dataset(record, &portal_url, None, "en")
+    })
+}
+
+async fn harvest_ogc_csw() -> Vec<NewDataset> {
+    const RECORDS: &str = include_str!("fixtures/csw_get_records.xml");
+
+    let server = MockServer::start().await;
+    // GetCapabilities advertises the operation endpoints, so its hrefs have to
+    // point back at the mock server and cannot live in a static fixture.
+    let capabilities = format!(
+        r#"<ows:Capabilities xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <ows:OperationsMetadata>
+    <ows:Operation name="GetRecords">
+      <ows:DCP><ows:HTTP><ows:Get xlink:href="{base}/csw"/></ows:HTTP></ows:DCP>
+    </ows:Operation>
+    <ows:Operation name="GetRecordById">
+      <ows:DCP><ows:HTTP><ows:Get xlink:href="{base}/csw"/></ows:HTTP></ows:DCP>
+    </ows:Operation>
+  </ows:OperationsMetadata>
+</ows:Capabilities>"#,
+        base = server.uri()
+    );
+    Mock::given(method("GET"))
+        .and(path("/csw"))
+        .and(query_param("request", "GetCapabilities"))
+        .respond_with(xml_body(&capabilities))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/csw"))
+        .and(query_param("request", "GetRecords"))
+        .respond_with(xml_body(RECORDS))
+        .mount(&server)
+        .await;
+
+    let endpoint = format!("{}/csw", server.uri());
+    let portal_url = server.uri();
+    let client = OgcRecordsClient::new(&server.uri(), "en", Some(&endpoint)).unwrap();
+    normalize(client.search_all_datasets().await.unwrap(), |record| {
+        OgcRecordsClient::into_new_dataset(record, &portal_url, None, "en")
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn json_body(fixture: &[u8]) -> ResponseTemplate {
+    ResponseTemplate::new(200)
+        .insert_header("content-type", "application/json")
+        .set_body_bytes(fixture.to_vec())
+}
+
+fn xml_body(fixture: &str) -> ResponseTemplate {
+    ResponseTemplate::new(200)
+        .insert_header("content-type", "application/xml")
+        .set_body_string(fixture.to_string())
+}
+
+/// Runs each harvested record through the client's own `into_new_dataset`, so
+/// the assertions see exactly the `metadata` a harvest would persist.
+///
+/// Takes a closure because the DCAT and Project Open Data clients expose
+/// `into_new_dataset` as an inherent method rather than through [`PortalClient`].
+fn normalize<T>(data: Vec<T>, into_new_dataset: impl Fn(T) -> NewDataset) -> Vec<NewDataset> {
+    data.into_iter().map(into_new_dataset).collect()
+}

--- a/crates/ceres-client/tests/resource_parity.rs
+++ b/crates/ceres-client/tests/resource_parity.rs
@@ -110,7 +110,7 @@ fn expectations() -> BTreeMap<&'static str, Expect> {
         (
             "socrata",
             Expect::Gap {
-                issue: "#187 follow-up",
+                issue: "#203",
                 where_it_lives: "`resource.columns_name` / `columns_datatype` — a full column \
                                  schema, but not shaped as a resource array",
             },
@@ -118,7 +118,7 @@ fn expectations() -> BTreeMap<&'static str, Expect> {
         (
             "opendatasoft",
             Expect::Gap {
-                issue: "#187 follow-up",
+                issue: "#202",
                 where_it_lives: "dataset-level `fields[]` — a full column schema; the dataset \
                                  is itself the single resource",
             },
@@ -126,7 +126,7 @@ fn expectations() -> BTreeMap<&'static str, Expect> {
         (
             "arcgis",
             Expect::Gap {
-                issue: "#187 follow-up",
+                issue: "#206",
                 where_it_lives: "`properties.url` — the service endpoint, with `properties.type` \
                                  as its format",
             },
@@ -134,14 +134,14 @@ fn expectations() -> BTreeMap<&'static str, Expect> {
         (
             "stac",
             Expect::Gap {
-                issue: "#187 follow-up",
+                issue: "#205",
                 where_it_lives: "`assets` — a keyed object rather than an array",
             },
         ),
         (
             "ogc_csw",
             Expect::Gap {
-                issue: "#187 follow-up",
+                issue: "#204",
                 where_it_lives: "`online_resources[]` — already normalized by the client, \
                                  merely under a key `DatasetSchema` does not read",
             },

--- a/crates/ceres-core/src/schema.rs
+++ b/crates/ceres-core/src/schema.rs
@@ -19,7 +19,11 @@
 //! - For DCAT portals, distributions published as separate `@graph` nodes are
 //!   inlined onto the dataset node at harvest time by the DCAT client. A
 //!   distribution paginated onto a later catalog page cannot be resolved, so its
-//!   reference is preserved verbatim and yields no detail here.
+//!   reference is preserved verbatim.
+//! - An unresolved `{"@id": "..."}` reference is still a JSON object, so it
+//!   currently normalizes into a [`DatasetResource`] with every facet `None`.
+//!   A non-empty `resources` therefore does not by itself imply usable resource
+//!   depth — check that at least one facet is populated. Tracked in #207.
 //! - Socrata, OpenDataSoft, ArcGIS Hub, STAC, and OGC CSW harvest resource
 //!   detail into shapes this module does not yet read; see the resource-parity
 //!   suite in `ceres-client/tests/resource_parity.rs` for the current baseline.

--- a/crates/ceres-core/src/schema.rs
+++ b/crates/ceres-core/src/schema.rs
@@ -16,9 +16,13 @@
 //! - Field-level schema only appears when the portal inlined it in the harvested
 //!   metadata (e.g. a Frictionless `schema.fields` block). We do not call CKAN's
 //!   `datastore_info`/`datastore_search`, so DataStore-only schemas are not enriched.
-//! - For DCAT portals, only the dataset node is persisted in `metadata`; the
-//!   separate distribution `@graph` nodes are not, so distribution detail is
-//!   limited to whatever is inlined on the dataset node.
+//! - For DCAT portals, distributions published as separate `@graph` nodes are
+//!   inlined onto the dataset node at harvest time by the DCAT client. A
+//!   distribution paginated onto a later catalog page cannot be resolved, so its
+//!   reference is preserved verbatim and yields no detail here.
+//! - Socrata, OpenDataSoft, ArcGIS Hub, STAC, and OGC CSW harvest resource
+//!   detail into shapes this module does not yet read; see the resource-parity
+//!   suite in `ceres-client/tests/resource_parity.rs` for the current baseline.
 
 use serde::Serialize;
 use serde_json::Value;
@@ -105,6 +109,46 @@ fn first_str(obj: &Value, keys: &[&str]) -> Option<String> {
     None
 }
 
+/// Reads the first present value among `keys`, additionally accepting a JSON-LD
+/// node reference `{"@id": "..."}`.
+///
+/// DCAT-AP producers overwhelmingly express `dcat:downloadURL`, `dcat:accessURL`,
+/// and `dct:format` as references to a URI rather than as literals, so a
+/// `@value`-only reader silently drops them.
+fn first_ref(obj: &Value, keys: &[&str]) -> Option<String> {
+    for key in keys {
+        if let Some(value) = first_str(obj, &[key]) {
+            return Some(value);
+        }
+        if let Some(id) = obj
+            .get(*key)
+            .and_then(|v| v.get("@id"))
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+        {
+            return Some(id.to_string());
+        }
+    }
+    None
+}
+
+/// Reduces a controlled-vocabulary format URI to its final segment.
+///
+/// DCAT-AP portals cite formats as authority URIs (for example
+/// `http://publications.europa.eu/resource/authority/file-type/CSV`); consumers
+/// want `CSV`. Plain format literals pass through untouched.
+fn shorten_format(format: String) -> String {
+    if !format.contains("://") {
+        return format;
+    }
+    format
+        .trim_end_matches('/')
+        .rsplit('/')
+        .find(|segment| !segment.is_empty())
+        .map(str::to_string)
+        .unwrap_or(format)
+}
+
 /// Normalizes a single resource/distribution node, returning `None` if it is not
 /// a JSON object.
 fn extract_resource(node: &Value) -> Option<DatasetResource> {
@@ -114,8 +158,8 @@ fn extract_resource(node: &Value) -> Option<DatasetResource> {
 
     Some(DatasetResource {
         name: first_str(node, &["name", "title", "dct:title"]),
-        format: first_str(node, &["format", "dct:format"]),
-        media_type: first_str(
+        format: first_ref(node, &["format", "dct:format"]).map(shorten_format),
+        media_type: first_ref(
             node,
             &[
                 "mimetype",
@@ -125,7 +169,7 @@ fn extract_resource(node: &Value) -> Option<DatasetResource> {
                 "dcat:mediaType",
             ],
         ),
-        url: first_str(
+        url: first_ref(
             node,
             &[
                 "url",
@@ -276,6 +320,55 @@ mod tests {
         assert_eq!(r.format.as_deref(), Some("GeoJSON"));
         assert_eq!(r.url.as_deref(), Some("https://example.org/data.geojson"));
         assert!(r.fields.is_empty());
+    }
+
+    #[test]
+    fn dcat_node_references_resolve_to_urls_and_formats() {
+        // The shape DCAT-AP portals actually emit: URLs and formats as JSON-LD
+        // node references rather than literals.
+        let metadata = json!({
+            "distribution": [{
+                "@type": "dcat:Distribution",
+                "dct:title": {"@language": "en", "@value": "Air quality CSV"},
+                "dct:format": {"@id": "http://publications.europa.eu/resource/authority/file-type/CSV"},
+                "dcat:mediaType": "text/csv",
+                "dcat:downloadURL": {"@id": "https://example.org/files/air-quality.csv"}
+            }]
+        });
+
+        let schema = DatasetSchema::from_metadata(&metadata);
+        let r = &schema.resources[0];
+        assert_eq!(r.name.as_deref(), Some("Air quality CSV"));
+        assert_eq!(r.format.as_deref(), Some("CSV"));
+        assert_eq!(r.media_type.as_deref(), Some("text/csv"));
+        assert_eq!(
+            r.url.as_deref(),
+            Some("https://example.org/files/air-quality.csv")
+        );
+    }
+
+    #[test]
+    fn plain_format_literals_are_not_shortened() {
+        let metadata =
+            json!({"resources": [{"format": "CSV", "url": "https://example.org/a.csv"}]});
+        let schema = DatasetSchema::from_metadata(&metadata);
+        assert_eq!(schema.resources[0].format.as_deref(), Some("CSV"));
+        assert_eq!(
+            schema.resources[0].url.as_deref(),
+            Some("https://example.org/a.csv")
+        );
+    }
+
+    #[test]
+    fn literal_values_win_over_node_references() {
+        let metadata = json!({
+            "distribution": [{
+                "dct:format": "GeoJSON",
+                "dcat:downloadURL": {"@id": "https://example.org/data.geojson"}
+            }]
+        });
+        let schema = DatasetSchema::from_metadata(&metadata);
+        assert_eq!(schema.resources[0].format.as_deref(), Some("GeoJSON"));
     }
 
     #[test]


### PR DESCRIPTION
Opens the 0.7.0 resource-metadata milestone (epic #68) with its two foundation issues, and corrects the milestone's central assumption with measured evidence.

Closes #187. Closes #188.

## The scope correction

The epic assumed resource depth was "~90% present" across clients, with DCAT as "the one genuine gap". Building the parity suite disproved that. Measured against the live index of **2.62M harvested datasets**:

| Family | Where the detail lives | Datasets | Status |
|---|---|---|---|
| CKAN | `resources[]` | ~1.22M | reachable |
| Project Open Data | `distribution[]` | ~106k | reachable |
| DCAT udata | `@graph` node references | 32,040 | **closed here** |
| OpenDataSoft | dataset-level `fields[]` | 170,144 | #202 |
| Socrata | `resource.columns_*[]` | 31,910 | #203 |
| OGC CSW | `online_resources[]` | 27,065 | #204 |
| ArcGIS Hub | `properties.url` | 25,154 | #206 |
| STAC | `assets{}` | 2,263 | #205 |

Six of eight families yielded zero resources, and OpenDataSoft alone is 5.3x the DCAT gap. In most cases the detail is already harvested and sitting in `metadata` — it just is not shaped as an array under a key `DatasetSchema` reads. Epic #68 now carries this table; the remaining families are filed as #202-#206.

## #188 — DCAT `@graph` distribution resolution

DCAT-AP publishes distributions as sibling `@graph` nodes, referenced from the dataset either as a bare URI string or as `{"@id": ...}`. The client persisted only the dataset node, so format, media type, and download URL were lost.

Resolution happens at harvest time against the other nodes on the same catalog page, and is deliberately conservative:

- the key is rewritten only when at least one reference resolves;
- unresolvable references (a distribution paginated onto a later page) are preserved verbatim rather than dropped or blanked;
- distributions the portal already inlined are left untouched.

This also required teaching `DatasetSchema` to read JSON-LD node references: DCAT-AP producers overwhelmingly express `dcat:downloadURL`, `dcat:accessURL`, and `dct:format` as `{"@id": ...}` rather than literals, so a `@value`-only reader dropped them even once the distribution was inlined. Controlled-vocabulary format URIs are reduced to their final segment, so consumers see `CSV` rather than the full `publications.europa.eu` authority URI.

**Verified against a live portal, not just fixtures.** I disabled the fix to measure the true baseline:

| data.public.lu | datasets exposing an informative resource |
|---|---|
| before | 0 / 2983 |
| after | 2973 / 2982 |

An opt-in smoke test covers this (`--ignored`, `CERES_DCAT_SMOKE_URL`).

## #187 — cross-client resource-parity suite

Every family is driven through its **real** client against a mock server, and the assertion runs on the `metadata` the client actually persists — so a client that stops preserving resource detail fails here even if its own unit tests still pass. Hand-written metadata fixtures would have been lighter, but they can drift from what clients really store, which is the exact regression this suite exists to catch.

The expectation table encodes the measured baseline rather than an aspiration, and ratchets **both** ways:

- `Resources` rows fail if a family stops populating;
- `Gap` rows fail if a gap closes without the table being updated, and additionally assert the payload still carries the unreachable detail, so a gap row cannot pass vacuously against a fixture that simply has no resources.

Both directions were observed failing during development — the DCAT `Gap` row fired on its own once #188 landed, which is how the row came to be flipped.

## One defect found along the way

`extract_resource` returns a `DatasetResource` for **any** JSON object, so an unresolvable `{"@id": ...}` reference normalizes into a resource with every field `None` — a phantom proving no resource depth. That would inflate #192's per-portal completeness signals and fill #189's Parquet column with all-null structs, and #190 is about to freeze that DTO. Filed as **#207**; the parity suite works around it locally via `is_informative` for now.

## Notes for the milestone

- **Sequencing:** #189 and #192 should land *after* the per-family normalizers, or the published snapshot and quality report will show most portals as resource-empty when they are not.
- **Re-harvest:** #188 changes what is *persisted*, so DCAT portals (data.gouv.fr, dados.gov.pt, data.e-gov.go.jp — ~32k datasets) need a re-harvest before the index reflects the improvement.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p ceres-client -p ceres-core` — 205 client + 156 core passing
- Live DCAT smoke run against data.public.lu (opt-in, `--ignored`)

Both commits are green in isolation, so bisect stays usable.
