### PR TITLE
fix(sparql): skip blank nodes in keyset harvests

### DIFF
--- a/crates/ceres-client/src/sparql.rs
+++ b/crates/ceres-client/src/sparql.rs
@@ -845,6 +845,7 @@ impl SparqlDcatClient {
             "PREFIX dcat: <http://www.w3.org/ns/dcat#>\n\
              SELECT ?dataset WHERE {{\n\
                ?dataset a dcat:Dataset .\n\
+               FILTER(isIRI(?dataset))\n\
                FILTER(STR(?dataset) > \"{cursor_esc}\")\n\
              }}\n\
              ORDER BY ?dataset\n\
@@ -1904,6 +1905,7 @@ mod tests {
         let client = SparqlDcatClient::new("https://data.europa.eu", "en", None).unwrap();
         let q = client.build_keyset_enum_query("http://example.org/d/1");
         assert!(q.contains("ORDER BY ?dataset"));
+        assert!(q.contains("FILTER(isIRI(?dataset))"));
         assert!(q.contains(r#"FILTER(STR(?dataset) > "http://example.org/d/1")"#));
         assert!(q.contains(&format!("LIMIT {ENUM_PAGE_SIZE}")));
         assert!(!q.contains("OFFSET"), "keyset must not use OFFSET");
@@ -2506,6 +2508,21 @@ mod tests {
     }
 
     // ---- Integration smoke test (requires network) -------------------------
+
+    #[tokio::test]
+    #[ignore = "requires network access to data.europa.eu"]
+    async fn data_europa_keyset_page_smoke() {
+        let client = SparqlDcatClient::new("https://data.europa.eu", "en", None).unwrap();
+        let uris = client.fetch_keyset_page("").await.unwrap();
+        assert_eq!(uris.len(), ENUM_PAGE_SIZE);
+        assert!(uris.iter().all(|uri| is_safe_iri(uri)));
+
+        let datasets = client
+            .fetch_values_metadata(&uris[..VALUES_BATCH_SIZE])
+            .await
+            .unwrap();
+        assert!(!datasets.is_empty());
+    }
 
     #[tokio::test]
     #[ignore = "requires network access to data.europa.eu"]


### PR DESCRIPTION
## What changed

- Restricts the `data.europa.eu` keyset enumeration to named dataset IRIs with `FILTER(isIRI(?dataset))`.
- Adds an offline query-shape assertion and an opt-in live smoke that covers enumeration plus the bounded metadata/distribution phase.

## Root cause

The first keyset page begins with RDF blank nodes. Those identifiers cannot be referenced in the next cross-query `VALUES` phase, so they were filtered out locally and produced an empty `VALUES ?dataset { }` clause. Virtuoso returned HTTP 500 before the first dataset batch, making forced metadata re-harvests terminate as partial with zero processed rows.

## Impact

Full `data.europa.eu` harvests now advance over stable named IRIs and can persist the SPARQL distribution metadata added for 0.7.0.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p ceres-client --all-features` — 245 unit tests, parity test, and 7 doctests passed
- `cargo clippy -p ceres-client --all-targets --all-features -- -D warnings`
- `cargo test -p ceres-client sparql::tests::data_europa_keyset_page_smoke -- --ignored --exact --nocapture` against the live endpoint
- Forced local re-harvest advanced beyond the previously failing first page and began rewriting enriched rows