### PR TITLE
feat(stac): normalize collection assets into resources (#205)

### DIFF
--- a/crates/ceres-client/tests/fixtures/stac_collections_1_0.json
+++ b/crates/ceres-client/tests/fixtures/stac_collections_1_0.json
@@ -14,7 +14,16 @@
         "temporal": {"interval": [["2015-06-27T00:00:00Z", null]]}
       },
       "summaries": {"platform": ["sentinel-2a", "sentinel-2b"]},
-      "assets": {"thumbnail": {"href": "https://catalog.test/thumb.png", "type": "image/png"}},
+      "assets": {
+        "thumbnail": {"href": "https://catalog.test/thumb.png", "type": "image/png", "roles": ["thumbnail"]},
+        "zarr": {
+          "href": "https://catalog.test/sentinel-2-l2a.zarr",
+          "type": "application/vnd+zarr",
+          "title": "Analysis-ready cube",
+          "description": "Chunked for time-series access",
+          "roles": ["data"]
+        }
+      },
       "links": [
         {"rel": "self", "href": "https://catalog.test/collections/sentinel-2-l2a", "type": "application/json"},
         {"rel": "items", "href": "https://catalog.test/collections/sentinel-2-l2a/items", "type": "application/geo+json"}

--- a/crates/ceres-client/tests/resource_parity.rs
+++ b/crates/ceres-client/tests/resource_parity.rs
@@ -82,8 +82,9 @@ impl Facet {
 ///
 /// Measured against the live index at the time of writing: of 2.62M harvested
 /// datasets, the `Resources` rows below account for ~1.47M with reachable
-/// resources, while the `Gap` rows account for ~27k whose detail is harvested
-/// but unreachable.
+/// resources, while the `Gap` rows account for ~25k whose detail is harvested
+/// but unreachable — the 25,154 ArcGIS Hub items of #206, now that STAC's 2,263
+/// collections read their assets.
 ///
 /// A `Resources` row means the family's detail is reachable *where the portal
 /// published it*, not that every dataset in the family has some. OpenDataSoft
@@ -143,10 +144,13 @@ fn expectations() -> BTreeMap<&'static str, Expect> {
             },
         ),
         (
+            // A collection's artifacts, read from the keyed `assets` object.
+            // `type` is a media type, so no format is expected; `links` are
+            // navigation rather than distributions and are not read at all.
             "stac",
-            Expect::Gap {
-                issue: "#205",
-                where_it_lives: "`assets` — a keyed object rather than an array",
+            Expect::Resources {
+                facets: &[Facet::Name, Facet::MediaType, Facet::Url],
+                fields: false,
             },
         ),
         (
@@ -304,10 +308,6 @@ fn carries_unreachable_detail(family: &str, metadata: &Value) -> bool {
             !distribution.is_array() || distribution.as_array().is_some_and(|d| !d.is_empty())
         }),
         "arcgis" => metadata.pointer("/properties/url").is_some(),
-        "stac" => metadata
-            .get("assets")
-            .and_then(Value::as_object)
-            .is_some_and(|assets| !assets.is_empty()),
         "ogc_csw" => metadata
             .get("online_resources")
             .and_then(Value::as_array)

--- a/crates/ceres-core/src/schema.rs
+++ b/crates/ceres-core/src/schema.rs
@@ -37,8 +37,13 @@
 //!   `resource.columns_*` arrays rather than a resource array. Its resource is
 //!   synthesized too, and unlike OpenDataSoft it does carry a URL: the SODA
 //!   endpoint is rebuilt from the payload's own domain and dataset identifier.
-//! - ArcGIS Hub and STAC harvest resource detail into shapes this module does
-//!   not yet read; see the resource-parity suite in
+//! - A STAC Collection keys its artifacts by name in an `assets` object rather
+//!   than listing them, so they are read from there. Its `links` are the catalog
+//!   navigation graph, not distributions, and are deliberately skipped: a
+//!   collection with no assets yields no resources, because its data lives in
+//!   its Items, which Ceres does not harvest.
+//! - ArcGIS Hub harvests resource detail into a shape this module does not yet
+//!   read; see the resource-parity suite in
 //!   `ceres-client/tests/resource_parity.rs` for the current baseline.
 
 use serde::Serialize;
@@ -93,6 +98,10 @@ impl DatasetSchema {
             .or_else(|| socrata_table(metadata))
             .into_iter()
             .collect();
+
+        // STAC keys its artifacts by name instead of listing them, so they are
+        // invisible to the array walk below.
+        resources.extend(stac_assets(metadata));
 
         for key in [
             "resources",
@@ -389,6 +398,59 @@ fn socrata_table(metadata: &Value) -> Option<DatasetResource> {
     // A Discovery envelope with nothing to say about its table is not a
     // resource, by the same rule the generic path applies.
     .filter(is_informative)
+}
+
+/// Reads a STAC Collection's `assets` as normalized resources.
+///
+/// STAC carries a collection's downloadable artifacts in `assets`, a **keyed
+/// object** rather than an array, so the array walk in
+/// [`DatasetSchema::from_metadata`] never sees them. Each value is an asset
+/// object whose fields map onto the normalized shape directly: `href` is the
+/// URL, `type` the media type, and `title` the name — falling back to the asset
+/// key (`thumbnail`, `data`, `zarr`) when the publisher supplied no title, since
+/// the key is the name STAC itself addresses the asset by.
+///
+/// `type` is a media type rather than a format label, so `format` stays `None`
+/// instead of being invented from it — the same restraint the OGC CSW path
+/// applies to an access protocol.
+///
+/// **`links` are deliberately not read.** They are STAC's navigation graph
+/// (`self`, `root`, `parent`, `child`, `items`, `next`), not the collection's
+/// distributions: `rel="items"` returns further STAC JSON to walk rather than
+/// the data, and its shape is uniform across every collection in a catalog, so
+/// reading it would add one resource of no information to each. Assets alone
+/// represent what the collection published. A collection with no assets
+/// therefore yields no resources — the honest answer, since its data lives in
+/// its Items, which Ceres does not harvest.
+///
+/// Recognized by `stac_version`, which the spec requires on every Collection and
+/// which no other supported family emits, guarding against a keyed `assets`
+/// object meaning something else elsewhere. Iteration follows the asset key:
+/// `serde_json` maps are ordered, so the result is stable across runs.
+fn stac_assets(metadata: &Value) -> Vec<DatasetResource> {
+    if !metadata.get("stac_version").is_some_and(Value::is_string) {
+        return Vec::new();
+    }
+    let Some(assets) = metadata.get("assets").and_then(Value::as_object) else {
+        return Vec::new();
+    };
+
+    assets
+        .iter()
+        .filter(|(_, asset)| asset.is_object())
+        .filter_map(|(key, asset)| {
+            Some(DatasetResource {
+                name: first_str(asset, &["title"])
+                    .or_else(|| (!key.is_empty()).then(|| key.clone())),
+                format: None,
+                media_type: first_str(asset, &["type"]),
+                url: first_str(asset, &["href"]),
+                description: first_str(asset, &["description"]),
+                fields: Vec::new(),
+            })
+            .filter(is_informative)
+        })
+        .collect()
 }
 
 /// Zips Socrata's parallel `columns_*` arrays into column-level fields.
@@ -1034,6 +1096,106 @@ mod tests {
                 "{metadata} should yield no resource"
             );
         }
+    }
+
+    /// A trimmed STAC Collection, in the shape the client persists.
+    fn stac_collection(assets: Value) -> Value {
+        json!({
+            "stac_version": "1.0.0",
+            "type": "Collection",
+            "id": "sentinel-2-l2a",
+            "title": "Sentinel-2 Level 2A",
+            "license": "proprietary",
+            "assets": assets,
+            "links": [
+                {"rel": "self", "href": "https://catalog.test/collections/sentinel-2-l2a",
+                 "type": "application/json"},
+                {"rel": "items", "href": "https://catalog.test/collections/sentinel-2-l2a/items",
+                 "type": "application/geo+json"}
+            ]
+        })
+    }
+
+    #[test]
+    fn stac_keyed_assets_become_resources() {
+        let metadata = stac_collection(json!({
+            "thumbnail": {
+                "href": "https://catalog.test/thumb.png",
+                "type": "image/png",
+                "roles": ["thumbnail"]
+            },
+            "zarr": {
+                "href": "https://catalog.test/cube.zarr",
+                "type": "application/vnd+zarr",
+                "title": "Analysis-ready cube",
+                "description": "Chunked for time-series access",
+                "roles": ["data"]
+            }
+        }));
+
+        let schema = DatasetSchema::from_metadata(&metadata);
+        assert_eq!(schema.resources.len(), 2);
+
+        // Assets are keyed, not ordered; iteration follows the key.
+        let thumbnail = &schema.resources[0];
+        assert_eq!(thumbnail.name.as_deref(), Some("thumbnail"));
+        assert_eq!(thumbnail.media_type.as_deref(), Some("image/png"));
+        assert_eq!(
+            thumbnail.url.as_deref(),
+            Some("https://catalog.test/thumb.png")
+        );
+        // `type` is a media type; no format is invented from it.
+        assert_eq!(thumbnail.format, None);
+
+        let zarr = &schema.resources[1];
+        assert_eq!(zarr.name.as_deref(), Some("Analysis-ready cube"));
+        assert_eq!(zarr.media_type.as_deref(), Some("application/vnd+zarr"));
+        assert_eq!(zarr.url.as_deref(), Some("https://catalog.test/cube.zarr"));
+        assert_eq!(
+            zarr.description.as_deref(),
+            Some("Chunked for time-series access")
+        );
+    }
+
+    #[test]
+    fn stac_links_are_not_resources() {
+        // `links` is STAC's navigation graph, not the collection's
+        // distributions. A collection with no assets exposes nothing, rather
+        // than one resource per catalog rel.
+        let schema = DatasetSchema::from_metadata(&stac_collection(json!({})));
+        assert!(schema.resources.is_empty());
+    }
+
+    #[test]
+    fn stac_assets_need_the_collection_signature() {
+        // A keyed `assets` object on some other family's payload is not a STAC
+        // collection, and an array-valued `assets` is not the keyed map either.
+        for metadata in [
+            json!({"assets": {"data": {"href": "https://example.org/a.tif"}}}),
+            json!({"stac_version": "1.0.0",
+                   "assets": [{"href": "https://example.org/a.tif"}]}),
+        ] {
+            assert!(
+                DatasetSchema::from_metadata(&metadata).resources.is_empty(),
+                "{metadata} is not a STAC collection with keyed assets"
+            );
+        }
+    }
+
+    #[test]
+    fn stac_degenerate_assets_are_skipped() {
+        let metadata = stac_collection(json!({
+            // Not an object: nothing to normalize, and the key alone would
+            // otherwise invent a resource out of a bare string.
+            "broken": "https://catalog.test/a.tif",
+            // An object with nothing in it and no key to fall back on.
+            "": {},
+            "data": {"href": "https://catalog.test/a.tif"}
+        }));
+
+        let schema = DatasetSchema::from_metadata(&metadata);
+        assert_eq!(schema.resources.len(), 1);
+        assert_eq!(schema.resources[0].name.as_deref(), Some("data"));
     }
 
     #[test]

--- a/crates/ceres-core/src/schema.rs
+++ b/crates/ceres-core/src/schema.rs
@@ -419,7 +419,7 @@ fn socrata_table(metadata: &Value) -> Option<DatasetResource> {
     .filter(is_informative)
 }
 
-/// Reads a STAC Collection's `assets` as normalized resources.
+/// Reads a STAC object's `assets` as normalized resources.
 ///
 /// STAC carries a collection's downloadable artifacts in `assets`, a **keyed
 /// object** rather than an array, so the array walk in
@@ -442,10 +442,17 @@ fn socrata_table(metadata: &Value) -> Option<DatasetResource> {
 /// therefore yields no resources — the honest answer, since its data lives in
 /// its Items, which Ceres does not harvest.
 ///
-/// Recognized by `stac_version`, which the spec requires on every Collection and
-/// which no other supported family emits, guarding against a keyed `assets`
-/// object meaning something else elsewhere. Iteration follows the asset key:
-/// `serde_json` maps are ordered, so the result is stable across runs.
+/// Recognized by `stac_version` alone — deliberately any STAC object, not
+/// Collections specifically. Ceres harvests Collections, so that is what this
+/// sees in practice, but `assets` has the same shape on an Item, so narrowing
+/// the guard to `type == "Collection"` would buy no correctness while risking
+/// the silent loss of every collection from a portal that omits `type`. A
+/// Catalog has no `assets` and so yields nothing either way. What the guard is
+/// for is the opposite direction: keeping a keyed `assets` object that means
+/// something else on a non-STAC payload from being read as artifacts.
+///
+/// Iteration follows the asset key, so the result is stable for a given
+/// payload.
 fn stac_assets(metadata: &Value) -> Vec<DatasetResource> {
     if !metadata.get("stac_version").is_some_and(Value::is_string) {
         return Vec::new();
@@ -1155,21 +1162,27 @@ mod tests {
         let schema = DatasetSchema::from_metadata(&metadata);
         assert_eq!(schema.resources.len(), 2);
 
-        // Assets are keyed, not ordered; iteration follows the key.
-        let thumbnail = &schema.resources[0];
+        // Assets are keyed rather than ordered, so each is located by its URL:
+        // what matters here is the mapping, not the order it comes out in.
+        let by_url = |url: &str| {
+            schema
+                .resources
+                .iter()
+                .find(|r| r.url.as_deref() == Some(url))
+                .unwrap_or_else(|| panic!("no resource for {url}"))
+        };
+
+        // No title: the asset key names the resource.
+        let thumbnail = by_url("https://catalog.test/thumb.png");
         assert_eq!(thumbnail.name.as_deref(), Some("thumbnail"));
         assert_eq!(thumbnail.media_type.as_deref(), Some("image/png"));
-        assert_eq!(
-            thumbnail.url.as_deref(),
-            Some("https://catalog.test/thumb.png")
-        );
         // `type` is a media type; no format is invented from it.
         assert_eq!(thumbnail.format, None);
 
-        let zarr = &schema.resources[1];
+        // A title wins over the key.
+        let zarr = by_url("https://catalog.test/cube.zarr");
         assert_eq!(zarr.name.as_deref(), Some("Analysis-ready cube"));
         assert_eq!(zarr.media_type.as_deref(), Some("application/vnd+zarr"));
-        assert_eq!(zarr.url.as_deref(), Some("https://catalog.test/cube.zarr"));
         assert_eq!(
             zarr.description.as_deref(),
             Some("Chunked for time-series access")


### PR DESCRIPTION
Closes #205. Part of #68.

> **Stacked on #212** (`fix/207-phantom-resources`), which it uses for the shared `is_informative` rule. Base retargets to `master` automatically once #212 merges. Review the [second commit](https://github.com/AndreaBozzo/Ceres/pull/213/commits) only.

## Problem

STAC carries a collection's downloadable artifacts in `assets` — a **keyed object**, not an array — so the array walk in `DatasetSchema::from_metadata` never saw them, and all 2,263 harvested collections scored zero resources.

## Mapping

| STAC asset | Normalized resource |
|---|---|
| `href` | `url` |
| `type` | `media_type` |
| `title`, falling back to the asset key | `name` |
| `description` | `description` |

The asset key (`thumbnail`, `data`, `zarr`) is the name STAC itself addresses the asset by, so it is the natural fallback.

`type` is a media type rather than a format label, so **`format` stays `None`** instead of being invented from it — the same restraint the OGC CSW path applies to an access protocol.

## Decision: `links` are not resources

The issue asked whether `links` (`rel=items`, `data`) should also become resources, or whether assets alone represent the collection's distributions. **Assets alone**, documented on `stac_assets`:

- `links` is STAC's navigation graph — `self`, `root`, `parent`, `child`, `items`, `next`. Traversal, not distribution.
- `rel="items"` returns further STAC JSON to walk, not the data. Presenting it as a distribution would tell a consumer "here is a download" when it is not.
- Its shape is uniform across every collection in a catalog, so reading it would add exactly one resource of no information to each — the same coverage inflation #207 just removed at the node level.

A collection with no assets therefore yields no resources. That is the honest answer: its data lives in its Items, which Ceres does not harvest.

This also means no navigational-rel filtering is needed — assets are artifacts by definition, and `thumbnail` is a genuine one.

## Recognition

Guarded by `stac_version`, which the spec requires on every Collection and which no other supported family emits, so a keyed `assets` object meaning something else elsewhere is not misread. Iteration follows the asset key; `serde_json` maps are ordered, so results are stable across runs.

## Acceptance criteria

- [x] The `stac` row in `crates/ceres-client/tests/resource_parity.rs` moves from `Expect::Gap` to `Expect::Resources` (`Name`, `MediaType`, `Url`). ArcGIS Hub (#206) is now the last gap.
- [x] The `links` choice is documented, on `stac_assets` and in the module-level limitations.

## Tests

Four new cases in `ceres_core::schema`. The two positive ones were confirmed to fail against the unfixed code:

- `stac_keyed_assets_become_resources` — both the key fallback and the `title` path, and that no format is invented from `type`
- `stac_degenerate_assets_are_skipped` — a non-object asset value, and an empty key with an empty object

The other two guard against over-reach, so they pass with and without the change by design:

- `stac_links_are_not_resources`
- `stac_assets_need_the_collection_signature` — a keyed `assets` object without `stac_version`, and an array-valued `assets`

The shared parity fixture gains a second, titled `zarr` asset alongside the existing thumbnail, so the parity row exercises the `title` path against the real client's persisted metadata rather than only the key fallback.

`cargo fmt --all -- --check`, `cargo test -p ceres-core -p ceres-client`, and `cargo clippy --workspace --all-targets --all-features -- -D warnings` all pass.