### PR TITLE
feat(schema): read OGC CSW online_resources as normalized resources (#204)

### DIFF
--- a/crates/ceres-client/tests/resource_parity.rs
+++ b/crates/ceres-client/tests/resource_parity.rs
@@ -139,11 +139,15 @@ fn expectations() -> BTreeMap<&'static str, Expect> {
             },
         ),
         (
+            // The shared CSW fixture's records carry only link and download
+            // access protocols, which describe how to fetch a resource rather
+            // than what it is, so no format or media type is expected here. The
+            // `protocol` split is unit-tested against all three real-world
+            // shapes in `ceres_core::schema`.
             "ogc_csw",
-            Expect::Gap {
-                issue: "#204",
-                where_it_lives: "`online_resources[]` — already normalized by the client, \
-                                 merely under a key `DatasetSchema` does not read",
+            Expect::Resources {
+                facets: &[Facet::Url],
+                fields: false,
             },
         ),
     ])

--- a/crates/ceres-core/src/schema.rs
+++ b/crates/ceres-core/src/schema.rs
@@ -165,10 +165,17 @@ fn shorten_format(format: String) -> String {
 /// than polluting the format distribution reported for the index.
 fn split_protocol(protocol: &str) -> (Option<String>, Option<String>) {
     let protocol = protocol.trim();
+    let lowered = protocol.to_ascii_lowercase();
 
-    // MIME type, possibly with parameters (`image/png; mode=24bit`). Guard
-    // against a URL, which also contains a slash.
-    if protocol.contains('/') && !protocol.starts_with("http") {
+    // A URI is never a media type — its scheme separator would otherwise read as
+    // a MIME slash. It may still name a service, though: the values that reach
+    // here are free text lifted from XML, and in practice a URI-valued protocol
+    // that mentions a service (an OGC `serviceType` URI, a GetCapabilities
+    // endpoint) genuinely identifies that service, so the check below still runs.
+    let is_uri = lowered.contains("://");
+
+    // MIME type, possibly with parameters (`image/png; mode=24bit`).
+    if !is_uri && protocol.contains('/') {
         let media_type = protocol
             .split(';')
             .next()
@@ -179,7 +186,6 @@ fn split_protocol(protocol: &str) -> (Option<String>, Option<String>) {
     }
 
     // OGC service identifier, spelled either `OGC:WFS` or `OGC Web Feature Service`.
-    let lowered = protocol.to_ascii_lowercase();
     for service in ["wmts", "wms", "wfs", "wcs", "csw", "sos"] {
         let spelled_out = match service {
             "wms" => "web map service",
@@ -469,12 +475,43 @@ mod tests {
 
     #[test]
     fn a_url_valued_protocol_is_not_read_as_a_media_type() {
-        let metadata = json!({
-            "online_resources": [{"url": "https://catalog.test/a", "protocol": "https://example.org/spec"}]
-        });
-        let schema = DatasetSchema::from_metadata(&metadata);
-        assert_eq!(schema.resources[0].media_type, None);
-        assert_eq!(schema.resources[0].format, None);
+        // Case-insensitively: the scheme separator must not read as a MIME slash
+        // whatever the casing.
+        for protocol in [
+            "https://example.org/spec",
+            "HTTP://EXAMPLE.ORG/SPEC",
+            "http://",
+        ] {
+            let metadata = json!({
+                "online_resources": [{"url": "https://catalog.test/a", "protocol": protocol}]
+            });
+            let schema = DatasetSchema::from_metadata(&metadata);
+            assert_eq!(
+                schema.resources[0].media_type, None,
+                "{protocol} should not yield a media type"
+            );
+            assert_eq!(
+                schema.resources[0].format, None,
+                "{protocol} names no service"
+            );
+        }
+    }
+
+    #[test]
+    fn a_uri_valued_protocol_naming_a_service_still_yields_its_format() {
+        // Both shapes occur verbatim in the harvested index: an OGC `serviceType`
+        // URI leaked with its surrounding markup, and a GetCapabilities endpoint.
+        for protocol in [
+            r#"xlink:href="http://www.opengis.net/def/serviceType/ogc/wms">OGC Web Map Service"#,
+            "https://example.org/svc?service=WMS&request=GetCapabilities",
+        ] {
+            let metadata = json!({
+                "online_resources": [{"url": "https://catalog.test/a", "protocol": protocol}]
+            });
+            let schema = DatasetSchema::from_metadata(&metadata);
+            assert_eq!(schema.resources[0].format.as_deref(), Some("WMS"));
+            assert_eq!(schema.resources[0].media_type, None);
+        }
     }
 
     #[test]

--- a/crates/ceres-core/src/schema.rs
+++ b/crates/ceres-core/src/schema.rs
@@ -80,6 +80,7 @@ impl DatasetSchema {
             "distribution",
             "dcat:distribution",
             "distributions",
+            "online_resources",
         ] {
             if let Some(Value::Array(items)) = metadata.get(key) {
                 resources.extend(items.iter().filter_map(extract_resource));
@@ -153,6 +154,49 @@ fn shorten_format(format: String) -> String {
         .unwrap_or(format)
 }
 
+/// Splits an ISO 19139 `CI_OnlineResource/protocol` into a format and a media
+/// type, returning `(format, media_type)`.
+///
+/// The field is overloaded in practice. Across the harvested index it holds MIME
+/// types (`image/png`, `text/xml`), OGC service identifiers (`OGC:WFS`,
+/// `OGC Web Map Service`), and pure access methods (`WWW:LINK-1.0-http--link`,
+/// `WWW:DOWNLOAD-1.0-http--download`). Only the first two describe the resource;
+/// access methods say how to fetch it, not what it is, so they are dropped rather
+/// than polluting the format distribution reported for the index.
+fn split_protocol(protocol: &str) -> (Option<String>, Option<String>) {
+    let protocol = protocol.trim();
+
+    // MIME type, possibly with parameters (`image/png; mode=24bit`). Guard
+    // against a URL, which also contains a slash.
+    if protocol.contains('/') && !protocol.starts_with("http") {
+        let media_type = protocol
+            .split(';')
+            .next()
+            .unwrap_or(protocol)
+            .trim()
+            .to_string();
+        return (None, Some(media_type));
+    }
+
+    // OGC service identifier, spelled either `OGC:WFS` or `OGC Web Feature Service`.
+    let lowered = protocol.to_ascii_lowercase();
+    for service in ["wmts", "wms", "wfs", "wcs", "csw", "sos"] {
+        let spelled_out = match service {
+            "wms" => "web map service",
+            "wfs" => "web feature service",
+            "wcs" => "web coverage service",
+            "wmts" => "web map tile service",
+            "csw" => "catalogue service",
+            _ => "sensor observation service",
+        };
+        if lowered.contains(service) || lowered.contains(spelled_out) {
+            return (Some(service.to_ascii_uppercase()), None);
+        }
+    }
+
+    (None, None)
+}
+
 /// Normalizes a single resource/distribution node, returning `None` if it is not
 /// a JSON object.
 fn extract_resource(node: &Value) -> Option<DatasetResource> {
@@ -160,9 +204,15 @@ fn extract_resource(node: &Value) -> Option<DatasetResource> {
         return None;
     }
 
+    let (protocol_format, protocol_media_type) = first_str(node, &["protocol"])
+        .map(|protocol| split_protocol(&protocol))
+        .unwrap_or((None, None));
+
     Some(DatasetResource {
         name: first_str(node, &["name", "title", "dct:title"]),
-        format: first_ref(node, &["format", "dct:format"]).map(shorten_format),
+        format: first_ref(node, &["format", "dct:format"])
+            .map(shorten_format)
+            .or(protocol_format),
         media_type: first_ref(
             node,
             &[
@@ -172,7 +222,8 @@ fn extract_resource(node: &Value) -> Option<DatasetResource> {
                 "media_type",
                 "dcat:mediaType",
             ],
-        ),
+        )
+        .or(protocol_media_type),
         url: first_ref(
             node,
             &[
@@ -373,6 +424,70 @@ mod tests {
         });
         let schema = DatasetSchema::from_metadata(&metadata);
         assert_eq!(schema.resources[0].format.as_deref(), Some("GeoJSON"));
+    }
+
+    #[test]
+    fn ogc_online_resources_are_read() {
+        let metadata = json!({
+            "online_resources": [
+                {"url": "https://catalog.test/download/sst.nc",
+                 "protocol": "WWW:DOWNLOAD-1.0-http--download", "downloadable": true},
+                {"url": "https://catalog.test/wfs", "protocol": "OGC:WFS", "downloadable": true},
+                {"url": "https://catalog.test/preview.png", "protocol": "image/png; mode=24bit",
+                 "downloadable": false}
+            ]
+        });
+
+        let schema = DatasetSchema::from_metadata(&metadata);
+        assert_eq!(schema.resources.len(), 3);
+
+        // A pure access method describes how to fetch, not what the resource is.
+        assert_eq!(schema.resources[0].format, None);
+        assert_eq!(schema.resources[0].media_type, None);
+        assert_eq!(
+            schema.resources[0].url.as_deref(),
+            Some("https://catalog.test/download/sst.nc")
+        );
+
+        assert_eq!(schema.resources[1].format.as_deref(), Some("WFS"));
+        assert_eq!(schema.resources[2].media_type.as_deref(), Some("image/png"));
+        assert_eq!(schema.resources[2].format, None);
+    }
+
+    #[test]
+    fn spelled_out_ogc_service_protocols_are_recognized() {
+        let metadata = json!({
+            "online_resources": [
+                {"url": "https://catalog.test/wms", "protocol": "OGC Web Map Service"},
+                {"url": "https://catalog.test/wfs", "protocol": "OGC Web Feature Service"}
+            ]
+        });
+        let schema = DatasetSchema::from_metadata(&metadata);
+        assert_eq!(schema.resources[0].format.as_deref(), Some("WMS"));
+        assert_eq!(schema.resources[1].format.as_deref(), Some("WFS"));
+    }
+
+    #[test]
+    fn a_url_valued_protocol_is_not_read_as_a_media_type() {
+        let metadata = json!({
+            "online_resources": [{"url": "https://catalog.test/a", "protocol": "https://example.org/spec"}]
+        });
+        let schema = DatasetSchema::from_metadata(&metadata);
+        assert_eq!(schema.resources[0].media_type, None);
+        assert_eq!(schema.resources[0].format, None);
+    }
+
+    #[test]
+    fn explicit_format_wins_over_the_protocol_fallback() {
+        let metadata = json!({
+            "online_resources": [{"format": "NetCDF", "protocol": "OGC:WFS", "mimetype": "application/x-netcdf"}]
+        });
+        let schema = DatasetSchema::from_metadata(&metadata);
+        assert_eq!(schema.resources[0].format.as_deref(), Some("NetCDF"));
+        assert_eq!(
+            schema.resources[0].media_type.as_deref(),
+            Some("application/x-netcdf")
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #204. First of the five per-family normalizers opened by the parity baseline in #208.

## What was wrong

The OGC CSW client already does the hard part: it parses `CI_OnlineResource` elements out of ISO 19139 XML and writes a normalized `online_resources` array into the stored `metadata`. `DatasetSchema::from_metadata` simply never read that key, so all 27k CSW records reported zero resources.

This is the cheapest gap in the milestone — the data was already harvested and already normalized.

## The one real decision: `protocol` is overloaded

`CI_OnlineResource/protocol` does not mean one thing. Surveying all 262,503 harvested entries:

| Kind | Examples | Entries |
|---|---|---|
| MIME type | `image/png`, `text/xml`, `image/png; mode=24bit` | 27,464 |
| OGC service id | `OGC:WFS`, `OGC Web Map Service` | 24,649 |
| Pure access method | `WWW:LINK-1.0-http--link`, `WWW:DOWNLOAD-1.0-http--download` | ~50k |
| Absent | — | 160,525 |

So it maps to **two** different fields depending on shape. MIME types become `media_type` (parameters stripped); service identifiers become `format`, normalized to the short name so `OGC:WFS` and `OGC Web Feature Service` both yield `WFS`.

Access methods are deliberately **dropped**. `WWW:LINK-1.0-http--link` describes how to fetch a resource, not what it is; putting it in `format` would produce garbage buckets in the `by_format` distribution #192 is about to publish. An explicit `format`/`mimetype` on the entry always wins over this fallback.

`WMTS` is checked before `WMS` so a tile service is not misread, and a `protocol` that is itself a URL is not mistaken for a MIME type on account of its slash.

## Verified against the live index, not just fixtures

Normalization is **on read**, so this needs no re-harvest and applies to already-harvested data immediately. Projecting the implemented logic over the real index:

- **27,056** of 27,391 CSW datasets go from zero to informative resources
- **27,464** entries gain a media type
- **24,649** entries gain a format

The parity suite's `ogc_csw` row moves from `Expect::Gap` to `Expect::Resources`. The gap ratchet fired on its own first, naming #204 and pointing at the row to update — working as designed.

## Scope notes

- The shared CSW fixture's records carry only link and download protocols, and an existing client test asserts on that array's exact length. Rather than perturb it, the parity row asserts `Url` and the `protocol` split is unit-tested in `ceres_core::schema` against all three real-world shapes.
- **12,825** entries have no URL and no usable protocol; those normalize into the empty phantom resources tracked in #207. This PR does not special-case them — that fix belongs in #207 so it applies uniformly across families rather than only to CSW.
- Non-data links are not filtered: a record's landing page can also appear as an online resource. Filtering risks dropping genuine distributions (a WMS endpoint is a real distribution), so all entries are kept.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p ceres-client -p ceres-core` — 205 client + 160 core passing
