### PR TITLE
feat(arcgis): expose the service endpoint as a normalized resource (#206)

### DIFF
--- a/crates/ceres-client/tests/resource_parity.rs
+++ b/crates/ceres-client/tests/resource_parity.rs
@@ -13,19 +13,27 @@
 //!
 //! # Reading the expectation table
 //!
-//! [`expectations`] records, per family, what resource detail is reachable
-//! **today**. Families whose source payload carries resource detail that
-//! [`DatasetSchema`] cannot yet reach are marked [`Expect::Gap`] with the
-//! tracking issue. Those rows assert the gap is still *exactly* as described,
-//! so closing one without updating this table fails the suite rather than
-//! silently drifting — the table is the milestone's ratchet, not a wishlist.
+//! [`expectations`] records, per family, which resource facets are reachable.
+//! Every supported family now reaches its resource detail, so the table is a
+//! floor rather than a ratchet: a family that stops populating a listed facet
+//! fails here, and a new family arrives with a row of its own.
+//!
+//! It is a floor, not a wishlist. A row lists only the facets the family's
+//! source payload genuinely provides — the OGC CSW fixture carries no format,
+//! and an ArcGIS service has no media type — so a facet is added when the
+//! mapping starts producing it, never in anticipation.
+//!
+//! Until #206 closed the last gap, families whose detail `DatasetSchema` could
+//! not yet reach were carried here as `Expect::Gap` rows naming the tracking
+//! issue and the key their detail lived in. See the history of this file for
+//! that shape if a future client family lands with detail left unreached.
 
 use std::collections::BTreeMap;
 
 use ceres_core::schema::DatasetSchema;
 use ceres_core::traits::PortalClient;
 use ceres_core::{DatasetResource, NewDataset};
-use serde_json::{Value, json};
+use serde_json::json;
 use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -39,23 +47,15 @@ use ceres_client::{
 // ---------------------------------------------------------------------------
 
 /// What a portal family is expected to yield through `DatasetSchema`.
+///
+/// Asserts that at least one harvested dataset exposes a resource populating
+/// each listed facet.
 #[derive(Debug)]
-enum Expect {
-    /// The family reaches its resource detail. Asserts at least one dataset
-    /// exposes a resource whose listed facets are populated.
-    Resources {
-        /// Facets that must be non-`None` on at least one resource.
-        facets: &'static [Facet],
-        /// Whether at least one resource must carry column-level fields.
-        fields: bool,
-    },
-    /// The source payload carries resource detail that `DatasetSchema` cannot
-    /// reach yet. `where_it_lives` documents the key holding it, so the row
-    /// doubles as the specification for closing the gap.
-    Gap {
-        issue: &'static str,
-        where_it_lives: &'static str,
-    },
+struct Expect {
+    /// Facets that must be non-`None` on at least one resource.
+    facets: &'static [Facet],
+    /// Whether at least one resource must carry column-level fields.
+    fields: bool,
 }
 
 /// A normalized resource facet, named so failures point at a concrete field.
@@ -81,35 +81,35 @@ impl Facet {
 /// The reachability baseline, one row per portal family.
 ///
 /// Measured against the live index at the time of writing: of 2.62M harvested
-/// datasets, the `Resources` rows below account for ~1.47M with reachable
-/// resources, while the `Gap` rows account for ~25k whose detail is harvested
-/// but unreachable — the 25,154 ArcGIS Hub items of #206, now that STAC's 2,263
-/// collections read their assets.
+/// datasets, ~1.47M had reachable resources when this table was first written,
+/// with 27k more behind the two gaps that #205 and #206 have since closed —
+/// STAC's 2,263 collections and ArcGIS Hub's 25,154 items.
 ///
-/// A `Resources` row means the family's detail is reachable *where the portal
-/// published it*, not that every dataset in the family has some. OpenDataSoft
-/// is the clearest case: 58,510 of its 170,144 harvested datasets yield an
-/// informative resource, because ODS ships an empty column schema for every
-/// dataset that carries no records.
+/// A row means the family's detail is reachable *where the portal published
+/// it*, not that every dataset in the family has some. OpenDataSoft is the
+/// clearest case: 58,510 of its 170,144 harvested datasets yield a resource,
+/// because ODS ships an empty column schema for every dataset that carries no
+/// records. ArcGIS Hub is the same story for a different reason: items that are
+/// uploaded files rather than services publish no endpoint to point at.
 fn expectations() -> BTreeMap<&'static str, Expect> {
     BTreeMap::from([
         (
             "ckan",
-            Expect::Resources {
+            Expect {
                 facets: &[Facet::Name, Facet::Format, Facet::MediaType, Facet::Url],
                 fields: true,
             },
         ),
         (
             "project_open_data",
-            Expect::Resources {
+            Expect {
                 facets: &[Facet::Name, Facet::Format, Facet::Url],
                 fields: false,
             },
         ),
         (
             "dcat_udata",
-            Expect::Resources {
+            Expect {
                 facets: &[Facet::Name, Facet::Format, Facet::MediaType, Facet::Url],
                 fields: false,
             },
@@ -119,7 +119,7 @@ fn expectations() -> BTreeMap<&'static str, Expect> {
             // arrays, addressed by the SODA endpoint rebuilt from the payload's
             // own domain and four-by-four identifier.
             "socrata",
-            Expect::Resources {
+            Expect {
                 facets: &[Facet::Name, Facet::Format, Facet::MediaType, Facet::Url],
                 fields: true,
             },
@@ -130,17 +130,19 @@ fn expectations() -> BTreeMap<&'static str, Expect> {
             // absolute one. `Url` and `MediaType` come from the attachments and
             // alternative exports hanging off it, which do.
             "opendatasoft",
-            Expect::Resources {
+            Expect {
                 facets: &[Facet::Name, Facet::MediaType, Facet::Url],
                 fields: true,
             },
         ),
         (
+            // A Hub item is a service, not a file: one resource, the endpoint
+            // at `properties.url`, typed by `properties.type`. The root answers
+            // in whatever `f=` asks for, so no media type is expected.
             "arcgis",
-            Expect::Gap {
-                issue: "#206",
-                where_it_lives: "`properties.url` — the service endpoint, with `properties.type` \
-                                 as its format",
+            Expect {
+                facets: &[Facet::Name, Facet::Format, Facet::Url],
+                fields: false,
             },
         ),
         (
@@ -148,7 +150,7 @@ fn expectations() -> BTreeMap<&'static str, Expect> {
             // `type` is a media type, so no format is expected; `links` are
             // navigation rather than distributions and are not read at all.
             "stac",
-            Expect::Resources {
+            Expect {
                 facets: &[Facet::Name, Facet::MediaType, Facet::Url],
                 fields: false,
             },
@@ -160,7 +162,7 @@ fn expectations() -> BTreeMap<&'static str, Expect> {
             // `protocol` split is unit-tested against all three real-world
             // shapes in `ceres_core::schema`.
             "ogc_csw",
-            Expect::Resources {
+            Expect {
                 facets: &[Facet::Url],
                 fields: false,
             },
@@ -211,50 +213,25 @@ async fn every_client_family_matches_its_documented_resource_reachability() {
             .flat_map(|schema| schema.resources.iter())
             .collect();
 
-        match &expectations[family] {
-            Expect::Resources { facets, fields } => {
-                assert!(
-                    !resources.is_empty(),
-                    "{family}: expected reachable resources but DatasetSchema found none — \
-                     the client stopped preserving resource detail in `metadata`"
-                );
+        let Expect { facets, fields } = &expectations[family];
+        assert!(
+            !resources.is_empty(),
+            "{family}: expected reachable resources but DatasetSchema found none — \
+             the client stopped preserving resource detail in `metadata`"
+        );
 
-                for facet in *facets {
-                    assert!(
-                        resources.iter().any(|r| facet.get(r).is_some()),
-                        "{family}: no resource populated {facet:?}, though the source payload \
-                         provides it"
-                    );
-                }
+        for facet in *facets {
+            assert!(
+                resources.iter().any(|r| facet.get(r).is_some()),
+                "{family}: no resource populated {facet:?}, though the source payload provides it"
+            );
+        }
 
-                if *fields {
-                    assert!(
-                        resources.iter().any(|r| !r.fields.is_empty()),
-                        "{family}: no resource carried column-level fields"
-                    );
-                }
-            }
-            Expect::Gap {
-                issue,
-                where_it_lives,
-            } => {
-                assert!(
-                    resources.is_empty(),
-                    "{family}: resources are now reachable ({} found) — the {issue} gap is \
-                     closed, so move this row to Expect::Resources. Detail lived in: \
-                     {where_it_lives}",
-                    resources.len()
-                );
-
-                assert!(
-                    datasets
-                        .iter()
-                        .any(|dataset| carries_unreachable_detail(family, &dataset.metadata)),
-                    "{family}: the mock payload no longer carries the unreachable resource \
-                     detail this row describes ({where_it_lives}), so the gap assertion is \
-                     vacuous"
-                );
-            }
+        if *fields {
+            assert!(
+                resources.iter().any(|r| !r.fields.is_empty()),
+                "{family}: no resource carried column-level fields"
+            );
         }
     }
 }
@@ -297,23 +274,6 @@ async fn dcat_resource_smoke() {
         "{portal_url}: no dataset exposed an informative resource, so `@graph` \
          distribution resolution is not reaching real portal payloads"
     );
-}
-
-/// Confirms a `Gap` family really does hold resource detail in `metadata`, so
-/// the "still empty" assertion above cannot pass vacuously against a payload
-/// that simply has no resources to find.
-fn carries_unreachable_detail(family: &str, metadata: &Value) -> bool {
-    match family {
-        "dcat_udata" => metadata.get("distribution").is_some_and(|distribution| {
-            !distribution.is_array() || distribution.as_array().is_some_and(|d| !d.is_empty())
-        }),
-        "arcgis" => metadata.pointer("/properties/url").is_some(),
-        "ogc_csw" => metadata
-            .get("online_resources")
-            .and_then(Value::as_array)
-            .is_some_and(|resources| !resources.is_empty()),
-        _ => false,
-    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/ceres-core/src/schema.rs
+++ b/crates/ceres-core/src/schema.rs
@@ -43,9 +43,14 @@
 //!   navigation graph, not distributions, and are deliberately skipped: a
 //!   collection with no assets yields no resources, because its data lives in
 //!   its Items, which Ceres does not harvest.
-//! - ArcGIS Hub harvests resource detail into a shape this module does not yet
-//!   read; see the resource-parity suite in
-//!   `ceres-client/tests/resource_parity.rs` for the current baseline.
+//! - An ArcGIS Hub item is a service rather than a file, so it yields exactly
+//!   one resource: the endpoint at `properties.url`, typed by
+//!   `properties.type`. The service root only — deriving its layer and query
+//!   endpoints would mean probing the service at harvest time. An item that
+//!   publishes no URL yields no resource.
+//!
+//! The resource-parity suite in `ceres-client/tests/resource_parity.rs` holds
+//! the per-family reachability table this module is measured against.
 
 use serde::Serialize;
 use serde_json::Value;
@@ -103,6 +108,7 @@ impl DatasetSchema {
         // STAC keys its artifacts by name instead of listing them, so they are
         // invisible to the array walk below.
         resources.extend(stac_assets(metadata));
+        resources.extend(arcgis_service(metadata));
 
         for key in [
             "resources",
@@ -417,6 +423,60 @@ fn socrata_table(metadata: &Value) -> Option<DatasetResource> {
     // A Discovery envelope with nothing to say about its table is not a
     // resource, by the same rule the generic path applies.
     .filter(is_informative)
+}
+
+/// Exposes an ArcGIS Hub item's service endpoint as its single resource.
+///
+/// An ArcGIS Hub item is a **service, not a file**, so it has no resource array
+/// to walk: the one thing it publishes is the endpoint at `properties.url`,
+/// with `properties.type` (`Feature Service`, `Map Service`, `Image Service`)
+/// naming what answers there. That is a format in the same sense an OGC
+/// `protocol` of `OGC:WFS` is one — it says what the endpoint speaks — so it is
+/// carried verbatim rather than reduced to an abbreviation.
+///
+/// **One resource per service.** This differs from the file-per-resource model
+/// of the other families, and deliberately so:
+///
+/// - Only the service **root** is exposed. The standard export endpoints
+///   (`/0`, `/query?f=geojson`) need a layer index, and the layer set of a
+///   `FeatureServer` or `MapServer` is only knowable by asking the service. A
+///   synthesized `/0/query` would be wrong for every service whose layers do
+///   not start at zero, and meaningless for an `ImageServer`. Since resolving
+///   that would mean probing the service at harvest time — network I/O per
+///   item, on catalogs of tens of thousands — the root is the honest stopping
+///   point, and a consumer that wants layers can walk it themselves.
+/// - No media type is set. The root answers as HTML or JSON depending on the
+///   `f=` query parameter, so no single one describes it.
+///
+/// The resource takes `properties.name` — the service's own name
+/// (`Remarkable_Trees`) — rather than `properties.title`, which is the item
+/// title the dataset already carries. Its description is likewise left to the
+/// dataset, as for the OpenDataSoft and Socrata tables.
+///
+/// Returns `None` without a `properties.url`. Hub items that are uploaded files
+/// rather than services carry none in the search payload, so there is no
+/// endpoint to point at, and their item type alone is not a distribution.
+///
+/// Recognized by `orgId`/`typeKeywords`, ArcGIS item fields that no other
+/// supported family emits, so a `properties.url` on some other GeoJSON payload
+/// is not misread as a service.
+fn arcgis_service(metadata: &Value) -> Option<DatasetResource> {
+    let properties = metadata.get("properties").filter(|p| p.is_object())?;
+    if !["orgId", "typeKeywords"]
+        .iter()
+        .any(|key| properties.get(*key).is_some())
+    {
+        return None;
+    }
+
+    Some(DatasetResource {
+        name: first_str(properties, &["name"]),
+        format: first_str(properties, &["type"]),
+        media_type: None,
+        url: Some(first_str(properties, &["url"])?),
+        description: None,
+        fields: Vec::new(),
+    })
 }
 
 /// Reads a STAC object's `assets` as normalized resources.
@@ -1122,6 +1182,90 @@ mod tests {
                 "{metadata} should yield no resource"
             );
         }
+    }
+
+    /// A trimmed ArcGIS Hub item, in the shape the client persists.
+    fn arcgis_item(properties: Value) -> Value {
+        let mut item = json!({
+            "type": "Feature",
+            "id": "a1b2c3d4",
+            "geometry": null,
+            "properties": {
+                "id": "a1b2c3d4",
+                "title": "Remarkable Trees",
+                "name": "Remarkable_Trees",
+                "type": "Feature Service",
+                "typeKeywords": ["ArcGIS Server", "Data", "Feature Service", "Service"],
+                "owner": "ExampleGIS",
+                "orgId": "AbCdEfGhIjKlMnOp",
+                "snippet": "Inventory of remarkable trees.",
+                "url": "https://services.arcgis.com/AbCdEfGhIjKlMnOp/arcgis/rest/services/Remarkable_Trees/FeatureServer"
+            }
+        });
+        for (key, value) in properties.as_object().unwrap() {
+            item["properties"][key] = value.clone();
+        }
+        item
+    }
+
+    #[test]
+    fn arcgis_service_endpoint_becomes_one_resource() {
+        let schema = DatasetSchema::from_metadata(&arcgis_item(json!({})));
+        assert_eq!(schema.resources.len(), 1);
+        let r = &schema.resources[0];
+
+        // The service's own name, not the item title the dataset already carries.
+        assert_eq!(r.name.as_deref(), Some("Remarkable_Trees"));
+        // The ArcGIS item type names the service, as an OGC protocol does.
+        assert_eq!(r.format.as_deref(), Some("Feature Service"));
+        assert_eq!(
+            r.url.as_deref(),
+            Some(
+                "https://services.arcgis.com/AbCdEfGhIjKlMnOp/arcgis/rest/services/Remarkable_Trees/FeatureServer"
+            )
+        );
+        // The service root answers in whatever `f=` asks for, so no media type
+        // is invented; the item carries no column schema either.
+        assert_eq!(r.media_type, None);
+        assert!(r.fields.is_empty());
+        // The dataset already carries its own description.
+        assert_eq!(r.description, None);
+    }
+
+    #[test]
+    fn arcgis_item_without_a_service_url_yields_no_resource() {
+        // Hub items that are uploaded files rather than services carry no URL
+        // in the search payload, so there is no endpoint to point at. Their
+        // item type alone is not a distribution.
+        for url in [Value::Null, json!(""), json!(42)] {
+            let metadata = arcgis_item(json!({"url": url.clone(), "type": "CSV"}));
+            assert!(
+                DatasetSchema::from_metadata(&metadata).resources.is_empty(),
+                "url {url} is not a service endpoint"
+            );
+        }
+    }
+
+    #[test]
+    fn arcgis_service_without_a_name_still_exposes_its_endpoint() {
+        let mut metadata = arcgis_item(json!({}));
+        metadata["properties"]["name"] = Value::Null;
+
+        let r = &DatasetSchema::from_metadata(&metadata).resources[0];
+        assert_eq!(r.name, None);
+        assert_eq!(r.format.as_deref(), Some("Feature Service"));
+        assert!(r.url.is_some());
+    }
+
+    #[test]
+    fn arcgis_needs_the_item_signature() {
+        // A `properties.url` on some other family's GeoJSON payload is not an
+        // ArcGIS Hub item; `orgId`/`typeKeywords` are what make it one.
+        let metadata = json!({
+            "type": "Feature",
+            "properties": {"url": "https://example.org/service", "type": "Feature Service"}
+        });
+        assert!(DatasetSchema::from_metadata(&metadata).resources.is_empty());
     }
 
     /// A trimmed STAC Collection, in the shape the client persists.


### PR DESCRIPTION
Closes #206. Part of #68. **Closes the last row of the resource-parity gap table.**

> **Stacked on #213** (`feat/205-stac-assets`), itself stacked on #212. Base retargets automatically as those merge. Review the [last commit](https://github.com/AndreaBozzo/Ceres/pull/214/commits) only.

## Problem

25,154 harvested ArcGIS Hub items expose a service endpoint at `properties.url` that `DatasetSchema::from_metadata` never read, so they all scored zero resources.

## Semantics: one resource per service

This differs from the file-per-resource model of the other families, which the issue asked to have documented. An ArcGIS Hub item **is a service, not a file**, so it yields exactly one resource:

| ArcGIS item | Normalized resource |
|---|---|
| `properties.url` | `url` |
| `properties.type` (`Feature Service`, `Map Service`) | `format` |
| `properties.name` | `name` |
| — | `media_type`, `description`, `fields` all empty |

- **`type` as format** is the same call the OGC CSW path already makes for a `protocol` of `OGC:WFS` — it says what the endpoint speaks. Carried verbatim rather than reduced to an abbreviation.
- **`name`, not `title`.** `properties.name` is the service's own name (`Remarkable_Trees`); `properties.title` is the item title the dataset already carries. Its description is likewise left to the dataset, as for the OpenDataSoft and Socrata tables.
- **No media type.** The service root answers as HTML or JSON depending on the `f=` query parameter, so no single one describes it.

## Decision: service root only

The issue asked whether to synthesize the standard export endpoints. **No** — they cannot be derived reliably:

- `/query?f=geojson` and `/0` need a layer index, and the layer set of a `FeatureServer` or `MapServer` is only knowable by asking the service.
- A synthesized `/0/query` would be wrong for every service whose layers do not start at zero, and meaningless for an `ImageServer`.
- Resolving that would mean **probing the service at harvest time** — network I/O per item, on catalogs of tens of thousands — which the issue rules out.

The root is the honest stopping point; a consumer that wants layers can walk it themselves.

## No URL, no resource

Hub items that are uploaded files rather than services carry no `properties.url` in the search payload (the fixture's CSV item is one), so there is no endpoint to point at, and their item type alone is not a distribution. Recognized by `orgId`/`typeKeywords`, ArcGIS item fields that no other supported family emits.

## The gap table retires

With `arcgis` moved to a facet row, no family is a gap any more. Rather than leave `Expect::Gap` and `carries_unreachable_detail` unconstructed behind a dead-code allow, they are removed and `Expect` collapses to a struct. The module doc records what the table now means — a floor every family must clear, listing only facets the payload genuinely provides — and points at this file's history for the gap-row shape, should a future client family land with detail left unreached.

This is forced rather than optional: `-D warnings` fails on the unconstructed variant.

## Acceptance criteria

- [x] The `arcgis` row moves from `Expect::Gap` to a facet row (`Name`, `Format`, `Url`).
- [x] The "one resource per service" semantics are documented, on `arcgis_service` and in the module-level limitations.

## Tests

Four new cases in `ceres_core::schema`. The two positive ones were confirmed to fail against the unfixed code:

- `arcgis_service_endpoint_becomes_one_resource`
- `arcgis_service_without_a_name_still_exposes_its_endpoint`

The other two guard against over-reach and pass with and without the change by design:

- `arcgis_item_without_a_service_url_yields_no_resource` — null, empty, and non-string URLs
- `arcgis_needs_the_item_signature`

`cargo fmt --all -- --check`, `cargo test -p ceres-core -p ceres-client`, and `cargo clippy --workspace --all-targets --all-features -- -D warnings` all pass.