### PR TITLE
feat(schema): surface OpenDataSoft column schema and artifacts as resources (#202)

### DIFF
--- a/crates/ceres-client/src/opendatasoft.rs
+++ b/crates/ceres-client/src/opendatasoft.rs
@@ -11,8 +11,11 @@
 //! text fields such as `dataset_id`. Datasets without a `modified` timestamp
 //! are collected in a final `where=modified is null` sweep.
 //!
-//! The complete catalog entry (including the `fields` schema hints) is
-//! preserved in [`NewDataset::metadata`].
+//! The complete catalog entry is preserved verbatim in
+//! [`NewDataset::metadata`]. `ceres_core::DatasetSchema` normalizes it on read:
+//! the dataset-level `fields[]` become the column schema of the single table an
+//! ODS dataset is, and `attachments[]` / `alternative_exports[]` become
+//! resources of their own.
 
 use std::collections::HashSet;
 use std::time::Duration;

--- a/crates/ceres-client/tests/fixtures/opendatasoft_catalog.json
+++ b/crates/ceres-client/tests/fixtures/opendatasoft_catalog.json
@@ -7,8 +7,23 @@
       "dataset_uid": "da_abc123",
       "has_records": true,
       "features": ["analyze", "geo"],
-      "attachments": [],
-      "alternative_exports": [],
+      "attachments": [
+        {
+          "id": "notice_methodologique_pdf",
+          "title": "Notice méthodologique.pdf",
+          "mimetype": "application/pdf",
+          "url": "https://opendata.example.fr/api/explore/v2.1/catalog/datasets/arbres-remarquables/attachments/notice_methodologique_pdf"
+        }
+      ],
+      "alternative_exports": [
+        {
+          "id": "arbres_remarquables_shp_zip",
+          "title": "arbres_remarquables.zip",
+          "mimetype": "application/zip",
+          "description": "Fichier de formes (Shapefile) en RGF93",
+          "url": "https://opendata.example.fr/api/explore/v2.1/catalog/datasets/arbres-remarquables/alternative_exports/arbres_remarquables_shp_zip"
+        }
+      ],
       "data_visible": true,
       "fields": [
         {

--- a/crates/ceres-client/tests/resource_parity.rs
+++ b/crates/ceres-client/tests/resource_parity.rs
@@ -81,9 +81,15 @@ impl Facet {
 /// The reachability baseline, one row per portal family.
 ///
 /// Measured against the live index at the time of writing: of 2.62M harvested
-/// datasets, the `Resources` rows below account for ~1.33M with reachable
-/// resources, while the `Gap` rows account for ~289k whose detail is harvested
+/// datasets, the `Resources` rows below account for ~1.44M with reachable
+/// resources, while the `Gap` rows account for ~59k whose detail is harvested
 /// but unreachable.
+///
+/// A `Resources` row means the family's detail is reachable *where the portal
+/// published it*, not that every dataset in the family has some. OpenDataSoft
+/// is the clearest case: 58,510 of its 170,144 harvested datasets yield an
+/// informative resource, because ODS ships an empty column schema for every
+/// dataset that carries no records.
 fn expectations() -> BTreeMap<&'static str, Expect> {
     BTreeMap::from([
         (
@@ -116,11 +122,14 @@ fn expectations() -> BTreeMap<&'static str, Expect> {
             },
         ),
         (
+            // The dataset's own table is synthesized from the dataset-level
+            // `fields[]` and carries no URL — the catalog entry holds no
+            // absolute one. `Url` and `MediaType` come from the attachments and
+            // alternative exports hanging off it, which do.
             "opendatasoft",
-            Expect::Gap {
-                issue: "#202",
-                where_it_lives: "dataset-level `fields[]` — a full column schema; the dataset \
-                                 is itself the single resource",
+            Expect::Resources {
+                facets: &[Facet::Name, Facet::MediaType, Facet::Url],
+                fields: true,
             },
         ),
         (
@@ -310,10 +319,6 @@ fn carries_unreachable_detail(family: &str, metadata: &Value) -> bool {
             .pointer("/resource/columns_name")
             .and_then(Value::as_array)
             .is_some_and(|columns| !columns.is_empty()),
-        "opendatasoft" => metadata
-            .get("fields")
-            .and_then(Value::as_array)
-            .is_some_and(|fields| !fields.is_empty()),
         "arcgis" => metadata.pointer("/properties/url").is_some(),
         "stac" => metadata
             .get("assets")

--- a/crates/ceres-core/src/schema.rs
+++ b/crates/ceres-core/src/schema.rs
@@ -24,9 +24,17 @@
 //!   currently normalizes into a [`DatasetResource`] with every facet `None`.
 //!   A non-empty `resources` therefore does not by itself imply usable resource
 //!   depth — check that at least one facet is populated. Tracked in #207.
-//! - Socrata, OpenDataSoft, ArcGIS Hub, STAC, and OGC CSW harvest resource
-//!   detail into shapes this module does not yet read; see the resource-parity
-//!   suite in `ceres-client/tests/resource_parity.rs` for the current baseline.
+//! - An OpenDataSoft dataset is a single table whose column schema lives at the
+//!   *dataset* level, so its primary resource is synthesized rather than read
+//!   from an array, and carries no URL: the catalog payload holds no absolute
+//!   one. The Explore export endpoint is not synthesized either — it is a
+//!   portal-wide API capability rather than per-dataset metadata, and it does
+//!   not resolve for the federated `dataset_id@domain` entries that make up all
+//!   of `data.opendatasoft.com`. Attachments and alternative exports do carry
+//!   real URLs and are read as additional resources.
+//! - Socrata, ArcGIS Hub, and STAC harvest resource detail into shapes this
+//!   module does not yet read; see the resource-parity suite in
+//!   `ceres-client/tests/resource_parity.rs` for the current baseline.
 
 use serde::Serialize;
 use serde_json::Value;
@@ -73,7 +81,11 @@ impl DatasetSchema {
     /// supported portal types and normalizes each entry. Always returns a value;
     /// an absent or unrecognized structure yields an empty `resources` vector.
     pub fn from_metadata(metadata: &Value) -> Self {
-        let mut resources = Vec::new();
+        // The dataset's own table, where the portal describes it at the dataset
+        // level rather than in a resource array, comes before the artifacts
+        // hanging off it.
+        let mut resources: Vec<DatasetResource> =
+            opendatasoft_table(metadata).into_iter().collect();
 
         for key in [
             "resources",
@@ -81,6 +93,8 @@ impl DatasetSchema {
             "dcat:distribution",
             "distributions",
             "online_resources",
+            "attachments",
+            "alternative_exports",
         ] {
             if let Some(Value::Array(items)) = metadata.get(key) {
                 resources.extend(items.iter().filter_map(extract_resource));
@@ -242,6 +256,63 @@ fn extract_resource(node: &Value) -> Option<DatasetResource> {
         ),
         description: first_str(node, &["description", "dct:description"]),
         fields: extract_fields(node),
+    })
+}
+
+/// Synthesizes the single tabular resource an OpenDataSoft dataset represents.
+///
+/// An ODS dataset is one table, so the Explore catalog entry describes its
+/// columns at the *dataset* level in `fields[]` rather than inside a resource
+/// array — there is no node for [`extract_resource`] to normalize. Recognized
+/// by the catalog-entry signature (a `dataset_id` alongside a `metas` block),
+/// which no other supported family emits.
+///
+/// Returns `None` unless the column schema is actually populated: ODS ships
+/// `fields: []` for every dataset without records (all but one of
+/// `webstat.banque-france.fr`, for instance), and a resource naming the dataset
+/// with nothing else to say is the phantom of #207.
+///
+/// The resource carries no URL. The catalog payload holds no absolute one, and
+/// the Explore export endpoint is deliberately not synthesized: it describes
+/// what the API can do rather than what the portal published, and it 400s for
+/// the federated `dataset_id@domain` entries that make up the whole of the
+/// `data.opendatasoft.com` hub. `attachments` and `alternative_exports` are the
+/// artifacts that do carry real URLs, and are read as resources in their own
+/// right by [`DatasetSchema::from_metadata`].
+fn opendatasoft_table(metadata: &Value) -> Option<DatasetResource> {
+    let dataset_id = metadata.get("dataset_id").and_then(Value::as_str)?;
+    if !metadata.get("metas").is_some_and(Value::is_object) {
+        return None;
+    }
+
+    let fields: Vec<ResourceField> = metadata
+        .get("fields")
+        .and_then(Value::as_array)?
+        .iter()
+        .filter_map(extract_field)
+        .collect();
+    if fields.is_empty() {
+        return None;
+    }
+
+    // Blank titles occur in the wild; the client falls back to the dataset id
+    // for the dataset's own title, so the resource does the same.
+    let name = metadata
+        .pointer("/metas/default")
+        .and_then(|metas| first_str(metas, &["title"]))
+        .filter(|title| !title.trim().is_empty())
+        .unwrap_or_else(|| dataset_id.to_string());
+
+    Some(DatasetResource {
+        name: Some(name),
+        format: None,
+        media_type: None,
+        url: None,
+        // The dataset-level description is already carried by the dataset
+        // itself; repeating it here would add bytes to every exported row
+        // without adding information.
+        description: None,
+        fields,
     })
 }
 
@@ -525,6 +596,137 @@ mod tests {
             schema.resources[0].media_type.as_deref(),
             Some("application/x-netcdf")
         );
+    }
+
+    /// A trimmed Explore v2.1 catalog entry, in the shape the client persists.
+    fn ods_entry(fields: Value, extra: Value) -> Value {
+        let mut entry = json!({
+            "dataset_id": "arbres-remarquables",
+            "has_records": true,
+            "attachments": [],
+            "alternative_exports": [],
+            "fields": fields,
+            "metas": {"default": {"title": "Arbres remarquables", "records_count": 187}}
+        });
+        for (key, value) in extra.as_object().unwrap() {
+            entry[key] = value.clone();
+        }
+        entry
+    }
+
+    #[test]
+    fn opendatasoft_dataset_level_fields_become_one_table_resource() {
+        let metadata = ods_entry(
+            json!([
+                {"name": "essence", "label": "Essence", "description": null, "type": "text"},
+                {"name": "geo_point", "label": "Coordonnées géo", "description": null,
+                 "type": "geo_point_2d"}
+            ]),
+            json!({}),
+        );
+
+        let schema = DatasetSchema::from_metadata(&metadata);
+        assert_eq!(schema.resources.len(), 1);
+        let r = &schema.resources[0];
+        assert_eq!(r.name.as_deref(), Some("Arbres remarquables"));
+        // The catalog entry carries no absolute URL and the export endpoint is
+        // not synthesized; the column schema is what this resource contributes.
+        assert_eq!(r.url, None);
+        assert_eq!(r.format, None);
+        assert_eq!(r.fields.len(), 2);
+        assert_eq!(r.fields[0].name, "essence");
+        assert_eq!(r.fields[0].r#type.as_deref(), Some("text"));
+        // ODS leaves `description` null and puts the human label in `label`.
+        assert_eq!(r.fields[0].description.as_deref(), Some("Essence"));
+        assert_eq!(r.fields[1].r#type.as_deref(), Some("geo_point_2d"));
+    }
+
+    #[test]
+    fn opendatasoft_blank_title_falls_back_to_the_dataset_id() {
+        for title in [json!("   "), json!(""), Value::Null] {
+            let mut metadata = ods_entry(json!([{"name": "col", "type": "text"}]), json!({}));
+            metadata["metas"]["default"]["title"] = title.clone();
+
+            let schema = DatasetSchema::from_metadata(&metadata);
+            assert_eq!(
+                schema.resources[0].name.as_deref(),
+                Some("arbres-remarquables"),
+                "title {title} should fall back to the dataset id"
+            );
+        }
+    }
+
+    #[test]
+    fn opendatasoft_without_records_yields_no_phantom_table() {
+        // ODS ships `fields: []` for every dataset that has no records. A
+        // resource naming the dataset and nothing else proves no depth.
+        let metadata = ods_entry(json!([]), json!({"has_records": false}));
+        assert!(DatasetSchema::from_metadata(&metadata).resources.is_empty());
+    }
+
+    #[test]
+    fn opendatasoft_attachments_and_alternative_exports_are_resources() {
+        let metadata = ods_entry(
+            json!([{"name": "essence", "label": "Essence", "type": "text"}]),
+            json!({
+                "attachments": [{
+                    "id": "notice_pdf",
+                    "title": "Notice.pdf",
+                    "mimetype": "application/pdf",
+                    "url": "https://opendata.example.fr/api/explore/v2.1/catalog/datasets/arbres-remarquables/attachments/notice_pdf"
+                }],
+                "alternative_exports": [{
+                    "id": "arbres_shp_zip",
+                    "title": "arbres.zip",
+                    "mimetype": "application/zip",
+                    "description": "Shapefile en RGF93",
+                    "url": "https://opendata.example.fr/api/explore/v2.1/catalog/datasets/arbres-remarquables/alternative_exports/arbres_shp_zip"
+                }]
+            }),
+        );
+
+        let schema = DatasetSchema::from_metadata(&metadata);
+        // The dataset's own table first, then the artifacts hanging off it.
+        assert_eq!(schema.resources.len(), 3);
+        assert_eq!(
+            schema.resources[0].name.as_deref(),
+            Some("Arbres remarquables")
+        );
+
+        let attachment = &schema.resources[1];
+        assert_eq!(attachment.name.as_deref(), Some("Notice.pdf"));
+        assert_eq!(attachment.media_type.as_deref(), Some("application/pdf"));
+        assert!(
+            attachment
+                .url
+                .as_deref()
+                .is_some_and(|url| url.ends_with("/attachments/notice_pdf"))
+        );
+
+        let alternative = &schema.resources[2];
+        assert_eq!(alternative.name.as_deref(), Some("arbres.zip"));
+        assert_eq!(alternative.media_type.as_deref(), Some("application/zip"));
+        assert_eq!(
+            alternative.description.as_deref(),
+            Some("Shapefile en RGF93")
+        );
+    }
+
+    #[test]
+    fn a_dataset_level_fields_array_alone_is_not_an_opendatasoft_table() {
+        // The ODS signature is a catalog entry: `dataset_id` plus a `metas`
+        // block. A bare `fields` array on some other family's payload must not
+        // be read as a table resource.
+        for metadata in [
+            json!({"fields": [{"name": "col", "type": "text"}]}),
+            json!({"dataset_id": "x", "fields": [{"name": "col", "type": "text"}]}),
+            json!({"metas": {"default": {}}, "fields": [{"name": "col", "type": "text"}]}),
+        ] {
+            assert!(
+                DatasetSchema::from_metadata(&metadata).resources.is_empty(),
+                "{metadata} is not an OpenDataSoft catalog entry"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #202. Part of #68.

## What

OpenDataSoft was the largest single resource-metadata gap in the index. An ODS dataset is a single table, so the Explore catalog entry describes its columns at the **dataset** level in `fields[]` rather than inside a resource array — `DatasetSchema::from_metadata` had no node to normalize and reported zero resources for the whole family.

- Synthesize the dataset's table as one resource, recognized by the catalog-entry signature (`dataset_id` alongside `metas`), with `fields[]` as its column schema.
- Read `attachments[]` and `alternative_exports[]` through the existing extraction path — they already carry absolute URLs, media types, titles and descriptions.

Normalization is **on read**, so no re-harvest is needed.

## The export-endpoint question

#202 asked whether export formats become additional resources or facets of the single resource. Neither: they are a portal-wide API capability rather than per-dataset metadata, and the endpoint does not resolve for the federated `dataset_id@domain` entries that make up **all** of `data.opendatasoft.com` (94k datasets) — it returns 400 `NoDomainMatchingException`. The table resource therefore carries no URL; the artifacts that do have real URLs are `attachments` and `alternative_exports`.

## Measured against the live index

Of 170,144 harvested ODS datasets:

| | datasets |
|---|---|
| gain an informative resource | **58,510** |
| ├ gain a column-level schema (904,365 columns) | 55,369 |
| └ gain a downloadable artifact with a real URL | 10,053 |
| gain nothing | 111,634 |

The 111,634 are correct: ODS ships `fields: []` for every dataset without records — all but one of `webstat.banque-france.fr` (35,839) and all but five of `pndb.opendatasoft.com` (17,837). **#68's table overstates this family's reachable gain at 170,144**; the parity suite now records the measured subset, and #68 should be corrected before #192 sets expectations from it.

Emitting a resource for those record-less datasets would name the dataset and say nothing else — the phantom tracked in #207 — so the synthesizer returns nothing unless the column schema is populated.

## Tests

- The `opendatasoft` row in `resource_parity.rs` moves from `Expect::Gap` to `Expect::Resources { facets: [Name, MediaType, Url], fields: true }`, per the acceptance criteria.
- The ODS fixture gains a real attachment and alternative export, so the row measures client behaviour rather than fixture poverty (same reasoning as the CKAN fixture in #187).
- Six unit tests in `ceres_core::schema` cover the synthesizer, the `label` → field-description fallback ODS relies on, blank-title fallback, the no-records case, and that a bare `fields` array on another family's payload is not mistaken for an ODS table.

Both halves of the change were reverted independently against the parity suite: without the synthesizer it fails on `no resource carried column-level fields`; without the two new keys it fails on `no resource populated MediaType`.

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `cargo test -p ceres-client -p ceres-core` all pass.
