### PR TITLE
fix(csw): read Dublin Core links published as dc:URI, not only dct:references

### DIFF
--- a/crates/ceres-client/src/ogc_records.rs
+++ b/crates/ceres-client/src/ogc_records.rs
@@ -464,22 +464,34 @@ fn parse_record(
         })
         .unwrap_or_default();
     let record_kind = classify_kind(&scope);
-    // Dublin Core has no `CI_OnlineResource`; it carries the same links as
-    // `dct:references`, whose `scheme` attribute (`WMS`, `WFS`, `alternate.json`)
-    // occupies the slot ISO calls `protocol` — the same slot
-    // `ceres_core::schema` already reads a service type out of.
+    // Dublin Core has no `CI_OnlineResource`. It carries its links in one of
+    // two shapes, and both occur among the catalogues Ceres harvests, so both
+    // are read:
+    //
+    // * `dct:references scheme="WMS"` — Italy's RNDT;
+    // * `dc:URI protocol="OGC:WMS" name="…" description="…"` — GeoNetwork's own
+    //   output, which is richer and is what Eurac publishes.
+    //
+    // Either way the service identifier lands in the slot ISO calls `protocol`,
+    // the same slot `ceres_core::schema::split_protocol` reads a format or a
+    // media type out of.
     let dublin_core_resources: Vec<Value> = node
         .descendants()
-        .filter(|n| local(*n) == "references")
+        .filter(|n| matches!(local(*n), "references" | "URI"))
         .filter_map(|n| {
             let url = node_value(n)?;
-            let protocol = n.attribute("scheme").map(str::to_owned);
-            let downloadable = protocol.as_deref().is_some_and(|scheme| {
-                let scheme = scheme.to_ascii_lowercase();
-                scheme.contains("download") || scheme.contains("wfs")
+            let protocol = n
+                .attribute("scheme")
+                .or_else(|| n.attribute("protocol"))
+                .map(str::to_owned);
+            let downloadable = protocol.as_deref().is_some_and(|protocol| {
+                let protocol = protocol.to_ascii_lowercase();
+                protocol.contains("download") || protocol.contains("wfs")
             });
             Some(json!({
                 "url": url,
+                "name": n.attribute("name"),
+                "description": n.attribute("description"),
                 "protocol": protocol,
                 "function": Value::Null,
                 "downloadable": downloadable,
@@ -786,6 +798,58 @@ mod tests {
 
     const FIXTURE: &str = include_str!("../tests/fixtures/csw_get_records.xml");
     const DUBLIN_CORE: &str = include_str!("../tests/fixtures/csw_dublin_core.xml");
+    const DUBLIN_CORE_GEONETWORK: &str =
+        include_str!("../tests/fixtures/csw_dublin_core_geonetwork.xml");
+
+    /// GeoNetwork publishes links as `dc:URI protocol="OGC:WMS"` rather than
+    /// RNDT's `dct:references scheme="WMS"`. Reading only the latter left 362 of
+    /// Eurac's 363 harvested records with no reachable resource at all.
+    #[test]
+    fn geonetwork_dublin_core_uris_become_online_resources() {
+        use ceres_core::schema::DatasetSchema;
+
+        let page = parse_get_records(DUBLIN_CORE_GEONETWORK, "https://edp-portal.eurac.edu", "en")
+            .unwrap();
+        let record = &page.records[0];
+        assert_eq!(record.title, "World Land Cover Himalayas 2015");
+
+        let resources = record.metadata["online_resources"].as_array().unwrap();
+        assert!(!resources.is_empty());
+        let wms = resources
+            .iter()
+            .find(|r| r["protocol"] == "OGC:WMS")
+            .expect("the WMS service");
+        assert_eq!(wms["url"], "https://maps.eurac.edu/geoserver/ows");
+        // `name` and `description` are attributes here, unlike RNDT's shape,
+        // and they are what gives the normalized resource a usable label.
+        assert_eq!(wms["name"], "geonode:World_Land_Cover_Himalayas_2015_v1");
+
+        let normalized = DatasetSchema::from_metadata(
+            &OgcRecordsClient::into_new_dataset(
+                page.records.into_iter().next().unwrap(),
+                "https://edp-portal.eurac.edu",
+                None,
+                "en",
+            )
+            .metadata,
+        )
+        .resources;
+        assert!(!normalized.is_empty());
+        assert!(
+            normalized
+                .iter()
+                .any(|r| r.format.as_deref() == Some("WMS")),
+            "{normalized:?}"
+        );
+        // `protocol="image/png"` is a media type, not a service.
+        assert!(
+            normalized
+                .iter()
+                .any(|r| r.media_type.as_deref() == Some("image/png")),
+            "{normalized:?}"
+        );
+        assert!(normalized.iter().any(|r| r.name.is_some()));
+    }
 
     // -----------------------------------------------------------------------
     // Dublin Core profile (#242)

--- a/crates/ceres-client/tests/fixtures/csw_dublin_core_geonetwork.xml
+++ b/crates/ceres-client/tests/fixtures/csw_dublin_core_geonetwork.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  A real GeoNetwork Dublin Core record, taken verbatim from Eurac Research's
+  catalogue (edp-portal.eurac.edu) on 2026-08-05, wrapped in a GetRecords
+  envelope. One preview URL's `access_token` query parameter is replaced with
+  REDACTED; nothing else is altered.
+
+  This is the *other* Dublin Core link shape. Italy's RNDT publishes
+  `dct:references scheme="WMS"`; GeoNetwork publishes `dc:URI protocol="OGC:WMS"`
+  with a `name` and `description`. Generalizing from RNDT alone left 362 of
+  Eurac's 363 records with no reachable resource, which is what this fixture
+  exists to prevent recurring.
+-->
+<csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:ows="http://www.opengis.net/ows">
+  <csw:SearchStatus timestamp="2026-08-05T19:02:54Z"/>
+  <csw:SearchResults numberOfRecordsMatched="1" numberOfRecordsReturned="1" nextRecord="0" recordSchema="http://www.opengis.net/cat/csw/2.0.2" elementSet="full">
+    <csw:Record xmlns:geonet="http://www.fao.org/geonetwork" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ows="http://www.opengis.net/ows" xmlns:dct="http://purl.org/dc/terms/">
+      <dc:identifier>1a25539e-21c9-11ec-bf18-0050568ebac4</dc:identifier>
+      <dc:date>2023-09-14T17:00:33Z</dc:date>
+      <dc:title>World Land Cover Himalayas 2015</dc:title>
+      <dc:type>dataset</dc:type>
+      <dc:subject>ecosystem</dc:subject>
+      <dc:subject>landcover</dc:subject>
+      <dc:subject>Asia</dc:subject>
+      <dc:subject>China</dc:subject>
+      <dc:subject>Nepal</dc:subject>
+      <dc:subject>environment</dc:subject>
+      <dct:abstract>Downscaled land cover component of the World Terrestrial Ecosystem maps of the AI4EBV project.</dct:abstract>
+      <dc:description>Downscaled land cover component of the World Terrestrial Ecosystem maps of the AI4EBV project.</dc:description>
+      <dc:rights>license</dc:rights>
+      <dc:rights />
+      <dc:language>eng</dc:language>
+      <dc:source />
+      <ows:BoundingBox crs="urn:ogc:def:crs:EPSG:6.6:4326">
+        <ows:LowerCorner>27.01973558522765 84.94856806237871</ows:LowerCorner>
+        <ows:UpperCorner>28.928245496281214 87.1001363021547</ows:UpperCorner>
+      </ows:BoundingBox>
+      <dc:URI protocol="WWW:LINK-1.0-http--link" description="Online link to the 'World Land Cover Himalayas 2015' description on GeoNode">https://maps.eurac.edu/layers/World_Land_Cover_Himalayas_2015_v1:geonode:World_Land_Cover_Himalayas_2015_v1</dc:URI>
+      <dc:URI protocol="WWW:DOWNLOAD-1.0-http--download" name="World_Land_Cover_Himalayas_2015_v1.zip" description="World Land Cover Himalayas 2015 (Original Dataset Format)">https://maps.eurac.edu/download/781</dc:URI>
+      <dc:URI protocol="WWW:DOWNLOAD-1.0-http--download" name="World_Land_Cover_Himalayas_2015_v1.jpg" description="World Land Cover Himalayas 2015 (JPEG Format)">https://maps.eurac.edu/geoserver/ows?service=WMS&amp;request=GetMap&amp;layers=geonode%3AWorld_Land_Cover_Himalayas_2015_v1&amp;format=image%2Fjpeg&amp;height=550&amp;width=550&amp;srs=EPSG%3A32645&amp;bbox=300000.000000000000000%2C2990220.000000000000000%2C509760.000000000000000%2C3200040.000000000000000</dc:URI>
+      <dc:URI protocol="WWW:DOWNLOAD-1.0-http--download" name="World_Land_Cover_Himalayas_2015_v1.pdf" description="World Land Cover Himalayas 2015 (PDF Format)">https://maps.eurac.edu/geoserver/ows?service=WMS&amp;request=GetMap&amp;layers=geonode%3AWorld_Land_Cover_Himalayas_2015_v1&amp;format=application%2Fpdf&amp;height=550&amp;width=550&amp;srs=EPSG%3A32645&amp;bbox=300000.000000000000000%2C2990220.000000000000000%2C509760.000000000000000%2C3200040.000000000000000</dc:URI>
+      <dc:URI protocol="WWW:DOWNLOAD-1.0-http--download" name="World_Land_Cover_Himalayas_2015_v1.png" description="World Land Cover Himalayas 2015 (PNG Format)">https://maps.eurac.edu/geoserver/ows?service=WMS&amp;request=GetMap&amp;layers=geonode%3AWorld_Land_Cover_Himalayas_2015_v1&amp;format=image%2Fpng&amp;height=550&amp;width=550&amp;srs=EPSG%3A32645&amp;bbox=300000.000000000000000%2C2990220.000000000000000%2C509760.000000000000000%2C3200040.000000000000000</dc:URI>
+      <dc:URI protocol="WWW:DOWNLOAD-1.0-http--download" name="World_Land_Cover_Himalayas_2015_v1.x-gzip" description="World Land Cover Himalayas 2015 (GZIP Format)">https://maps.eurac.edu/geoserver/wcs?service=WCS&amp;request=GetCoverage&amp;coverageid=geonode__World_Land_Cover_Himalayas_2015_v1&amp;format=application%2Fx-gzip&amp;version=2.0.1&amp;srs=EPSG%3A32645&amp;bbox=300000.000000000000000%2C2990220.000000000000000%2C509760.000000000000000%2C3200040.000000000000000</dc:URI>
+      <dc:URI protocol="WWW:DOWNLOAD-1.0-http--download" name="World_Land_Cover_Himalayas_2015_v1.geotiff" description="World Land Cover Himalayas 2015 (GeoTIFF Format)">https://maps.eurac.edu/geoserver/wcs?service=WCS&amp;request=GetCoverage&amp;coverageid=geonode__World_Land_Cover_Himalayas_2015_v1&amp;format=image%2Ftiff&amp;version=2.0.1&amp;srs=EPSG%3A32645&amp;bbox=300000.000000000000000%2C2990220.000000000000000%2C509760.000000000000000%2C3200040.000000000000000</dc:URI>
+      <dc:URI protocol="WWW:DOWNLOAD-1.0-http--download" name="World_Land_Cover_Himalayas_2015_v1.png" description="World Land Cover Himalayas 2015 (Legend Format)">https://maps.eurac.edu/geoserver/ows?service=WMS&amp;request=GetLegendGraphic&amp;format=image/png&amp;WIDTH=20&amp;HEIGHT=20&amp;LAYER=geonode:World_Land_Cover_Himalayas_2015_v1&amp;STYLE=World_Land_Cover_Himalayas_2015_v1&amp;legend_options=fontAntiAliasing:true;fontSize:12;forceLabels:on</dc:URI>
+      <dc:URI protocol="WWW:DOWNLOAD-1.0-http--download" name="World_Land_Cover_Himalayas_2015_v1.png" description="World Land Cover Himalayas 2015 (Remote Thumbnail Format)">https://maps.eurac.edu/geoserver/ows?service=WMS&amp;version=1.1.1&amp;request=GetMap&amp;layers=geonode:World_Land_Cover_Himalayas_2015_v1&amp;format=image/png8&amp;bbox=84.94856806237871,27.01973558522765,87.1001363021547,28.928245496281214&amp;crs=EPSG:4326&amp;width=240&amp;height=200&amp;access_token=REDACTED</dc:URI>
+      <dc:URI protocol="WWW:DOWNLOAD-1.0-http--download" name="World_Land_Cover_Himalayas_2015_v1.png" description="World Land Cover Himalayas 2015 (Thumbnail Format)">https://maps.eurac.edu/uploaded/thumbs/layer-1a25539e-21c9-11ec-bf18-0050568ebac4-thumb.png</dc:URI>
+      <dc:URI protocol="WWW:DOWNLOAD-1.0-http--download" name="World_Land_Cover_Himalayas_2015_v1.png" description="World Land Cover Himalayas 2015 (Thumbnail Format)">https://maps.eurac.edu/uploaded/thumbs/layer-1a25539e-21c9-11ec-bf18-0050568ebac4-thumb.png?v=5b7b6bd9</dc:URI>
+      <dc:URI protocol="OGC:WMS" name="geonode:World_Land_Cover_Himalayas_2015_v1" description="geonode Service - Provides Layer: World Land Cover Himalayas 2015">https://maps.eurac.edu/geoserver/ows</dc:URI>
+      <dc:URI protocol="OGC:WCS" name="geonode:World_Land_Cover_Himalayas_2015_v1" description="geonode Service - Provides Layer: World Land Cover Himalayas 2015">https://maps.eurac.edu/geoserver/ows</dc:URI>
+      <dc:URI protocol="image/png" name="Thumbnail for 'World Land Cover Himalayas 2015'">https://maps.eurac.edu/uploaded/thumbs/layer-1a25539e-21c9-11ec-bf18-0050568ebac4-thumb.png?v=270fce37</dc:URI>
+    </csw:Record>
+  </csw:SearchResults>
+</csw:GetRecordsResponse>


### PR DESCRIPTION
Follow-up to #245. Found by harvesting the first #243 replacement catalogue rather than by review.

## What was wrong

#242 built the Dublin Core link mapping from Italy's RNDT alone, which publishes:

```xml
<dct:references scheme="WMS">https://…</dct:references>
```

GeoNetwork publishes the same information in a different shape, and it was not read at all:

```xml
<dc:URI protocol="OGC:WMS" name="geonode:World_Land_Cover_Himalayas_2015_v1"
        description="geonode Service - Provides Layer: …">https://maps.eurac.edu/geoserver/ows</dc:URI>
```

I generalized a link mapping from one service. Harvesting Eurac Research — the first catalogue in the replacement set — put **362 of its 363 records into the index with no reachable resource**, despite every one of them carrying WMS, WCS, and download links.

## The fix

Read `dc:URI` alongside `dct:references`, taking the service identifier from `protocol` or `scheme`, and carry through GeoNetwork's `name` and `description` attributes — its shape is the richer of the two, and those are what give the normalized resource a label instead of a bare URL.

Measured against the live catalogue, before and after, on the same 363 records:

| | rows with a resource | resources |
|---|---|---|
| before | 0 | 0 |
| after | 362 | 5,252 |

`protocol="OGC:WMS"` types as format `WMS`, and `protocol="image/png"` as media type `image/png` — both through the existing `schema::split_protocol`, unchanged.

## Testing

`csw_dublin_core_geonetwork.xml` is a real Eurac record kept verbatim, with one preview URL's `access_token` query parameter replaced by `REDACTED` and nothing else altered — so the shape this generalizes over is pinned by evidence rather than by a second guess.

Confirmed the new test fails when `dc:URI` is dropped from the match. fmt, clippy, and the ceres-client/ceres-core suites pass.
